### PR TITLE
Split out stdout and stderr. Scroll to bottom. Cap size

### DIFF
--- a/src/routes/session.tsx
+++ b/src/routes/session.tsx
@@ -548,17 +548,31 @@ function CellOutput(props: { cellId: string }) {
   const stderrText = formatOutput(getOutput(props.cellId, 'stderr'));
 
   return (
-    <div className="group relative border rounded mt-2 font-mono text-sm bg-input/10 divide-y">
+    <div className="relative group border rounded mt-2 font-mono text-sm bg-input/10">
       <div
         onClick={() => clearOutput(props.cellId)}
         className="absolute top-0 right-0 hover:cursor-pointer text-gray-200 hover:underline group-hover:text-gray-400 transition-all p-0.5 text-xs"
       >
         Clear
       </div>
-      {stdoutText && <div className="p-2 whitespace-pre-wrap overflow-scroll">{stdoutText}</div>}
-      {stderrText && (
-        <div className="p-2 whitespace-pre-wrap text-red-500 overflow-scroll">{stderrText}</div>
-      )}
+      <div className="divide-y">
+        {stdoutText && (
+          <>
+            <h1 className="font-bold px-2">Output</h1>
+            <div className="overflow-scroll p-2 whitespace-pre-wrap flex flex-col-reverse max-h-[400px]">
+              {stdoutText}
+            </div>
+          </>
+        )}
+        {stderrText && (
+          <>
+            <h1 className="font-bold px-2">Errors & Warnings</h1>
+            <div className="flex flex-col-reverse max-h-[400px] overflow-scroll p-2 whitespace-pre-wrap text-red-500">
+              {stderrText}
+            </div>
+          </>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
fixes AXF-125

I am not fully satisfied with this, in particular:
* There's a lot of borders, with `Output` and `Errors & Warnings` headers
* Clearing can be jarring, but vertical height animations are very non trivial and I think not worth our time right now
* When the cell is at the bottom of the viewport, the output goes below the viewport, and I wish the scroll would be pushed down as the `CellOutput` div gets bigger.
* `clear` action looks like it will clear only one. This is OK we know that design is temporary

However, I do think it's a net improvement, and will likely also depend on some bigger design changes, so shipping for now.

Gif:
![CleanShot 2024-05-31 at 16 32 46](https://github.com/axflow/srcbook/assets/1666947/770752d2-e5b4-4703-bb14-94ccc0f33191)
