### PR TITLE
Fix dep checking bug with devDependencies

### DIFF
--- a/packages/api/fs-utils.mts
+++ b/packages/api/fs-utils.mts
@@ -9,6 +9,21 @@ export async function fileExists(filepath: string) {
   }
 }
 
+export async function readFile(
+  path: string,
+): Promise<{ exists: true; contents: string } | { exists: false }> {
+  try {
+    const contents = await fs.readFile(path, 'utf8');
+    return { exists: true, contents };
+  } catch (e) {
+    const error = e as NodeJS.ErrnoException;
+    if (error && error.code === 'ENOENT') {
+      return { exists: false };
+    }
+    throw error;
+  }
+}
+
 export async function readdir(
   path: string,
 ): Promise<{ exists: true; files: string[] } | { exists: false }> {
@@ -16,10 +31,10 @@ export async function readdir(
     const files = await fs.readdir(path);
     return { exists: true, files };
   } catch (e) {
-    const error = e as Error & { code: string };
+    const error = e as NodeJS.ErrnoException;
     if (error && error.code === 'ENOENT') {
       return { exists: false };
     }
-    throw e;
+    throw error;
   }
 }


### PR DESCRIPTION
With typescript, I am adding devDependencies and I noticed a bug when doing so: We took package.json dependencies AND devDependencies and checked against _only_ the package-lock.json dependencies (not its devDependencies).

This PR:

1. Fixes the above bug
2. Shrinks the number of file read operations from 4 synchronous ones to 2 ones that run in parallel, so we speed up the dep checking by quite a bit.