### PR TITLE
Add basic WebSocket retry logic

### DIFF
--- a/packages/api/server/ws.mts
+++ b/packages/api/server/ws.mts
@@ -205,7 +205,9 @@ async function cellUpdate(payload: CellUpdatePayloadType) {
   const cell = findCell(session, payload.cellId);
 
   if (!cell) {
-    throw new Error(`No cell exists for session '${payload.sessionId}' and cell ${payload.cellId}`);
+    throw new Error(
+      `No cell exists for session '${payload.sessionId}' and cell '${payload.cellId}'`,
+    );
   }
 
   const result = await updateCell(session, cell, payload.updates);


### PR DESCRIPTION
The retry logic follows a [similar pattern in Phoenix](https://github.com/phoenixframework/phoenix/blob/main/assets/js/phoenix/socket.js#L162).

### What this PR does

* If a server terminates the connection for unexpected reasons AND the underlying WebSocket 'close' event is received by the client, we start retrying.

### What this PR does not do

* Use a heartbeat to determine if the connection is still alive. Robust WS implementations (phoenix, partykit, etc) use heartbeats to ping the server and receive a reply. While servers and clients send a 'close' event when they terminate, the network could have issues them, so the only real way to know connections are still alive is to ping the server and receive a reply. This will need to be done eventually, but I'm hoping this basic PR is plenty robust given this is running on people's local machines.