### PR TITLE
Styling tweaks

### DIFF
--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -1,6 +1,7 @@
 import { useLoaderData } from 'react-router-dom';
+import { useState } from 'react';
 import { Outlet, NavLink } from 'react-router-dom';
-import { LockKeyholeIcon, HomeIcon, SettingsIcon } from 'lucide-react';
+import { LockKeyholeIcon, HomeIcon, SettingsIcon, ChevronsLeft, ChevronsRight } from 'lucide-react';
 import { getNodeVersion } from '@/lib/server';
 import { cn } from '@/lib/utils';
 
@@ -11,10 +12,26 @@ async function loader() {
 
 function Layout() {
   const version = useLoaderData() as string;
+  const [mode, setMode] = useState<'icons' | 'list'>('icons');
+
   return (
     <div className="flex">
-      <nav className="h-screen fixed bg-foreground text-background">
-        <div className="flex flex-col justify-between h-full">
+      <nav
+        className={cn(
+          'h-screen fixed bg-foreground text-background transition-all flex flex-col',
+          mode === 'icons' ? 'w-20' : 'w-32',
+        )}
+      >
+        <div
+          className="flex w-full items-center justify-between py-3 px-2 opacity-60 hover:opacity-100 hover:cursor-pointer"
+          onClick={() => setMode(mode === 'list' ? 'icons' : 'list')}
+        >
+          <p className="font-mono text-xs">{mode === 'list' ? 'SourceBook' : ''}</p>
+
+          {mode === 'icons' ? <ChevronsRight /> : <ChevronsLeft />}
+        </div>
+        <hr className="mx-4 opacity-10" />
+        <div className="flex flex-col justify-between h-full pt-2">
           <ul className="flex flex-col space-y-2 p-2">
             <li>
               <NavLink
@@ -24,11 +41,12 @@ function Layout() {
                   cn(
                     'flex items-center gap-2 p-2 rounded-full hover:bg-background hover:text-foreground transition-colors',
                     isActive ? 'underline underline-offset-8' : undefined,
+                    mode === 'icons' ? 'justify-center' : 'justify-start',
                   )
                 }
               >
                 <HomeIcon className="w-6 h-6" />
-                <p>Home</p>
+                {mode === 'list' && <p>Home</p>}
               </NavLink>
             </li>
             <li>
@@ -39,15 +57,16 @@ function Layout() {
                   cn(
                     'flex items-center gap-2 p-2 rounded-full hover:bg-background hover:text-foreground transition-colors',
                     isActive ? 'underline underline-offset-8' : undefined,
+                    mode === 'icons' ? 'justify-center' : 'justify-start',
                   )
                 }
               >
                 <LockKeyholeIcon className="w-6 h-6" />
-                <p>Secrets</p>
+                {mode === 'list' && <p>Secrets</p>}
               </NavLink>
             </li>
           </ul>
-          <div className="flex flex-col">
+          <div className="flex flex-col p-2">
             <NavLink
               to="/settings"
               title="Settings"
@@ -55,20 +74,23 @@ function Layout() {
                 cn(
                   'flex items-center gap-2 p-2 rounded-full hover:bg-background hover:text-foreground transition-colors',
                   isActive ? 'underline underline-offset-8' : undefined,
+                  mode === 'icons' ? 'justify-center' : 'justify-start',
                 )
               }
             >
               <SettingsIcon className="w-6 h-6" />
-              <p>Settings</p>
+              {mode === 'list' && <p>Settings</p>}
             </NavLink>
-            <p className="mx-2 px-2 text-sm opacity-50 text-center">
-              node version
-              <br /> {version}
-            </p>
+            {mode === 'list' && (
+              <p className="mx-2 px-2 text-xs opacity-50 text-center">
+                node version
+                <br /> {version}
+              </p>
+            )}
           </div>
         </div>
       </nav>
-      <div className="flex-1">
+      <div className={cn('flex-1', mode === 'icons' ? 'pl-20' : 'pl-32')}>
         <div className="max-w-4xl mx-auto p-4">
           <Outlet />
         </div>

--- a/src/components/file-picker.tsx
+++ b/src/components/file-picker.tsx
@@ -38,7 +38,6 @@ export default function FilePicker(props: {
   return (
     <div className="space-y-4 mt-4">
       <Form method="post" className="flex items-center space-x-2">
-        <input type="hidden" name="formId" value="open" />
         <input type="hidden" value={dirname} name="dirname" />
         <input type="hidden" value={selected?.basename ?? ''} name="basename" />
         <Input value={selected?.path || dirname} name="path" readOnly />
@@ -47,7 +46,7 @@ export default function FilePicker(props: {
         </Button>
       </Form>
 
-      <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
+      <ul className="flex flex-wrap max-h-[383px] overflow-y-scroll">
         {entries.map((entry) => (
           <FsEntryItem
             key={entry.path}
@@ -76,14 +75,13 @@ export function DirPicker(props: { dirname: string; entries: FsObjectType[]; cta
   return (
     <div className="space-y-4 mt-4">
       <Form method="post" className="flex items-center space-x-2">
-        <input type="hidden" name="formId" value="open" />
         <Input value={dirname} name="dirname" readOnly />
         <Button variant="default" className="min-w-32" type="submit" disabled={selected === null}>
           {props.cta}
         </Button>
       </Form>
 
-      <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
+      <ul className="flex flex-wrap max-h-[383px] overflow-y-scroll">
         {entries.map((entry) => (
           <FsEntryItem
             key={entry.path}
@@ -111,7 +109,7 @@ function FsEntryItem({
   return (
     <li
       className={cn(
-        'p-2 flex items-center text-sm cursor-pointer rounded',
+        'my-0.5 py-2 flex items-center text-sm cursor-pointer rounded w-1/2 md:w-1/3',
         selected
           ? 'bg-accent text-accent-foreground'
           : 'hover:bg-accent hover:text-accent-foreground',

--- a/src/components/install-package-modal.tsx
+++ b/src/components/install-package-modal.tsx
@@ -82,12 +82,10 @@ export default function InstallPackageModal({
         )}
       >
         {mode === 'error' && (
-          <>
-            <div className="flex flex-col w-full h-full items-center justify-center gap-3">
-              <DialogTitle className="text-red-400">Something went wrong</DialogTitle>
-              <p>Failed to install {pkg}, please try again.</p>
-            </div>
-          </>
+          <div className="flex flex-col w-full h-full items-center justify-center gap-3">
+            <DialogTitle className="text-red-400">Something went wrong</DialogTitle>
+            <p>Failed to install {pkg}, please try again.</p>
+          </div>
         )}
         {mode === 'loading' && (
           <div className="flex w-full h-full items-center justify-center gap-3">
@@ -120,7 +118,7 @@ export default function InstallPackageModal({
                 <CommandGroup>
                   {results.map((result) => {
                     return (
-                      <CommandItem key={result.name} value={result.name}>
+                      <CommandItem key={result.name} value={result.name} className="rounded-lg">
                         <div className="flex justify-between w-full items-center gap-6">
                           <div className="flex flex-col">
                             <div className="flex gap-1">

--- a/src/routes/session.tsx
+++ b/src/routes/session.tsx
@@ -396,13 +396,19 @@ function CellOutput(props: { output: OutputType[] }) {
     return null;
   }
 
+  const stdoutText = props.output
+    .filter(({ type }) => type === 'stdout')
+    .map(({ data }) => data)
+    .join('');
+
+  const stderrText = props.output
+    .filter(({ type }) => type === 'stderr')
+    .map(({ data }) => data)
+    .join('');
   return (
     <div className="border rounded mt-2 font-mono text-sm bg-input/10 divide-y">
-      {props.output.length > 0 && (
-        <div className="p-2 whitespace-pre-wrap">
-          {props.output.map(({ data }) => data).join('')}
-        </div>
-      )}
+      {stdoutText && <div className="p-2 whitespace-pre-wrap">{stdoutText}</div>}
+      {stderrText && <div className="p-2 whitespace-pre-wrap text-red-500">{stderrText}</div>}
     </div>
   );
 }


### PR DESCRIPTION
* Fixed sidebar logic (it wasn't applying padding properly when you resized the screen)
* Added a toggle between icons and list modes for the sidebar. FYI I don't love this yet, but want to experiment with it until we get to a place that I like. I looked at notion + livebook, happy to look at other examples you think do a good job with the sidebar
* Capped the height of the filepicker element, made the height a number which breaks a filename in half (on purpose) to making scrolling obvious even if scrollbars are disabled by the operating system (most macs do this by default)
* Added colored output and separation of `stdout` and `stderr` in `CellOutput` component.

Happy to take feedback but this is all meant to be experimental and incremental, so merging and we can fix forward.
![CleanShot 2024-05-26 at 13 10 57](https://github.com/axflow/srcbook/assets/1666947/73c4a489-0081-4933-8c07-89b6c9bbb308)
![CleanShot 2024-05-26 at 13 11 13](https://github.com/axflow/srcbook/assets/1666947/31ba17bd-04cb-447a-abf3-e322e7f3436a)
![CleanShot 2024-05-26 at 13 11 31](https://github.com/axflow/srcbook/assets/1666947/aa5aaca5-7752-4080-99aa-dae17850a400)
