### PR TITLE
Use node child processes for executing javascript

### DIFF
--- a/server/exec.mts
+++ b/server/exec.mts
@@ -1,0 +1,51 @@
+import Path from 'node:path';
+import { spawn } from 'node:child_process';
+import { ProcessOutputType } from './types';
+
+export type ExecRequestType = {
+  cwd: string;
+};
+
+export type ExecResponseType = {
+  exitCode: number;
+  output: ProcessOutputType[];
+};
+
+/**
+ * Execute a JavaScript file using node.
+ *
+ * Example:
+ *
+ *     const { exitCode, output } = await exec('foo.mjs', {
+ *       cwd: '/Users/ben/.srcbook/foo',
+ *     });
+ *
+ * @param file Path of file to execute. Can be an absolute path or relative. If relative, it's joined with `options.cwd`.
+ * @param options
+ * @param options.cwd Current working directory of the child process.
+ * @returns An object containing the exit code and stdout/err.
+ */
+export function exec(file: string, options: ExecRequestType): Promise<ExecResponseType> {
+  return new Promise((resolve) => {
+    const cwd = options.cwd;
+    const filepath = Path.isAbsolute(file) ? file : Path.join(cwd, file);
+
+    // Explicitly using spawn here (over fork) to make it clear these
+    // processes should be as decoupled from one another as possible.
+    const child = spawn('node', [filepath], { cwd: cwd });
+
+    const output: ProcessOutputType[] = [];
+
+    child.stdout.on('data', (data) => {
+      output.push({ type: 'stdout', data: data.toString('utf8') });
+    });
+
+    child.stderr.on('data', (data) => {
+      output.push({ type: 'stderr', data: data.toString('utf8') });
+    });
+
+    child.on('close', (code) => {
+      resolve({ exitCode: code!, output: output });
+    });
+  });
+}

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,3 +1,15 @@
+export type StdoutOutputType = {
+  type: 'stdout';
+  data: string;
+};
+
+export type StderrOutputType = {
+  type: 'stderr';
+  data: string;
+};
+
+export type ProcessOutputType = StdoutOutputType | StderrOutputType;
+
 export type TitleCellType = {
   id: string;
   type: 'title';
@@ -23,14 +35,20 @@ export type CodeCellType = {
   source: string;
   language: string;
   filename: string;
-  output: any[];
+  output: ProcessOutputType[];
 };
 
 export type CellType = TitleCellType | MarkdownCellType | PackageJsonCellType | CodeCellType;
 
 export type SessionType = {
   id: string;
-  hash: string;
-  path: string;
+  /**
+   * Path to the directory containing the srcbook files.
+   */
+  dir: string;
+  /**
+   * Path to a .srcmd file containing the srcbook.
+   */
+  srcmdPath: string;
   cells: CellType[];
 };

--- a/server/utils.mts
+++ b/server/utils.mts
@@ -7,12 +7,6 @@ export function randomid(byteSize = 16) {
   return base58.encode(bytes);
 }
 
-// data is uint8array
-export async function sha256(data: Uint8Array) {
-  const result = await crypto.subtle.digest('SHA-256', data);
-  return Buffer.from(result).toString('hex');
-}
-
 export function take<T extends object, K extends keyof T>(obj: T, ...keys: Array<K>): Pick<T, K> {
   const result = {} as Pick<T, K>;
 

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -1,4 +1,4 @@
-import type { CellType, FsObjectResultType } from '@/types';
+import type { CellType, FsObjectResultType, SessionType } from '@/types';
 
 const SERVER_BASE_URL = 'http://localhost:2150';
 
@@ -83,7 +83,7 @@ interface LoadSessionRequestType {
 
 interface LoadSessionResponseType {
   error: boolean;
-  result: { id: string };
+  result: SessionType;
 }
 
 export async function loadSession(

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,10 +16,9 @@ export type SettingsType = {
   baseDir: string;
 };
 
-export type EvalOutputType = { type: 'eval'; error: boolean; text: string };
-export type StdoutOutputType = { type: 'stdout'; text: string };
-export type StderrOutputType = { type: 'stderr'; text: string };
-export type OutputType = EvalOutputType | StdoutOutputType | StderrOutputType;
+export type StdoutOutputType = { type: 'stdout'; data: string };
+export type StderrOutputType = { type: 'stderr'; data: string };
+export type OutputType = StdoutOutputType | StderrOutputType;
 
 type BaseCellType = {
   id: string;
@@ -51,3 +50,8 @@ export type PackageJsonCellType = BaseCellType & {
 };
 
 export type CellType = TitleCellType | CodeCellType | MarkdownCellType | PackageJsonCellType;
+
+export type SessionType = {
+  id: string;
+  cells: CellType[];
+};


### PR DESCRIPTION
Long way to go for this to be robust.

### TLDR

* Create a directory for each session in .srcbook. The session id is the directory name.
* Write each code (and package.json) cell as a file in the session dir.
* Write all markdown and cells to the README.md file in the session dir. However, do not inline the cell source in the readme. Instead, link to the file. Otherwise, the format is the same as the srcmd format.
* Use child_process to spawn another OS process that runs the cell. Basically, `node path/to/file.js` where `file.js` is a file containing cell source.
* Stop writing to srcmd file (but importing from one still works)

### Inefficiencies

* Every change to the session causes the entire session contents to be written to the directory. Basically we recreate the directory on every change. This means we rewrite files that haven't been changed
* Every time a new session is created, we recreate the directory even if one already exists for the same notebook.
* Error handling is minimal to none
* We don't clean up old files. For instance, if you rename a cell, the previous file for that cell is not deleted
* Lots of bullshit code

The solution to improving a lot of these inefficiencies involves restructuring the code with a pattern in place for hooking in to events that occur on a cell or session. So, rather than try and write ad hoc code to solve all of this, I'm going to focus on a pattern for this stuff next.