### PR TITLE
Vendor tutorial mechanism and publish 0.0.25

### DIFF
--- a/srcbook/package.json
+++ b/srcbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scratch-srcbook",
-  "version": "0.0.23",
+  "version": "0.0.25",
   "type": "module",
   "bin": "./bin/start",
   "scripts": {

--- a/srcbook/vendor/package.json
+++ b/srcbook/vendor/package.json
@@ -29,7 +29,7 @@
     "predev": "pnpm run init",
     "dev": "vite-node dev-server.mts",
     "test": "vitest",
-    "build": "tsc && rm -rf ./dist/drizzle && cp -R ./drizzle ./dist/drizzle",
+    "build": "tsc && rm -rf ./dist/drizzle && cp -R ./drizzle ./dist/drizzle && rm -rf ./dist/tutorials && cp -R ./tutorials ./dist/tutorials",
     "check-types": "tsc",
     "depcheck": "depcheck",
     "generate": "drizzle-kit generate",

--- a/srcbook/vendor/server/ws.mts
+++ b/srcbook/vendor/server/ws.mts
@@ -200,18 +200,11 @@ async function tscExec({ session, cell, secrets }: ExecRequestType) {
       stderr(data) {
         wss.broadcast(`session:${session.id}`, 'cell:output', {
           cellId: cell.id,
-          output: { type: 'stderr', data: data.toString('utf8') },
+          output: { type: 'tsc', data: data.toString('utf8') },
         });
       },
       onExit() {
-        // Reload cell to get most recent version which may have been updated since
-        // in the time between initially running this cell and when running finishes.
-        //
-        // TODO: Real state management pls.
-        //
-        const mostRecentCell = session.cells.find((c) => c.id === cell.id) as CodeCellType;
-        mostRecentCell.status = 'idle';
-        wss.broadcast(`session:${session.id}`, 'cell:updated', { cell: mostRecentCell });
+        // TSC is only used to send data over stdout
       },
     }),
   );

--- a/srcbook/vendor/srcbook.mts
+++ b/srcbook/vendor/srcbook.mts
@@ -10,7 +10,7 @@ import type {
 import { encode, decode } from './srcmd.mjs';
 import { toFormattedJSON } from './utils.mjs';
 import { randomid } from '@srcbook/shared';
-import { SRCBOOKS_DIR } from './constants.mjs';
+import { SRCBOOKS_DIR, DIST_DIR } from './constants.mjs';
 
 export function writeToDisk(srcbookDir: string, metadata: SrcbookMetadataType, cells: CellType[]) {
   const writes = [writeReadmeToDisk(srcbookDir, metadata, cells)];
@@ -72,7 +72,10 @@ export function writeReadmeToDisk(
  * https://linear.app/axflow/issue/AXF-146/files-and-directories-behavior
  */
 export async function importSrcbookFromSrcmdFile(srcmdPath: string) {
-  const [srcmd, dirname] = await Promise.all([fs.readFile(srcmdPath, 'utf8'), newSrcbookDir()]);
+  // When we import tutorials, we don't have absolute paths but rather want to
+  // import them from the vendored srcbook application.
+  const finalPath = srcmdPath.startsWith('tutorials') ? Path.join(DIST_DIR, srcmdPath) : srcmdPath;
+  const [srcmd, dirname] = await Promise.all([fs.readFile(finalPath, 'utf8'), newSrcbookDir()]);
 
   const result = decode(srcmd);
 

--- a/srcbook/vendor/tutorials/getting-started.srcmd
+++ b/srcbook/vendor/tutorials/getting-started.srcmd
@@ -1,0 +1,83 @@
+<!-- srcbook:{"language":"javascript"} -->
+
+# Getting started
+
+###### package.json
+
+```json
+{
+  "type": "module",
+  "dependencies": {
+    "random-words": "^2.0.1"
+  }
+}
+```
+
+## What are srcbooks?
+
+Srcbooks are an interactive way of programming in JavaScript or TypeScript. They are similar to other notebooks like python's [jupyter notebooks](https://jupyter.org/), but unique in their own ways.
+They are based on the [node](https://nodejs.org/en) runtime.
+
+A srcbook is composed of **cells**. Currently, there are 4 types of cells:
+ 1. **Title cell**: this is "Getting started" above. There is one per srcbook.
+ 2. **package.json cell**: this is a special cell that manages dependencies for the srcbook.
+ 3. **markdown cell**: what you're reading is a markdown cell, it allows to express ideas more richly than with code comments, an idea called [literate programming](https://en.wikipedia.org/wiki/Literate_programming).
+ 4. **code cell**: think of these as JS or TS files, you can run them, or export things to be used in other cells.
+
+###### simple-code.js
+
+```javascript
+// This is a trivial code cell, you can run me by clicking 'Run' or using the shortcut `cmd` + `enter`.
+console.log("Hello, srcbook!")
+```
+
+## Dependencies
+
+You can add any external dependency from [npm](https://www.npmjs.com/). Let's look at an example below by importing the `random-words` library.
+
+You'll need to make sure you install dependencies, which you can do by running the package.json cell.
+
+###### generate-random-word.js
+
+```javascript
+import {generate} from 'random-words';
+
+console.log(generate())
+```
+
+## Importing other cells
+
+You can think of cells as files, more precisely, ecmascript 6 modules. Therefore you can export variables from one file and import them in another. See example below.
+
+###### star-wars.js
+
+```javascript
+export const func = (name) => `I am your father, ${name}`
+```
+
+###### logger.js
+
+```javascript
+import {func} from './star-wars.js';
+
+console.log(func("Luke"));
+```
+
+## Using secrets
+
+For security purposes, you should avoid pasting secrets directly into srcbooks. The mechanism you should leverage is [secrets](/secrets). These are stored securely and are accessed at runtime as environment variables.
+
+Secrets can then be imported in srcbooks using `process.env.SECRET_NAME`:
+```
+const API_KEY = process.env.SECRET_API_KEY;
+const token = auth(API_KEY);
+```
+
+## Exporting and sharing srcbooks
+
+Srcbooks are meant to be collaborative. They export to a friendly `.srcmd` format, which is valid markdown, and can be opened in any text editor.
+
+You can export srcbooks by clicking the `save` button in the top level menu on the left.
+
+
+You can also import `.srcmd` files directly in this application if you want to run, modify, or re-export them.


### PR DESCRIPTION
Published 0.0.25 so committing the code in a separate commit here.

We'll have to have a checklist for vendorizing + publishing. It's a bit heavy currently.

You can run this right now (it's deployed):
```
npm install scratch-srcbook@0.0.25
```