### PR TITLE
Add default tsconfig for TypeScript notebooks

### DIFF
--- a/packages/api/constants.mts
+++ b/packages/api/constants.mts
@@ -11,4 +11,14 @@ const __dirname = path.dirname(__filename);
 export const HOME_DIR = os.homedir();
 export const SRCBOOK_DIR = path.join(HOME_DIR, '.srcbook');
 export const SRCBOOKS_DIR = path.join(SRCBOOK_DIR, 'srcbooks');
+export const DEFAULT_TSCONFIG_PATH = path.join(SRCBOOK_DIR, 'tsconfig.json');
 export const DIST_DIR = __dirname;
+
+export const DEFAULT_TSCONFIG = {
+  module: 'nodenext',
+  moduleResolution: 'nodenext',
+  target: 'es2022',
+  resolveJsonModule: true,
+  noEmit: true,
+  allowImportingTsExtensions: true,
+};

--- a/packages/api/exec.mts
+++ b/packages/api/exec.mts
@@ -1,5 +1,7 @@
 import Path from 'node:path';
 import { spawn } from 'node:child_process';
+import { DEFAULT_TSCONFIG_PATH, DEFAULT_TSCONFIG } from './constants.mjs';
+import { tsConfigToArgs } from './utils.mjs';
 
 export type BaseExecRequestType = {
   cwd: string;
@@ -86,7 +88,7 @@ export function tsc(options: NodeRequestType) {
   return spawnCall({
     command: Path.join(cwd, 'node_modules', '.bin', 'tsc'),
     cwd,
-    args: [filepath, '--noEmit'],
+    args: [filepath, ...tsConfigToArgs(DEFAULT_TSCONFIG)],
     stdout,
     stderr,
     onExit,
@@ -120,7 +122,7 @@ export function tsx(options: NodeRequestType) {
   return spawnCall({
     command: Path.join(cwd, 'node_modules', '.bin', 'tsx'),
     cwd,
-    args: [filepath],
+    args: ['--tsconfig', DEFAULT_TSCONFIG_PATH, filepath],
     stdout,
     stderr,
     onExit,

--- a/packages/api/initialization.mts
+++ b/packages/api/initialization.mts
@@ -5,7 +5,8 @@
  */
 
 import fs from 'node:fs/promises';
-import { SRCBOOKS_DIR } from './constants.mjs';
+import Path from 'node:path';
+import { DEFAULT_TSCONFIG, DEFAULT_TSCONFIG_PATH, SRCBOOKS_DIR } from './constants.mjs';
 
 // This single mkdir is creating:
 //
@@ -16,3 +17,5 @@ import { SRCBOOKS_DIR } from './constants.mjs';
 // behavior and make sure both get created during initialization
 // or the app will not work properly.
 await fs.mkdir(SRCBOOKS_DIR, { recursive: true });
+
+await fs.writeFile(Path.join(DEFAULT_TSCONFIG_PATH), JSON.stringify(DEFAULT_TSCONFIG, null, 2));

--- a/packages/api/utils.mts
+++ b/packages/api/utils.mts
@@ -41,13 +41,13 @@ export async function disk(dirname: string, ext: string) {
   return isRootPath(dirname)
     ? entries
     : [
-        {
-          path: Path.dirname(dirname),
-          dirname: Path.dirname(dirname),
-          basename: '..',
-          isDirectory: true,
-        },
-      ].concat(entries);
+      {
+        path: Path.dirname(dirname),
+        dirname: Path.dirname(dirname),
+        basename: '..',
+        isDirectory: true,
+      },
+    ].concat(entries);
 }
 
 function isRootPath(path: string) {
@@ -66,4 +66,24 @@ function isRootPath(path: string) {
 
 export function toFormattedJSON(o: any) {
   return JSON.stringify(o, null, 2);
+}
+
+/**
+ * Given a configuration object like
+ *  const defaultTsConfig = {
+ *    target: 'es2022',
+ *    resolveJsonModule: true,
+ *    noEmit: true,
+ *   };
+ *
+ * Return an array of CLI args:
+ *   ['--target', 'es2022', '--resolveJsonModule', '--noEmit']
+ */
+export function tsConfigToArgs(config: Record<string, any>): string[] {
+  return Object.entries(config).flatMap(([key, value]) => {
+    if (typeof value === 'boolean') {
+      return value ? [`--${key}`] : [];
+    }
+    return [`--${key}`, String(value)];
+  });
 }


### PR DESCRIPTION
We store it in at `~/.srcbooks/tsconfig.json` as a file (we have to store it as a file since `tsx` does not accept it in any other way. We do this at initialization time.

Annoyingly, `tsc` does _not_ accept it as a file unless we're doing `--p` (directory mode), but that would mean copying the tsconfig in each directory. We can do this, but currently I am not, and instead added a utility which converts the default tsconfig into CLI args that we pass to `tsc`.

Tested locally: top level await works and imports work.

fixes [AXF-159 : Pass tsconfig to tsx to allow more modern syntax](https://linear.app/axflow/issue/AXF-159/pass-tsconfig-to-tsx-to-allow-more-modern-syntax)
