### PR TITLE
Fix bugs when initializing app

### DIFF
--- a/packages/api/constants.mts
+++ b/packages/api/constants.mts
@@ -1,0 +1,5 @@
+import os from 'node:os';
+import path from 'node:path';
+
+export const HOME_DIR = os.homedir();
+export const SRCBOOK_DIR = path.join(HOME_DIR, '.srcbook');

--- a/packages/api/drizzle.config.ts
+++ b/packages/api/drizzle.config.ts
@@ -1,11 +1,12 @@
 import { defineConfig } from 'drizzle-kit';
 import Path from 'node:path';
+import { SRCBOOK_DIR } from './constants.mts';
 
 export default defineConfig({
   schema: './db/schema.mts',
   out: './drizzle',
   dialect: 'sqlite',
   dbCredentials: {
-    url: Path.join(process.env.HOME || '~', '.srcbook', 'srcbook.db'),
+    url: Path.join(SRCBOOK_DIR, 'srcbook.db'),
   },
 });

--- a/packages/api/index.mts
+++ b/packages/api/index.mts
@@ -3,9 +3,6 @@ import { WebSocketServer as WsWebSocketServer } from 'ws';
 
 import app from './server/http.mjs';
 import webSocketServer from './server/ws.mjs';
-import { initializeConfig } from './config.mjs';
-
-initializeConfig();
 
 const server = http.createServer(app);
 

--- a/packages/api/initialization.mts
+++ b/packages/api/initialization.mts
@@ -1,0 +1,11 @@
+/**
+ * This file is meant to be executed before the rest of the application boots.
+ * Otherwise, the application will fail to boot because it expects the code in
+ * here to already have executed.
+ */
+
+import fs from 'node:fs/promises';
+import { SRCBOOK_DIR } from './constants.mjs';
+
+// make sure to await this
+await fs.mkdir(SRCBOOK_DIR, { recursive: true });

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -4,11 +4,14 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "init": "vite-node ./initialization.mts",
+    "predev": "pnpm run init",
     "dev": "vite-node index.mts",
     "test": "vitest",
     "check-types": "tsc",
     "depcheck": "depcheck",
     "generate": "drizzle-kit generate",
+    "premigrate": "pnpm run init",
     "migrate": "drizzle-kit migrate"
   },
   "dependencies": {

--- a/packages/api/session.mts
+++ b/packages/api/session.mts
@@ -15,7 +15,7 @@ import {
   CellErrorType,
 } from '@srcbook/shared';
 import { encode, decodeDir } from './srcmd.mjs';
-import { SRCBOOK_DIR } from './config.mjs';
+import { SRCBOOK_DIR } from './constants.mjs';
 import { SessionType } from './types';
 import { writeToDisk, writeCellToDisk, writeReadmeToDisk, moveCodeCellOnDisk } from './srcbook.mjs';
 import { fileExists } from './fs-utils.mjs';


### PR DESCRIPTION
I deleted the `.srcbook` directory off of my file system and the app was in a broken state since we removed the previous initialization code that created that directory.

It's more complicated now with database because of migrations as well. So I created a script that runs before we migrate or boot the server that ensures the `.srcbook` directory is created.

@nichochar we should make sure to check fresh installs, particularly when making changes to config or anything boot related.