### PR TITLE
Refactor events and split out dependency events

### DIFF
--- a/src/clients/websocket/index.ts
+++ b/src/clients/websocket/index.ts
@@ -7,25 +7,21 @@ const client = new WebSocketClient('ws://localhost:2150/websocket');
 
 export default client;
 
-export const CellExecMessageSchema = z.object({
-  sessionId: z.string(),
-  cellId: z.string(),
-  source: z.string().optional(),
-  // Packages can be sent when the cell is a package.json cell
-  // and it will install only the packages listed in the array
-  packages: z.array(z.string()).optional(),
-});
-
-export const CellStopMessageSchema = z.object({
+export const CellExecPayloadSchema = z.object({
   sessionId: z.string(),
   cellId: z.string(),
 });
 
-export const CellUpdatedMessageSchema = z.object({
+export const CellStopPayloadSchema = z.object({
+  sessionId: z.string(),
+  cellId: z.string(),
+});
+
+export const CellUpdatedPayloadSchema = z.object({
   cell: z.any(), // TODO: TYPE ME
 });
 
-export const CellOutputMessageSchema = z.object({
+export const CellOutputPayloadSchema = z.object({
   cellId: z.string(),
   output: z.object({
     type: z.enum(['stdout', 'stderr']),
@@ -33,43 +29,51 @@ export const CellOutputMessageSchema = z.object({
   }),
 });
 
-export const PkgJsonInstallMessageSchema = z.object({
-  // If packages is empty, install all dependencies
+export const DepsInstallPayloadSchema = z.object({
+  sessionId: z.string(),
   packages: z.array(z.string()).optional(),
 });
 
-export const FilenameCheckMessageSchema = z.object({
+export const DepsOutdatedPayloadSchema = z.object({
+  packages: z.array(z.string()).optional(),
+});
+
+export const CellValidatePayloadSchema = z.object({
   cellId: z.string(),
   sessionId: z.string(),
   filename: z.string(),
 });
 
-export const FilenameCheckResultSchema = z.object({
+export const CellValidateResponsePayloadSchema = z.object({
   cellId: z.string(),
   filename: z.string(),
   error: z.boolean(),
   message: z.string().optional(),
 });
 
-export type CellExecMessageType = z.infer<typeof CellExecMessageSchema>;
-export type CellStopMessageType = z.infer<typeof CellStopMessageSchema>;
-export type CellUpdatedMessageType = z.infer<typeof CellUpdatedMessageSchema>;
-export type CellOutputMessageType = z.infer<typeof CellOutputMessageSchema>;
-export type PkgJsonInstallMessageType = z.infer<typeof PkgJsonInstallMessageSchema>;
-export type FilenameCheckMessageType = z.infer<typeof FilenameCheckMessageSchema>;
-export type FilenameCheckResultType = z.infer<typeof FilenameCheckResultSchema>;
+export type CellExecPayloadType = z.infer<typeof CellExecPayloadSchema>;
+export type CellStopPayloadType = z.infer<typeof CellStopPayloadSchema>;
+export type CellUpdatedPayloadType = z.infer<typeof CellUpdatedPayloadSchema>;
+export type CellOutputPayloadType = z.infer<typeof CellOutputPayloadSchema>;
+
+export type DepsInstallPayloadType = z.infer<typeof DepsInstallPayloadSchema>;
+export type DepsOutdatedPayloadType = z.infer<typeof DepsOutdatedPayloadSchema>;
+
+export type CellValidatePayloadType = z.infer<typeof CellValidatePayloadSchema>;
+export type CellValidateResponsePayloadType = z.infer<typeof CellValidateResponsePayloadSchema>;
 
 const IncomingSessionEvents = {
-  'cell:output': CellOutputMessageSchema,
-  'cell:updated': CellUpdatedMessageSchema,
-  'package.json:install': PkgJsonInstallMessageSchema,
-  'filename-check': FilenameCheckResultSchema,
+  'cell:output': CellOutputPayloadSchema,
+  'cell:updated': CellUpdatedPayloadSchema,
+  'deps:outdated': DepsOutdatedPayloadSchema,
+  'cell:validate:response': CellValidateResponsePayloadSchema,
 };
 
 const OutgoingSessionEvents = {
-  'cell:exec': CellExecMessageSchema,
-  'cell:stop': CellStopMessageSchema,
-  'filename-check': FilenameCheckMessageSchema,
+  'cell:exec': CellExecPayloadSchema,
+  'cell:stop': CellStopPayloadSchema,
+  'deps:install': DepsInstallPayloadSchema,
+  'cell:validate': CellValidatePayloadSchema,
 };
 
 export class SessionChannel extends Channel<

--- a/src/components/install-package-modal.tsx
+++ b/src/components/install-package-modal.tsx
@@ -20,7 +20,7 @@ import {
   CommandList,
 } from '@/components/ui/command';
 import type { PackageJsonCellType, SessionType } from '@/types';
-import { CellUpdatedMessageType, SessionChannel } from '@/clients/websocket';
+import { CellUpdatedPayloadType, SessionChannel } from '@/clients/websocket';
 import { useCells } from './use-cell';
 
 type PackageMetadata = {
@@ -61,7 +61,7 @@ export default function InstallPackageModal({
     .join('');
 
   useEffect(() => {
-    const callback = (payload: CellUpdatedMessageType) => {
+    const callback = (payload: CellUpdatedPayloadType) => {
       if (open && payload.cell.id === cell.id && payload.cell.status === 'idle') {
         setMode('success');
       }
@@ -75,9 +75,8 @@ export default function InstallPackageModal({
     setPkg(packageName);
     setMode('loading');
 
-    channel.push('cell:exec', {
+    channel.push('deps:install', {
       sessionId: session.id,
-      cellId: cell.id,
       packages: [packageName],
     });
   };


### PR DESCRIPTION
* Split apart executing a node cell (`cell:exec`) vs executing a package json cell (`deps:install`)
* Rename `package.json:install` to `deps:outdated`
* Rename `filename-check` to `cell:validate`
* Introduce `cell:validate:response` to respond to the `cell:validate` request. We only need this until we have replies.
* Cleanup some code on the server
* Copy all client-side zod schemas to server side so they're the same (with the same naming)
* Some more naming touch ups
* Remove `source` attribute from `cell:exec` and `deps:install` request payloads. They don't need it now because each keystroke is immediately persisted. In the future if there's a delay between keystroke and persisting updates to disk, then we will need a better way to handle this anyways, involving some sort of "Pending source update sync" state.