### PR TITLE
Persist the "last filename used while exporting" in a cross server restart manner

### DIFF
--- a/server/session.mts
+++ b/server/session.mts
@@ -146,6 +146,7 @@ export function sessionToResponse(session: SessionType) {
   return {
     id: session.id,
     cells: session.cells,
+    dirName: Path.basename(session.dir),
   };
 }
 

--- a/src/components/file-picker.tsx
+++ b/src/components/file-picker.tsx
@@ -1,7 +1,7 @@
 import { Form } from 'react-router-dom';
 import { useState } from 'react';
 import { FileCode, Folder } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { cn, splitPath } from '@/lib/utils';
 import { disk } from '@/lib/server';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -132,11 +132,12 @@ function FsEntryItem({
 
 export function FileSaver(props: {
   dirname: string;
+  filename?: string;
   entries: FsObjectType[];
   onSave: (path: string) => void;
 }) {
   const [dirname, setDirname] = useState(props.dirname);
-  const [query, setQuery] = useState(props.dirname);
+  const [query, setQuery] = useState(props.filename || props.dirname);
   const [boldPrefix, setBoldPrefix] = useState<string>('');
   const [entries, _setEntries] = useState(props.entries);
   const [filteredEntries, setFilteredEntries] = useState<FsObjectType[]>(props.entries);
@@ -162,6 +163,7 @@ export function FileSaver(props: {
   }
 
   function suffixQuery(query: string) {
+    console.log('query', query);
     return query.endsWith('.srcmd') ? query : query + '.srcmd';
   }
 
@@ -216,26 +218,4 @@ export function FileSaver(props: {
       </Button>
     </div>
   );
-}
-
-function splitPath(fullPath: string) {
-  // Find the last slash in the path. Assumes macOSX or Linux-style paths
-  // For this, first we normalize the path to use forward slashes
-  const normalizedPath = fullPath.replace(/\\/g, '/');
-
-  const lastSlashIndex = normalizedPath.lastIndexOf('/');
-
-  // If there's no slash, the fullPath is just the basename
-  if (lastSlashIndex === -1) {
-    return {
-      dirname: '',
-      basename: fullPath,
-    };
-  }
-
-  // Split the path into dirname and basename
-  const dirname = fullPath.substring(0, lastSlashIndex);
-  const basename = fullPath.substring(lastSlashIndex + 1);
-
-  return { dirname, basename };
 }

--- a/src/components/save-modal-dialog.tsx
+++ b/src/components/save-modal-dialog.tsx
@@ -1,4 +1,5 @@
 import { exportSession, disk } from '@/lib/server';
+import { splitPath } from '@/lib/utils';
 import { SessionType, FsObjectType } from '@/types';
 import { useEffect, useState } from 'react';
 import { FileSaver } from '@/components/file-picker';
@@ -21,19 +22,26 @@ export default function SaveModal({
 }) {
   const [entries, setEntries] = useState<FsObjectType[]>([]);
   const [dirname, setDirname] = useState('');
+  const [filename, setFilename] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchInitialEntries = async () => {
-      const { result } = await disk();
+      const previousPath = localStorage.getItem(`srcbk:save-path:${session.dirName}`);
+      if (previousPath) {
+        const { dirname: dir } = splitPath(previousPath);
+        setDirname(dir);
+        setFilename(previousPath);
+      }
+      const { result } = await disk({ dirname });
       setEntries(result.entries);
       setDirname(result.dirname);
     };
     fetchInitialEntries();
-  }, []);
+  }, [session.dirName, dirname]);
 
   const onSave = async (path: string) => {
-    session.saveFile = path;
+    localStorage.setItem(`srcbk:save-path:${session.dirName}`, path);
     exportSession(session.id, { filename: path })
       .then(() => {
         onOpenChange(false);
@@ -59,7 +67,7 @@ export default function SaveModal({
             </div>
           </DialogDescription>
         </DialogHeader>
-        <FileSaver dirname={dirname} entries={entries} onSave={onSave} />
+        <FileSaver filename={filename} dirname={dirname} entries={entries} onSave={onSave} />
         {error && <p className="text-red-500">{error}</p>}
       </DialogContent>
     </Dialog>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -26,3 +26,25 @@ export function randomid(byteSize = 16) {
   const bytes = crypto.getRandomValues(new Uint8Array(byteSize));
   return base58.encode(bytes);
 }
+
+export function splitPath(fullPath: string) {
+  // Find the last slash in the path. Assumes macOSX or Linux-style paths
+  // For this, first we normalize the path to use forward slashes
+  const normalizedPath = fullPath.replace(/\\/g, '/');
+
+  const lastSlashIndex = normalizedPath.lastIndexOf('/');
+
+  // If there's no slash, the fullPath is just the basename
+  if (lastSlashIndex === -1) {
+    return {
+      dirname: '',
+      basename: fullPath,
+    };
+  }
+
+  // Split the path into dirname and basename
+  const dirname = fullPath.substring(0, lastSlashIndex);
+  const basename = fullPath.substring(lastSlashIndex + 1);
+
+  return { dirname, basename };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,5 +52,7 @@ export type SessionType = {
   id: string;
   path: string;
   cells: CellType[];
-  saveFile?: string;
+  // A unique identifier for this Srcbook which persists cross sessions
+  // It is used to store the files on the disk under ~/.srcbook/<dirName>
+  dirName: string;
 };


### PR DESCRIPTION
Fixes AXF-105

As I implement this, I was faced with some nuanced considerations: I would like this "memory" to be valid cross server restarts, not only valid for an ephemeral session. Similar to the UX of seeing your Recent Srcbooks still listed after server restarts, there's no intuitive reason for the user to lose this state if the server is stopped.
With that, we have 2 options for where to persist the .srcmd filename for a given Srcbook:
- on the server state, somewhere that persists cross sessions
- in localStorage

We've decided that we want to emphasize the directory as the source of truth for the data. This makes me lean towards this value being "client side only". Additionally, if we imagine we have multiple clients and only one server, there's no reason those clients would share the cached filename, which confirms that this should likely be client side.
This made me lean towards localStorage. I don't want to create a heavy localStorage pattern, which I think we'll want to do when we investigate the local-first ticket instead: [AXF-111 : Store local state in local client DB](https://linear.app/axflow/issue/AXF-111/store-local-state-in-local-client-db), so I'm going to keep this lightweight.


Finally, since I explicitly want to track this cross server restarts, I need a persistent identifier on the client that survives the session being killed, so I'm going to add the randomid() used for the dirname on the server. The basename in ~/.srcbook/<basename>/readme.md . I'm calling this out in case you have some strong reservations of leaking this information to the client.