### PR TITLE
Keep track of node processes server side

### DIFF
--- a/server/processes.mts
+++ b/server/processes.mts
@@ -1,0 +1,49 @@
+import { ChildProcess } from 'node:child_process';
+
+class Processes {
+  private processes: Record<string, ChildProcess> = {};
+
+  add(sessionId: string, cellId: string, process: ChildProcess) {
+    const key = this.toKey(sessionId, cellId);
+
+    if (typeof process.pid !== 'number') {
+      throw new Error('Cannot add a process with no pid');
+    }
+
+    if (process.killed) {
+      throw new Error('Cannot add a process that has been killed');
+    }
+
+    this.processes[key] = process;
+
+    process.on('exit', () => {
+      delete this.processes[key];
+    });
+  }
+
+  kill(sessionId: string, cellId: string) {
+    const key = this.toKey(sessionId, cellId);
+
+    const process = this.processes[key];
+
+    if (!process) {
+      throw new Error(
+        `Cannot kill process: no process for session ${sessionId} and cell ${cellId} exists`,
+      );
+    }
+
+    if (process.killed) {
+      throw new Error(
+        `Cannot kill process for session ${sessionId} and cell ${cellId}: process has already been killed`,
+      );
+    }
+
+    return process.kill('SIGTERM');
+  }
+
+  private toKey(sessionId: string, cellId: string) {
+    return sessionId + ':' + cellId;
+  }
+}
+
+export default new Processes();

--- a/server/srcmd.mts
+++ b/server/srcmd.mts
@@ -361,6 +361,7 @@ function convertPackageJson(token: Tokens.Code): PackageJsonCellType {
     type: 'package.json',
     source: token.text,
     filename: 'package.json',
+    status: 'idle',
   };
 }
 
@@ -371,6 +372,7 @@ function convertCode(token: Tokens.Code, filename: string): CodeCellType {
     source: token.text,
     language: token.lang || 'javascript',
     filename: filename,
+    status: 'idle',
   };
 }
 
@@ -384,6 +386,7 @@ function convertLinkedCode(token: Tokens.Link): CodeCellType | PackageJsonCellTy
       type: 'package.json',
       source: '',
       filename: 'package.json',
+      status: 'idle',
     };
   }
   function toCodeCell(token: Tokens.Link): CodeCellType {
@@ -393,6 +396,7 @@ function convertLinkedCode(token: Tokens.Link): CodeCellType | PackageJsonCellTy
       source: '',
       language: langFromFilename(token.text),
       filename: token.text,
+      status: 'idle',
     };
   }
   return token.text === 'package.json' ? toPkgJsonCell() : toCodeCell(token);

--- a/server/types.ts
+++ b/server/types.ts
@@ -15,6 +15,7 @@ export type PackageJsonCellType = {
   type: 'package.json';
   source: string;
   filename: 'package.json';
+  status: 'idle' | 'running';
 };
 
 export type CodeCellType = {
@@ -23,11 +24,7 @@ export type CodeCellType = {
   source: string;
   language: string;
   filename: string;
-  /**
-   * If a process is running, we store an abort controller.
-   * This is the mechanism we use to stop a running cell.
-   */
-  abortController?: AbortController;
+  status: 'idle' | 'running';
 };
 
 export type CellType = TitleCellType | MarkdownCellType | PackageJsonCellType | CodeCellType;

--- a/src/components/install-package-modal.tsx
+++ b/src/components/install-package-modal.tsx
@@ -62,12 +62,12 @@ export default function InstallPackageModal({
 
   useEffect(() => {
     const callback = (message: Message) => {
-      if (message.cellId === cell.id) {
+      if (message.cell.id === cell.id && message.cell.status === 'idle') {
         setMode('success');
       }
     };
-    client.on('cell:exited', callback);
-    return () => client.off('cell:exited', callback);
+    client.on('cell:updated', callback);
+    return () => client.off('cell:updated', callback);
   }, [client, cell]);
 
   const addPackage = (packageName: string) => {

--- a/src/components/use-cell.tsx
+++ b/src/components/use-cell.tsx
@@ -9,6 +9,7 @@ export function buildCodeCell(attrs: Partial<CodeCellType> = {}): CodeCellType {
     source: '',
     language: 'javascript',
     filename: 'untitled.mjs',
+    status: 'idle',
     ...attrs,
     id: randomid(),
     type: 'code',
@@ -115,23 +116,17 @@ export const CellsProvider: React.FC<{ initialCells: CellType[]; children: React
     [_output],
   );
 
-  const setOutput = useCallback(
-    (id: string, output: OutputType | OutputType[]) => {
-      output = Array.isArray(output) ? output : [output];
-      internalSetOutput({
-        ...outputRef.current,
-        [id]: (outputRef.current[id] || []).concat(output),
-      });
-    },
-    [_output],
-  );
+  const setOutput = useCallback((id: string, output: OutputType | OutputType[]) => {
+    output = Array.isArray(output) ? output : [output];
+    internalSetOutput({
+      ...outputRef.current,
+      [id]: (outputRef.current[id] || []).concat(output),
+    });
+  }, []);
 
-  const clearOutput = useCallback(
-    (id: string) => {
-      internalSetOutput({ ...outputRef.current, [id]: [] });
-    },
-    [_output],
-  );
+  const clearOutput = useCallback((id: string) => {
+    internalSetOutput({ ...outputRef.current, [id]: [] });
+  }, []);
 
   return (
     <CellsContext.Provider

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,11 +37,13 @@ export type CodeCellType = BaseCellType & {
   source: string;
   language: string;
   filename: string;
+  status: 'idle' | 'running';
 };
 
 export type PackageJsonCellType = BaseCellType & {
   type: 'package.json';
   source: string;
+  status: 'idle' | 'running';
 };
 
 export type CellType = TitleCellType | CodeCellType | MarkdownCellType | PackageJsonCellType;


### PR DESCRIPTION
### Changes

* I'm now storing a reference to the child node processes server side. We're not really using it for anything other than killing the process right now, but we now have the ability to ask how many processes are active, which cells / sessions they belong to, what the pid is, what command was used, etc. (all the ChildProcess instance properties).
* I added a `status` to cells that can be executed (code and package.json). This state is like any other and the client uses this to know whether or not a cell is running
* Got rid of the `cell:exited` event. There's no need because we can use the existing `cell:updated` to tell the client the cell is `idle` again.
    * We could also do this to initiate running a cell too. Just flip the flag to running and that syncs to server and server knows it needs to run it.
* Got to remove a bunch of react state that isn't needed.

### Outcome

This fixes one bug and introduces another.

1. Fix: if you refresh page while a cell is running, that state is maintainted through the page refresh now.
2. Bug: If you refresh page while a cell is running and then click "stop" running, it will do the right thing, but the websocket event is never sent back to the client telling it it's no longer running. This is because we're currently referencing a stale websocket connection (the page refreshed, so the websocket connection that is referenced in the onExit() callback is closed). We need to revamp how we reference websocket connections on the server to fix this. I will do it in a follow up PR.