### PR TITLE
Filename checking with server-side websocket messaging

### DIFF
--- a/src/clients/websocket/index.ts
+++ b/src/clients/websocket/index.ts
@@ -39,12 +39,16 @@ export const PkgJsonInstallMessageSchema = z.object({
 });
 
 export const FilenameCheckMessageSchema = z.object({
+  cellId: z.string(),
+  sessionId: z.string(),
   filename: z.string(),
 });
 
 export const FilenameCheckResultSchema = z.object({
+  cellId: z.string(),
   filename: z.string(),
-  exists: z.boolean(),
+  error: z.boolean(),
+  message: z.string().optional(),
 });
 
 export type CellExecMessageType = z.infer<typeof CellExecMessageSchema>;
@@ -52,6 +56,8 @@ export type CellStopMessageType = z.infer<typeof CellStopMessageSchema>;
 export type CellUpdatedMessageType = z.infer<typeof CellUpdatedMessageSchema>;
 export type CellOutputMessageType = z.infer<typeof CellOutputMessageSchema>;
 export type PkgJsonInstallMessageType = z.infer<typeof PkgJsonInstallMessageSchema>;
+export type FilenameCheckMessageType = z.infer<typeof FilenameCheckMessageSchema>;
+export type FilenameCheckResultType = z.infer<typeof FilenameCheckResultSchema>;
 
 const IncomingSessionEvents = {
   'cell:output': CellOutputMessageSchema,

--- a/src/components/use-cell.tsx
+++ b/src/components/use-cell.tsx
@@ -117,11 +117,11 @@ export const CellsProvider: React.FC<{ initialCells: CellType[]; children: React
 
   const createCodeCell = useCallback(
     (idx: number, attrs?: Partial<CodeCellType>) => {
-      const cell = buildCodeCell(cells, attrs);
+      const cell = buildCodeCell(cellsRef.current, attrs);
       insertCellAt(cell, idx);
       return cell;
     },
-    [insertCellAt, cells],
+    [insertCellAt],
   );
 
   const createMarkdownCell = useCallback(


### PR DESCRIPTION
As discussed, there isn't a ton of justification to do this check on the server, and if necessary, I am happy to refactor this to do a client side check only.

This PR offered a good example of introducing a new `wss` event with a request/response mechanism: the user changes the input for the filename, and we want to notify them if something went wrong or if it worked.

Some notes:
* Naming events is hard! We should keep iterating on this until we get strong conventions
* Because there is no request / response, I have to add sessionId and cellId and manually filter for those
* The pattern sends a request in a function, then receives the response in a useEffect. Not sure there is a better way, but it feels less natural than a `await fetch(...)` syntax
* Declaring zod types is tedious. Pretty much just as tedious as declaring request/response types (but it gives better type safety). This will be improved by having a mono-repo

## Experience 

https://github.com/axflow/srcbook/assets/1666947/21eeb8c4-ef69-4d1a-a81f-d3b9abccd9b6



## Note

This PR also introduces an "anti-footgun" where we name the file `untitled.mjs`, `untitled1.mjs`, `untitled2.mjs`, ... when we create a new code cell.

fixes AXF-108