### PR TITLE
Tweak menu styles and behavior

### DIFF
--- a/packages/web/src/components/session-menu.tsx
+++ b/packages/web/src/components/session-menu.tsx
@@ -4,10 +4,11 @@ import type { Tokens } from 'marked';
 import { useState } from 'react';
 import { Upload, Trash2, MessageCircleQuestion } from 'lucide-react';
 import type { SessionType } from '../types';
-import type { CellType } from '@srcbook/shared';
+import type { CodeCellType, MarkdownCellType, TitleCellType } from '@srcbook/shared';
 import KeyboardShortcutsDialog from '@/components/keyboard-shortcuts-dialog';
 import DeleteSrcbookModal from '@/components/delete-srcbook-dialog';
 import { ExportSrcbookModal } from '@/components/import-export-srcbook-modal';
+import { useCells } from './use-cell';
 
 type Props = {
   session: SessionType;
@@ -15,29 +16,24 @@ type Props = {
 
 marked.use({ gfm: true });
 
-const tocFromCell = (cell: CellType) => {
-  switch (cell.type) {
-    case 'code':
-      return cell.filename;
-    case 'markdown':
-      const tokens = marked.lexer(cell.text);
-      const heading = tokens.find((token) => token.type === 'heading') as
-        | Tokens.Heading
-        | undefined;
-      if (heading) {
-        return heading.text;
-      }
-      const paragraph = tokens.find((token) => token.type === 'paragraph') as
-        | Tokens.Paragraph
-        | undefined;
-      if (paragraph) {
-        return paragraph.text.slice(0, 15);
-      }
-      return 'Markdown cell';
-    case 'title':
-      return cell.text.slice(0, 15);
-    default:
-      return '';
+const tocFromCell = (cell: TitleCellType | CodeCellType | MarkdownCellType) => {
+  if (cell.type === 'title') {
+    return cell.text;
+  } else if (cell.type === 'code') {
+    return cell.filename;
+  } else if (cell.type === 'markdown') {
+    const tokens = marked.lexer(cell.text);
+    const heading = tokens.find((token) => token.type === 'heading') as Tokens.Heading | undefined;
+    if (heading) {
+      return heading.text;
+    }
+    const paragraph = tokens.find((token) => token.type === 'paragraph') as
+      | Tokens.Paragraph
+      | undefined;
+    if (paragraph) {
+      return paragraph.text;
+    }
+    return 'Markdown cell';
   }
 };
 
@@ -46,23 +42,29 @@ export default function SessionMenu({ session }: Props) {
   const [showDelete, setShowDelete] = useState(false);
   const [showSave, setShowSave] = useState(false);
 
+  const { cells: allCells } = useCells();
+
+  const cells = allCells.filter((cell) => {
+    return cell.type === 'title' || cell.type === 'markdown' || cell.type === 'code';
+  }) as Array<TitleCellType | CodeCellType | MarkdownCellType>;
+
   // The key '?' is buggy, so we use 'Slash' with 'shift' modifier.
   // This assumes qwerty layout.
   useHotkeys('shift+Slash', () => setShowShortcuts(!showShortcuts));
 
   return (
-    <div className="fixed top-20 left-0 bg-background p-6 rounded space-y-8 text-sm">
+    <div className="hidden xl:block fixed top-24 left-0 bg-background p-6 space-y-8 text-sm">
       <KeyboardShortcutsDialog open={showShortcuts} onOpenChange={setShowShortcuts} />
       <DeleteSrcbookModal open={showDelete} onOpenChange={setShowDelete} session={session} />
       <ExportSrcbookModal open={showSave} onOpenChange={setShowSave} session={session} />
 
       {/** table of contents */}
-      <div className="border-l text-tertiary-foreground py-0 space-y-2">
-        {session.cells.map((cell, index) => {
+      <div className="max-w-48 text-tertiary-foreground">
+        {cells.map((cell) => {
           return (
             <p
-              key={`toc-${index}`}
-              className="pl-3 hover:text-primary-hover hover:cursor-pointer border-l hover:border-l-foreground -ml-[1px]"
+              key={cell.id}
+              className="py-1 pl-3 hover:text-primary-hover border-l hover:border-l-foreground cursor-pointer truncate"
               onClick={() => document.getElementById(`cell-${cell.id}`)?.scrollIntoView()}
             >
               {tocFromCell(cell)}
@@ -71,17 +73,17 @@ export default function SessionMenu({ session }: Props) {
         })}
       </div>
       {/** actions menus */}
-      <div className="space-y-1.5">
+      <div className="space-y-1.5 text-tertiary-foreground">
         <div
           onClick={() => setShowSave(true)}
-          className="flex items-center gap-2 hover:cursor-pointer text-tertiary-foreground hover:text-primary-hover"
+          className="flex items-center gap-2 hover:text-primary-hover cursor-pointer"
         >
           <Upload size={16} />
           <p>Export</p>
         </div>
         <div
           onClick={() => setShowDelete(true)}
-          className="flex items-center gap-2 hover:cursor-pointer text-tertiary-foreground hover:text-primary-hover"
+          className="flex items-center gap-2 hover:text-primary-hover cursor-pointer"
         >
           <Trash2 size={16} />
           <p>Delete</p>
@@ -89,7 +91,7 @@ export default function SessionMenu({ session }: Props) {
 
         <div
           onClick={() => setShowShortcuts(true)}
-          className="flex items-center gap-2 hover:cursor-pointer text-tertiary-foreground hover:text-primary-hover"
+          className="flex items-center gap-2 hover:text-primary-hover cursor-pointer"
         >
           <MessageCircleQuestion size={16} />
           <p>Shortcuts</p>

--- a/packages/web/src/routes/session.tsx
+++ b/packages/web/src/routes/session.tsx
@@ -143,6 +143,7 @@ function Session(props: { session: SessionType; channel: SessionChannel }) {
       >
         toggle theme
       </p>
+
       <SessionMenu session={session} />
 
       <div>
@@ -440,11 +441,11 @@ function PackageJsonCell(props: {
           className={
             open
               ? cn(
-                'border rounded-md group',
-                cell.status === 'running'
-                  ? 'ring ring-2 ring-run-ring border-run-ring'
-                  : 'focus-within:ring focus-within:ring-2 focus-within:ring-ring focus-within:border-ring',
-              )
+                  'border rounded-md group',
+                  cell.status === 'running'
+                    ? 'ring ring-2 ring-run-ring border-run-ring'
+                    : 'focus-within:ring focus-within:ring-2 focus-within:ring-ring focus-within:border-ring',
+                )
               : ''
           }
         >


### PR DESCRIPTION
* Fix bug where cells being added, removed, or updated did not get reflected in the menu
* (For now) hide menu when window is too short which caused it to overflow on top of the rest of the content
* Fix annoying lint warnings (see screenshot)
* Use css (truncate) to clip text, not substrings
* Set appropriate max-width for ^
* Update a few style implementations

<img width="736" alt="Screenshot 2024-06-20 at 12 46 06 PM" src="https://github.com/axflow/srcbook/assets/606233/c15a53aa-2e58-4160-8a21-a05cf42ec43b">
