### PR TITLE
Explicit create, open, and import srcbook flows

### DIFF
--- a/packages/api/config.mts
+++ b/packages/api/config.mts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { fileExists } from './fs-utils.mjs';
 
 export const HOME_DIR = os.homedir();
 export const SRCBOOK_DIR = path.join(HOME_DIR, '.srcbook');
@@ -60,14 +61,5 @@ export async function initializeConfig() {
 
   if (!hasSecretsFile) {
     fs.writeFile(SECRETS_FILE_PATH, '{}', 'utf8');
-  }
-}
-
-async function fileExists(filepath: string) {
-  try {
-    await fs.access(filepath, fs.constants.F_OK);
-    return true;
-  } catch (error) {
-    return false;
   }
 }

--- a/packages/api/deps.mts
+++ b/packages/api/deps.mts
@@ -1,6 +1,7 @@
 import Path from 'node:path';
 import fs from 'node:fs/promises';
 import { exec } from 'node:child_process';
+import { fileExists } from './fs-utils.mjs';
 
 export async function shouldNpmInstall(dirPath: string): Promise<boolean> {
   const packageJsonPath = Path.resolve(Path.join(dirPath, 'package.json'));
@@ -63,13 +64,4 @@ export async function missingUndeclaredDeps(dirPath: string): Promise<string[]> 
       resolve(Object.keys(parsedResult.missing));
     });
   });
-}
-
-async function fileExists(filepath: string) {
-  try {
-    await fs.access(filepath, fs.constants.F_OK);
-    return true;
-  } catch (error) {
-    return false;
-  }
 }

--- a/packages/api/fs-utils.mts
+++ b/packages/api/fs-utils.mts
@@ -1,0 +1,25 @@
+import fs from 'node:fs/promises';
+
+export async function fileExists(filepath: string) {
+  try {
+    await fs.access(filepath, fs.constants.F_OK);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+export async function readdir(
+  path: string,
+): Promise<{ exists: true; files: string[] } | { exists: false }> {
+  try {
+    const files = await fs.readdir(path);
+    return { exists: true, files };
+  } catch (e) {
+    const error = e as Error & { code: string };
+    if (error && error.code === 'ENOENT') {
+      return { exists: false };
+    }
+    throw e;
+  }
+}

--- a/packages/api/srcbook.mts
+++ b/packages/api/srcbook.mts
@@ -1,0 +1,100 @@
+import fs from 'node:fs/promises';
+import Path from 'node:path';
+import { encode, decode } from './srcmd.mjs';
+import { toFormattedJSON } from './utils.mjs';
+import { readdir } from './fs-utils.mjs';
+import { CellType } from './types';
+import { randomid } from '@srcbook/shared';
+
+export async function writeToDisk(srcbookDir: string, cells: CellType[]) {
+  const writes = [
+    fs.writeFile(Path.join(srcbookDir, 'README.md'), encode(cells, { inline: false }), {
+      encoding: 'utf8',
+    }),
+  ];
+
+  for (const cell of cells) {
+    if (cell.type === 'package.json') {
+      writes.push(
+        fs.writeFile(Path.join(srcbookDir, 'package.json'), cell.source, { encoding: 'utf8' }),
+      );
+    } else if (cell.type === 'code') {
+      writes.push(
+        fs.writeFile(Path.join(srcbookDir, cell.filename), cell.source, { encoding: 'utf8' }),
+      );
+    }
+  }
+
+  await Promise.all(writes);
+}
+
+/**
+ * Creates a srcbook directory from a .srcmd file.
+ */
+export async function importSrcbookFromSrcmdFile(
+  srcmdPath: string,
+  destinationDir: string,
+  name: string,
+) {
+  const dirname = Path.join(destinationDir, name);
+
+  const [srcmd] = await Promise.all([
+    fs.readFile(srcmdPath, 'utf8'),
+    createSrcbookDirectory(dirname),
+  ]);
+
+  const result = decode(srcmd);
+
+  if (result.error) {
+    console.error(result.error);
+    throw new Error(`Cannot decode invalid srcmd in ${srcmdPath}`);
+  }
+
+  await writeToDisk(dirname, result.cells);
+
+  return dirname;
+}
+
+/**
+ * Creates a new srcbook.
+ */
+export async function createNewSrcbook(path: string, name: string) {
+  const dirname = Path.join(path, name);
+
+  await createSrcbookDirectory(dirname);
+
+  const cells: CellType[] = [
+    {
+      id: randomid(),
+      type: 'title',
+      text: name,
+    },
+    {
+      id: randomid(),
+      type: 'package.json',
+      source: buildPackageJson(),
+      filename: 'package.json',
+      status: 'idle',
+    },
+  ];
+
+  await writeToDisk(dirname, cells);
+
+  return dirname;
+}
+
+async function createSrcbookDirectory(dirname: string) {
+  const dir = await readdir(dirname);
+
+  if (dir.exists && dir.files.length > 0) {
+    throw new Error(`Cannot create srcbook in non-empty directory ${dirname}`);
+  }
+
+  if (!dir.exists) {
+    await fs.mkdir(dirname, { recursive: true });
+  }
+}
+
+function buildPackageJson() {
+  return toFormattedJSON({ dependencies: {} });
+}

--- a/packages/api/srcmd.mts
+++ b/packages/api/srcmd.mts
@@ -418,16 +418,3 @@ function serializeMarkdownTokens(tokens: Token[]) {
     })
     .join('');
 }
-
-export function newContents(title: string) {
-  return `# ${title}
-
-###### package.json
-
-\`\`\`json
-{
-  "dependencies": {}
-}
-\`\`\`
-`;
-}

--- a/packages/api/utils.mts
+++ b/packages/api/utils.mts
@@ -64,12 +64,6 @@ function isRootPath(path: string) {
   }
 }
 
-// Converts a string to a valid npm package name. Validation regex:
-// /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/
-export function toValidNpmName(title: string) {
-  return title
-    .toLowerCase() // Convert to lowercase
-    .replace(/[^a-z0-9-~._\s]/g, '') // Remove unwanted symbols
-    .replace(/\s+/g, '-') // Convert spaces to hyphens
-    .replace(/^-+|-+$/g, ''); // Remove leading and trailing hyphens
+export function toFormattedJSON(o: any) {
+  return JSON.stringify(o, null, 2);
 }

--- a/packages/web/src/lib/server.ts
+++ b/packages/web/src/lib/server.ts
@@ -33,9 +33,61 @@ export async function disk(request?: DiskRequestType): Promise<DiskResponseType>
   return response.json();
 }
 
+interface CreateSrcbookRequestType {
+  path: string;
+  name: string;
+}
+
+interface CreateSrcbookResponseType {
+  error: boolean;
+  result: { path: string; name: string };
+}
+
+export async function createSrcbook(
+  request: CreateSrcbookRequestType,
+): Promise<CreateSrcbookResponseType> {
+  const response = await fetch(SERVER_BASE_URL + '/srcbooks', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    console.error(response);
+    throw new Error('Request failed');
+  }
+
+  return response.json();
+}
+
+interface ImportSrcbookRequestType {
+  path: string;
+}
+
+interface ImportSrcbookResponseType {
+  error: boolean;
+  result: { dir: string; name: string };
+}
+
+export async function importSrcbook(
+  request: ImportSrcbookRequestType,
+): Promise<ImportSrcbookResponseType> {
+  const response = await fetch(SERVER_BASE_URL + '/import', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    console.error(response);
+    throw new Error('Request failed');
+  }
+
+  return response.json();
+}
+
 interface CreateSessionRequestType {
-  dirname: string;
-  title: string;
+  path: string;
 }
 
 interface CreateSessionResponseType {

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -1,9 +1,8 @@
 import { PlusIcon } from 'lucide-react';
 import { Form, useLoaderData, redirect, Link } from 'react-router-dom';
-import { getConfig, createSession, loadSessions } from '@/lib/server';
+import { getConfig, createSession, loadSessions, createSrcbook } from '@/lib/server';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { useState } from 'react';
 import CanvasCells from '@/components/canvas-cells';
 
 import type { SessionType, TitleCellType } from '@/types';
@@ -16,10 +15,11 @@ async function loader() {
 
 async function action({ request }: { request: Request }) {
   const formData = await request.formData();
-  const dirname = formData.get('dirname') as string;
-  const title = formData.get('title') as string;
-  const { result } = await createSession({ dirname, title });
-  return redirect(`/sessions/${result.id}`);
+  const path = formData.get('path') as string;
+  const name = formData.get('name') as string;
+  const { result } = await createSrcbook({ path, name });
+  const { result: sessionResult } = await createSession({ path: result.path });
+  return redirect(`/sessions/${sessionResult.id}`);
 }
 
 type HomeLoaderDataType = {
@@ -30,24 +30,15 @@ type HomeLoaderDataType = {
 function Home() {
   const { baseDir, sessions } = useLoaderData() as HomeLoaderDataType;
 
-  const [title, setTitle] = useState('');
-
   return (
     <>
       <h1 className="text-2xl mx-auto mb-8">Srcbooks</h1>
-      <p>Create your next Srcbook or open an existing one below.</p>
+      <p>Create a new Srcbook or open an existing one</p>
       <div className="mt-4 flex items-center gap-12">
         <Form method="post" className="h-full">
-          <Input type="hidden" name="dirname" value={baseDir} />
+          <Input type="hidden" name="path" value={baseDir} />
           <div className="flex items-center justify-center h-full gap-2">
-            <Input
-              placeholder="name your new srcBook"
-              required
-              className="w-60"
-              onChange={(e) => setTitle(e.target.value)}
-              name="title"
-              value={title}
-            />
+            <Input placeholder="Srcbook name" required className="w-60" name="name" />
             <Button className="min-w-32" type="submit">
               <div className="flex gap-2 items-center">
                 Create New <PlusIcon size={16} />
@@ -57,11 +48,11 @@ function Home() {
         </Form>
         <p>or</p>
         <div className="flex flex-col items-center justify-center h-full">
-          <Form action="/open" className="flex items-center space-x-2">
+          <Link to="/open" className="flex items-center space-x-2">
             <Button variant="outline" className="min-w-32" type="submit">
               Open
             </Button>
-          </Form>
+          </Link>
         </div>
       </div>
       <h2 className="text-xl mx-auto mt-8 mb-4">Recent notebooks</h2>

--- a/packages/web/src/routes/open.tsx
+++ b/packages/web/src/routes/open.tsx
@@ -13,9 +13,8 @@ async function loader() {
 
 async function action({ request }: { request: Request }) {
   const formData = await request.formData();
-  const dirname = formData.get('dirname') as string;
-  const basename = formData.get('basename') as string;
-  const { result } = await createSession({ dirname, title: basename });
+  const path = formData.get('path') as string;
+  const { result } = await createSession({ path });
   return redirect(`/sessions/${result.id}`);
 }
 

--- a/packages/web/src/routes/secrets.tsx
+++ b/packages/web/src/routes/secrets.tsx
@@ -109,7 +109,7 @@ function SecretRow({ name, value }: { name: string; value: string }) {
               <CopyableSecretValue value={value} />
             </div>
 
-            <div className="flex col-span-1 flex justify-end items-center gap-2">
+            <div className="col-span-1 flex justify-end items-center gap-2">
               <Button variant="outline" onClick={() => setMode('edit')}>
                 Edit
               </Button>


### PR DESCRIPTION
As I started adding more functionality for creating typescript srcbooks, it was getting hard to follow the create session code. It creates a session but also creates directories if they didn't exist, and more. It was worse if I added an option to create TS srcbook vs JS one.

Rethinking this, we have three flows:

1. Open an existing srcbook (existing means there's a directory)
2. Import a srcbook from a .srcmd file (create new srcbook directory and populate it with contents of .srcmd file)
3. Create a new srcbook from scratch (create directory for srcbook with mostly empty contents)

I restructured the code to make each of these flows separate and explicit. I still think some of the naming and what not is confusing, but it feels much less confusing to me than before.

TODO: Rethink the UX of these flows. For example, do we want the user to explicitly choose the directory name and location when they import from a srcmd file?
