### PR TITLE
Use directory ID as sessionId

### DIFF
--- a/packages/api/session.mts
+++ b/packages/api/session.mts
@@ -10,7 +10,6 @@ import type {
   CellErrorType,
 } from '@srcbook/shared';
 import {
-  randomid,
   TitleCellUpdateAttrsSchema,
   MarkdownCellUpdateAttrsSchema,
   CodeCellUpdateAttrsSchema,
@@ -45,7 +44,7 @@ export async function createSession(srcbookDir: string) {
   }
 
   const session: SessionType = {
-    id: randomid(),
+    id: Path.basename(srcbookDir),
     dir: srcbookDir,
     cells: result.cells,
     metadata: result.metadata,

--- a/packages/web/src/components/import-export-srcbook-modal.tsx
+++ b/packages/web/src/components/import-export-srcbook-modal.tsx
@@ -45,7 +45,7 @@ export function ImportSrcbookModal({
       return;
     }
 
-    return navigate(`/sessions/${result.id}`);
+    return navigate(`/srcbooks/${result.id}`);
   }
 
   return (

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -22,7 +22,7 @@ const router = createBrowserRouter([
         errorElement: <ErrorPage />,
       },
       {
-        path: '/sessions/:id',
+        path: '/srcbooks/:id',
         loader: Session.loader,
         element: <Session />,
         errorElement: <ErrorPage />,

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData, useNavigate } from 'react-router-dom';
+import { useNavigate, useLoaderData, useNavigate, redirect } from 'react-router-dom';
 import { CodeLanguageType, TitleCellType } from '@srcbook/shared';
 import { getConfig, createSession, loadSessions, createSrcbook, importSrcbook } from '@/lib/server';
 import type { SessionType } from '@/types';
@@ -61,13 +61,14 @@ export default function Home() {
   async function onCreateSrcbook(title: string, language: CodeLanguageType) {
     const { result } = await createSrcbook({ path: baseDir, name: title, language: language });
     const { result: sessionResult } = await createSession({ path: result.path });
-    return navigate(`/sessions/${sessionResult.id}`);
+    return navigate(`/srcbooks/${sessionResult.id}`);
   }
 
   async function openTutorial(tutorial: string) {
     const { result } = await importSrcbook({ path: `tutorials/${tutorial}.srcmd` });
     const { result: newSession } = await createSession({ path: result.dir });
-    return navigate(`/sessions/${newSession.id}`);
+
+    return navigate(`/srcbooks/${newSession.id}`);
   }
 
   return (
@@ -109,7 +110,7 @@ export default function Home() {
                 running={session.cells.some((c) => c.type === 'code' && c.status === 'running')}
                 language={session.metadata.language}
                 cellCount={session.cells.length}
-                onClick={() => navigate(`/sessions/${session.id}`)}
+                onClick={() => navigate(`/srcbooks/${session.id}`)}
                 onDelete={() => onDeleteSession(session)}
               />
             ))}


### PR DESCRIPTION
I tested this, and it indeed works and we can recover a session between server restarts.

Note that I made a really minimal set of changes. We might want to rename some thinks to srcbook, but this still makes sense to me, we just changed the identifier. We do have a redundancy on the client between sessionId and dirId, but I like keeping it because over time we could create a unique sessionId, should it make sense, and then we could add a mapping in the sqlite DB.

fixes AXF-178