### PR TITLE
Make dependency checking async

### DIFF
--- a/server/deps.mts
+++ b/server/deps.mts
@@ -1,0 +1,75 @@
+import Path from 'node:path';
+import fs from 'node:fs/promises';
+import { exec } from 'node:child_process';
+
+export async function shouldNpmInstall(dirPath: string): Promise<boolean> {
+  const packageJsonPath = Path.resolve(Path.join(dirPath, 'package.json'));
+  const packageLockPath = Path.resolve(Path.join(dirPath, 'package-lock.json'));
+
+  const packageJsonExists = await fileExists(packageJsonPath);
+
+  if (!packageJsonExists) {
+    throw new Error(`No package.json was found in ${dirPath}`);
+  }
+
+  const packageJsonData = await fs.readFile(packageJsonPath, 'utf8');
+  const pkgJson = JSON.parse(packageJsonData);
+
+  const dependencies = pkgJson.dependencies || {};
+  const devDependencies = pkgJson.devDependencies || {};
+
+  const allDeps = { ...dependencies, ...devDependencies };
+  const allDepsKeys = Object.keys(allDeps);
+
+  if (allDepsKeys.length === 0) {
+    return false; // No dependencies to install
+  }
+
+  const packageLockExists = await fileExists(packageLockPath);
+
+  if (!packageLockExists) {
+    return true; // package-lock.json does not exist, need to run npm install
+  }
+
+  const packageLockData = await fs.readFile(packageLockPath, 'utf8');
+  const pkgLockJson = JSON.parse(packageLockData);
+
+  const installedDeps = pkgLockJson.packages[''].dependencies || {};
+
+  for (const dep of allDepsKeys) {
+    if (!installedDeps[dep]) {
+      return true; // Dependency in package.json not found in package-lock.json
+    }
+  }
+  return false; // All dependencies are installed
+}
+
+export async function missingUndeclaredDeps(dirPath: string): Promise<string[]> {
+  return new Promise((resolve) => {
+    // Ignore the err argument because depcheck exists with a non zero code (255) when there are missing deps.
+    exec(`npm run depcheck ${Path.resolve(dirPath)} -- --json`, (_err, stdout) => {
+      const output = stdout || '';
+
+      // Use regex to extract JSON object
+      const jsonMatch = output.match(/{.*}/s);
+      if (!jsonMatch) {
+        throw new Error('Failed to extract JSON from depcheck output');
+      }
+
+      // Parse the JSON
+      const parsedResult = JSON.parse(jsonMatch[0]);
+
+      // Process and return the data as needed
+      resolve(Object.keys(parsedResult.missing));
+    });
+  });
+}
+
+async function fileExists(filepath: string) {
+  try {
+    await fs.access(filepath, fs.constants.F_OK);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}

--- a/server/exec.mts
+++ b/server/exec.mts
@@ -1,6 +1,5 @@
 import Path from 'node:path';
-import fs from 'node:fs';
-import { spawn, execSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 
 export type BaseExecRequestType = {
   cwd: string;
@@ -104,68 +103,4 @@ export function npmInstall(options: NPMInstallRequestType) {
   });
 
   return child;
-}
-
-export function shouldNpmInstall(cwd: string): boolean {
-  const packageJsonPath = Path.join(cwd, 'package.json');
-  const packageLockPath = Path.join(cwd, 'package-lock.json');
-
-  if (!fs.existsSync(packageJsonPath)) {
-    throw new Error('package.json not found in the specified directory.');
-  }
-
-  const packageJsonData = fs.readFileSync(packageJsonPath, 'utf8');
-  const pkgJson = JSON.parse(packageJsonData);
-
-  const dependencies = pkgJson.dependencies || {};
-  const devDependencies = pkgJson.devDependencies || {};
-
-  const allDeps = { ...dependencies, ...devDependencies };
-  const allDepsKeys = Object.keys(allDeps);
-
-  if (allDepsKeys.length === 0) {
-    return false; // No dependencies to install
-  }
-
-  if (!fs.existsSync(packageLockPath)) {
-    return true; // package-lock.json does not exist, need to run npm install
-  }
-
-  const packageLockData = fs.readFileSync(packageLockPath, 'utf8');
-  const pkgLockJson = JSON.parse(packageLockData);
-
-  const installedDeps = pkgLockJson.packages[''].dependencies || {};
-
-  for (const dep of allDepsKeys) {
-    if (!installedDeps[dep]) {
-      return true; // Dependency in package.json not found in package-lock.json
-    }
-  }
-  return false; // All dependencies are installed
-}
-
-export async function missingUndeclaredDeps(cwd: string): Promise<string[]> {
-  let output = '';
-  try {
-    const result = execSync(`npm run depcheck ${cwd} -- --json`);
-    output = result.toString('utf8');
-  } catch (err) {
-    const error = err as { stdout: Buffer; stderr: Buffer; code: number };
-    // When there are missing dependencies, depcheck exists with a non zero code (its 255).
-    if (error.stdout) {
-      output = error.stdout.toString('utf8');
-    }
-  }
-
-  // Use regex to extract JSON object
-  const jsonMatch = output.match(/{.*}/s);
-  if (!jsonMatch) {
-    throw new Error('Failed to extract JSON from depcheck output');
-  }
-
-  // Parse the JSON
-  const parsedResult = JSON.parse(jsonMatch[0]);
-
-  // Process and return the data as needed
-  return Object.keys(parsedResult.missing);
 }

--- a/server/index.mts
+++ b/server/index.mts
@@ -25,7 +25,8 @@ import type {
   SessionType,
   PackageJsonCellType,
 } from './types';
-import { node, npmInstall, shouldNpmInstall, missingUndeclaredDeps } from './exec.mjs';
+import { node, npmInstall } from './exec.mjs';
+import { shouldNpmInstall, missingUndeclaredDeps } from './deps.mjs';
 import processes from './processes.mjs';
 import WebSocketServer from './web-socket-server.mjs';
 import z from 'zod';
@@ -95,10 +96,13 @@ function addRunningProcess(
 }
 
 async function nudgeMissingDeps(wss: WebSocketServer, session: SessionType) {
-  if (shouldNpmInstall(session.dir)) {
+  if (await shouldNpmInstall(session.dir)) {
     wss.broadcast(`session:${session.id}`, 'deps:outdated', {});
+    return;
   }
+
   const missingDeps = await missingUndeclaredDeps(session.dir);
+
   if (missingDeps.length > 0) {
     wss.broadcast(`session:${session.id}`, 'deps:outdated', { packages: missingDeps });
   }


### PR DESCRIPTION
Executing cells were noticeably laggy. That's because we were doing multiple synchronous disk reads for dep checking before it had the chance to start the node process to execute the cell. This moves dep checking to be async as to not block the thread.

The existing dep checking is pretty naive. We should also be better about this. We don't need to check it on every cell execution when package.json hasn't been touched, for instance.