### PR TITLE
Add support for env vars (secrets)

### DIFF
--- a/server/config.mts
+++ b/server/config.mts
@@ -8,12 +8,15 @@ type ConfigObjectType = {
   baseDir: string;
 };
 
+type SecretsObjectType = Record<string, string>;
+
 // Default configuration
 const defaultConfig: ConfigObjectType = {
   baseDir: configDir,
 };
 
 let config = { ...defaultConfig }; // In-memory config object
+let secrets = {} as SecretsObjectType; // In-memory secrets object
 
 async function loadConfig() {
   const configPath = path.join(configDir, 'config.json');
@@ -24,11 +27,25 @@ async function loadConfig() {
 
     return { ...defaultConfig, ...config };
   } catch (error) {
-    console.error('Configuration file not found, creating one...');
+    console.warn('Configuration file not found, creating one...');
     fs.mkdir(configDir, { recursive: true });
     await fs.writeFile(configPath, JSON.stringify(defaultConfig, null, 2));
     console.info('Configuration file created at', configPath);
     return defaultConfig;
+  }
+}
+
+async function loadSecrets() {
+  const secretsPath = path.join(configDir, 'secrets.json');
+  try {
+    const secretsFile = await fs.readFile(secretsPath, 'utf-8');
+    return { ...secrets, ...JSON.parse(secretsFile) };
+  } catch (error) {
+    console.warn('Secrets file not found, creating one...');
+    fs.mkdir(configDir, { recursive: true });
+    await fs.writeFile(secretsPath, JSON.stringify({}, null, 2));
+    console.info('Secrets file created at', secretsPath);
+    return {};
   }
 }
 
@@ -44,9 +61,39 @@ export async function saveConfig(newConfig: ConfigObjectType) {
 
 export async function getConfig() {
   if (Object.keys(config).length === 0) {
-    await loadConfig();
+    config = await loadConfig();
   }
   return config;
 }
 
-export default await loadConfig();
+export async function getSecrets() {
+  if (Object.keys(secrets).length === 0) {
+    secrets = await loadSecrets();
+  }
+  return secrets;
+}
+
+export async function addSecret(key: string, value: string) {
+  try {
+    secrets[key] = value;
+    await fs.writeFile(path.join(configDir, 'secrets.json'), JSON.stringify(secrets, null, 2));
+  } catch (error) {
+    console.error('Failed to save secrets file:', error);
+  }
+}
+
+export async function removeSecret(key: string) {
+  try {
+    await fs.writeFile(path.join(configDir, 'secrets.json'), JSON.stringify(secrets, null, 2));
+    delete secrets[key];
+  } catch (error) {
+    console.error('Failed to save secrets file:', error);
+  }
+}
+
+async function load() {
+  await loadConfig();
+  await loadSecrets();
+}
+
+export default await load();

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -231,6 +231,71 @@ export async function updateConfig(request: EditConfigRequestType) {
   }
 }
 
+// Secret management
+export async function getSecrets() {
+  const response = await fetch(SERVER_BASE_URL + '/secrets', {
+    method: 'GET',
+    headers: { 'content-type': 'application/json' },
+  });
+
+  if (!response.ok) {
+    console.error(response);
+    throw new Error('Request failed');
+  }
+  return response.json();
+}
+
+interface CreateSecretRequestType {
+  name: string;
+  value: string;
+}
+
+export async function createSecret(request: CreateSecretRequestType) {
+  const response = await fetch(SERVER_BASE_URL + '/secrets', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+  if (!response.ok) {
+    console.error(response);
+    throw new Error('Request for creating a secret failed');
+  }
+  return response.json();
+}
+
+interface UpdateSecretRequestType {
+  previousName: string;
+  name: string;
+  value: string;
+}
+export async function updateSecret(request: UpdateSecretRequestType) {
+  const response = await fetch(SERVER_BASE_URL + '/secrets/' + request.previousName, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+  if (!response.ok) {
+    console.error(response);
+    throw new Error('Request for updating a secret failed');
+  }
+  return response.json();
+}
+
+interface DeleteSecretRequestType {
+  name: string;
+}
+export async function deleteSecret(request: DeleteSecretRequestType) {
+  const response = await fetch(SERVER_BASE_URL + '/secrets/' + request.name, {
+    method: 'DELETE',
+    headers: { 'content-type': 'application/json' },
+  });
+  if (!response.ok) {
+    console.error(response);
+    throw new Error('Request for deleting a secret failed');
+  }
+  return response.json();
+}
+
 export async function getNodeVersion() {
   const response = await fetch(SERVER_BASE_URL + '/node_version', {
     headers: { 'content-type': 'application/json' },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,7 @@ import Home, { loader as homeLoader, action as homeAction } from './routes/home'
 import Open, { loader as openLoader, action as openAction } from './routes/open';
 import Session, { loader as sessionLoader } from './routes/session';
 import Settings, { loader as settingsLoader, action as settingsAction } from './routes/settings';
-import Secrets, { loader as secretsLoader } from './routes/secrets';
+import Secrets from './routes/secrets';
 import ErrorPage from './error';
 
 const router = createBrowserRouter([
@@ -39,7 +39,8 @@ const router = createBrowserRouter([
       },
       {
         path: '/secrets',
-        loader: secretsLoader,
+        loader: Secrets.loader,
+        action: Secrets.action,
         element: <Secrets />,
         errorElement: <ErrorPage />,
       },

--- a/src/routes/secrets.tsx
+++ b/src/routes/secrets.tsx
@@ -1,12 +1,256 @@
-export async function loader() {
-  return {};
+import { useState } from 'react';
+import { getSecrets } from '@/lib/server';
+import { Eye, KeyRound, EyeOff, Copy, Check } from 'lucide-react';
+import { useLoaderData, Form, useRevalidator } from 'react-router-dom';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { updateSecret, createSecret, deleteSecret } from '@/lib/server';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+
+async function loader() {
+  const { result } = await getSecrets();
+  return { secrets: result };
 }
 
-export default function Secrets() {
+async function action({ request }: { request: Request }) {
+  const formData = await request.formData();
+  if (formData.get('new-form')) {
+    const name = formData.get('name') as string;
+    const value = formData.get('value') as string;
+    const { result } = await createSecret({ name, value });
+    if (!result) {
+      console.error('Error creating secret');
+    }
+    return { secrets: result };
+  }
+  return null;
+}
+
+function Secrets() {
+  const { secrets } = useLoaderData() as { secrets: Record<string, string> };
+
   return (
     <div>
-      <h1 className="text-2xl">Secrets</h1>
-      <p>This has not yet been implemented</p>
+      <h1 className="text-2xl my-4">Secrets</h1>
+      <p>
+        Secrets are a safe way to share credentials and tokens with notebooks. You can think of
+        these as environment variables, and access them with the usual{' '}
+        <code className="px-1 py-0.5 border border-gray-200 rounded-sm">process.env</code>{' '}
+      </p>
+      {secrets && (
+        <div>
+          <h2 className="text-xl mt-8 pb-4">Current Secrets</h2>
+          <ul className="flex flex-col gap-2">
+            {Object.entries(secrets)
+              .sort(([nameA], [nameB]) => nameA.localeCompare(nameB))
+              .map(([name, value]) => (
+                <SecretRow name={name} value={value} key={name} />
+              ))}
+          </ul>
+        </div>
+      )}
+
+      <h2 className="text-xl mt-8 pb-4">Add a new Secret</h2>
+      <NewSecretForm />
     </div>
   );
 }
+
+function SecretRow({ name, value }: { name: string; value: string }) {
+  const revalidator = useRevalidator();
+  const [mode, setMode] = useState<'view' | 'edit'>('view');
+  const [updatedName, setUpdatedName] = useState(name);
+  const [updatedValue, setUpdatedValue] = useState(value);
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleUpdate = async () => {
+    // name needs to follow the following pattern: "^[A-Z0-9_]+$"
+    const namePattern = /^[A-Z0-9_]+$/;
+    if (!namePattern.test(updatedName)) {
+      setError('Invalid name: only letters, numbers and underscores are allowed');
+      return;
+    }
+
+    // TODO handle errors
+    await updateSecret({
+      previousName: name,
+      name: updatedName,
+      value: updatedValue,
+    });
+    setMode('view');
+    revalidator.revalidate();
+  };
+
+  const handleDelete = async () => {
+    await deleteSecret({ name });
+    revalidator.revalidate();
+  };
+
+  return (
+    <>
+      <li className="grid grid-cols-5 border border-gray-200 rounded-lg p-3">
+        {mode === 'view' ? (
+          <>
+            <div className="col-span-2 flex gap-3 items-center ">
+              <div className="p-2 border border-gray-200 rounded-full">
+                <KeyRound className="text-gray-500" size={16} />
+              </div>
+              <p className="font-semibold">{name}</p>
+            </div>
+            <div className="col-span-2">
+              <CopyableSecretValue value={value} />
+            </div>
+
+            <div className="flex col-span-1 flex justify-end items-center gap-2">
+              <Button variant="outline" onClick={() => setMode('edit')}>
+                Edit
+              </Button>
+              <Dialog open={open} onOpenChange={setOpen}>
+                <DialogTrigger asChild>
+                  <Button variant="secondary">Remove</Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Delete this secret</DialogTitle>
+                    <DialogDescription>
+                      Are you sure you want to delete this secret?
+                    </DialogDescription>
+                    <div className="flex w-full justify-end items-center gap-2 pt-4 bg-background">
+                      <Button
+                        variant="outline"
+                        onClick={() => {
+                          setOpen(false);
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                      <Button variant="destructive" onClick={handleDelete}>
+                        Delete
+                      </Button>
+                    </div>
+                  </DialogHeader>
+                </DialogContent>
+              </Dialog>
+            </div>
+          </>
+        ) : (
+          <>
+            <Input type="hidden" name="editing" value="something" className="hidden" />
+            <Input
+              className="col-span-2 max-w-xs"
+              type="text"
+              value={updatedName}
+              onChange={(e) => setUpdatedName(e.target.value.toUpperCase())}
+            />
+            <Input
+              className="col-span-2 max-w-xs"
+              type="text"
+              name="value"
+              value={updatedValue}
+              onChange={(e) => setUpdatedValue(e.target.value)}
+            />
+            <div className="col-span-1 flex gap-2 justify-end">
+              <Button variant="outline" onClick={() => setMode('view')}>
+                Cancel
+              </Button>
+              <Button className="col-span-1" type="submit" onClick={handleUpdate}>
+                Update
+              </Button>
+            </div>
+          </>
+        )}
+      </li>
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+    </>
+  );
+}
+
+function CopyableSecretValue({ value }: { value: string }) {
+  const [state, setState] = useState<'hidden' | 'visible'>('hidden');
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  };
+  return (
+    <>
+      {state === 'hidden' ? (
+        <div className="flex gap-2 items-center">
+          <Button onClick={() => setState('visible')} variant="ghost">
+            <Eye size={16} onClick={() => setState('visible')} />
+          </Button>
+          <p>•••••••••••</p>
+          <Button variant="ghost" onClick={copy}>
+            {copied ? <Check size={16} /> : <Copy size={16} />}
+          </Button>
+          {copied && <p className="text-xs text-gray-500">Copied!</p>}
+        </div>
+      ) : (
+        <div className="flex gap-2 items-center">
+          <Button onClick={() => setState('hidden')} variant="ghost">
+            <EyeOff size={16} />
+          </Button>
+          <p className="text-sm">
+            {value.slice(0, 25)}
+            {value.length > 25 ? '...' : ''}
+          </p>
+          <Button variant="ghost" onClick={copy}>
+            {copied ? <Check size={16} /> : <Copy size={16} />}
+          </Button>
+          {copied && <p className="text-xs text-gray-500">Copied!</p>}
+        </div>
+      )}
+    </>
+  );
+}
+
+function NewSecretForm() {
+  const [name, setName] = useState('');
+  const [value, setValue] = useState('');
+
+  return (
+    <>
+      <Form method="post" className="flex items-center gap-4">
+        <Input type="hidden" name="new-form" value="something" className="hidden" />
+        <Input
+          type="text"
+          name="name"
+          value={name}
+          pattern="^[A-Z0-9_]+$"
+          onChange={(e) => setName(e.currentTarget.value.toUpperCase())}
+          placeholder="name"
+        />
+        <Input
+          type="text"
+          name="value"
+          value={value}
+          onChange={(e) => setValue(e.currentTarget.value)}
+          placeholder="value"
+        />
+
+        <Button type="submit" disabled={!name || !value}>
+          Add secret
+        </Button>
+      </Form>
+      <p className="text-xs text-gray-400 pl-4 pt-0.5">
+        only letters, numbers and underscores are allowed
+      </p>
+    </>
+  );
+}
+
+Secrets.loader = loader;
+Secrets.action = action;
+export default Secrets;

--- a/src/routes/session.tsx
+++ b/src/routes/session.tsx
@@ -90,7 +90,7 @@ export default function Session() {
       <div className="flex flex-col">
         {cells.map((cell, idx) => (
           <div key={`wrapper-${cell.id}`}>
-            {idx !== 0 && (
+            {idx > 1 && (
               <div className="flex justify-center w-full group">
                 <NewCellPopover
                   createNewCell={(type) => {
@@ -164,7 +164,7 @@ function TitleCell(props: {
   onUpdateCell: (cell: TitleCellType, attrs: Partial<TitleCellType>) => Promise<void>;
 }) {
   return (
-    <div className="mt-4">
+    <div className="my-4">
       <EditableH1
         text={props.cell.text}
         className="text-4xl font-bold"
@@ -205,7 +205,7 @@ function MarkdownCell(props: {
             </Button>
 
             <DeleteCellWithConfirmation onDeleteCell={() => props.onDeleteCell(cell)}>
-              <Button variant="ghost" asChild>
+              <Button variant="ghost" size={'icon'}>
                 <Trash2 size={16} />
               </Button>
             </DeleteCellWithConfirmation>
@@ -263,16 +263,25 @@ function PackageJsonCell(props: {
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
       <CollapsibleTrigger className="flex items-center w-full gap-3">
-        <p className="text-sm font-mono font-semibold">package.json</p>
-        <ChevronRight
-          size="24"
-          style={{
-            transform: open ? `rotate(90deg)` : 'none',
-          }}
-        />
+        <Button variant="ghost" className="font-mono font-semibold active:translate-y-0">
+          package.json
+          <ChevronRight
+            size="24"
+            style={{
+              transform: open ? `rotate(90deg)` : 'none',
+            }}
+          />
+        </Button>
       </CollapsibleTrigger>
-      <CollapsibleContent className="py-2 mt-2 border-t-2 transition-all data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
-        <CodeMirror value={source} extensions={[json()]} onChange={onChangeSource} />
+      <CollapsibleContent className="py-2">
+        <div className="border rounded group outline-blue-100 focus-within:outline focus-within:outline-2">
+          <CodeMirror
+            value={source}
+            extensions={[json()]}
+            onChange={onChangeSource}
+            basicSetup={{ lineNumbers: false, foldGutter: false }}
+          />
+        </div>
       </CollapsibleContent>
     </Collapsible>
   );
@@ -302,7 +311,7 @@ function CodeCell(props: {
           />
           <div className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity flex gap-2">
             <DeleteCellWithConfirmation onDeleteCell={() => props.onDeleteCell(cell)}>
-              <Button variant="ghost" asChild>
+              <Button variant="ghost">
                 <Trash2 size={16} />
               </Button>
             </DeleteCellWithConfirmation>


### PR DESCRIPTION
This is the foundation for supporting custom env vars (secrets) in source book. It allows to CRUD secrets from the secrets tab. They are currently unused in the rest of the app.

There is more details in the ticket AXF-74, but here are the cliff notes:
* For now, secrets are global. At least CRUD operations on them are global.
* The storage mechanism on disk is a json file right now, to be consistent with config. However we can easily switch this to the dotenv mechanism (it will be more obvious which is best once we start passing the values to the node context at execution time)
* UI + API for CRUD operations
* Secrets are not shown unless user wants them to (this is actually important for streamers or youtubers, so a good feature to have)


![CleanShot 2024-05-21 at 15 54 07](https://github.com/axflow/srcbook/assets/1666947/7033f1ef-5530-44c9-b82b-1ad7c03bf47c)

fixes https://linear.app/axflow/issue/AXF-85/add-ui-support-for-cruding-secrets
