### PR TITLE
Convert srcmd.mjs to srcmd.mts

### DIFF
--- a/server/session.mjs
+++ b/server/session.mjs
@@ -3,9 +3,9 @@ import { existsSync } from 'node:fs';
 import Path from 'node:path';
 import util from 'node:util';
 import vm, { SourceTextModule } from 'node:vm';
-import { decode, encode, newContents } from './srcmd.mjs';
-import { randomid, sha256 } from './utils.mjs';
-import { transformImportStatements } from './transform.mjs';
+import { decode, encode, newContents } from './srcmd.mts';
+import { randomid, sha256 } from './utils.mts';
+import { transformImportStatements } from './transform.mts';
 
 const sessions = {};
 

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,4 +1,34 @@
-export type CellType = any;
+type TitleCellType = {
+  id: string;
+  type: 'title';
+  text: string;
+};
+
+type MarkdownCellType = {
+  id: string;
+  type: 'markdown';
+  text: string;
+};
+
+type PackageJsonCellType = {
+  id: string;
+  type: 'package.json';
+  source: string;
+};
+
+type CodeCellType = {
+  id: string;
+  stale: boolean;
+  type: 'code';
+  source: string;
+  module: any;
+  context: any;
+  language: 'javascript' | 'json';
+  filename: string;
+  output: any[];
+};
+
+export type CellType = TitleCellType | MarkdownCellType | PackageJsonCellType | CodeCellType;
 
 export type SessionType = {
   id: string;


### PR DESCRIPTION
This also:

1. Fixes a bug with the wrong extensions being imported causing errors when starting the server
2. Fixes a package.json bug where it was not wrapping the name in quotes (and also not escaping it)
3. Removes the extra "group" types created during parsing for package.json. We can instead use the same pattern that exists for code where there's a `filename` group followed by a `code` group. The only difference is we know that if the `filename` is `package.json`, then it must be the `package.json` cell type.