### PR TITLE
Add theme toggle to header in DEV

### DIFF
--- a/packages/web/src/Layout.tsx
+++ b/packages/web/src/Layout.tsx
@@ -1,13 +1,16 @@
 import { Outlet, NavLink } from 'react-router-dom';
 import { Toaster } from '@/components/ui/sonner';
 import { SrcbookLogo } from './components/logos';
+import useTheme from './components/use-theme';
 
 export default function Layout() {
+  const { theme, toggleTheme } = useTheme();
+
   return (
     <>
       <div className="flex flex-col">
-        <header className="h-8 min-h-8 max-h-8 w-full flex items-center fixed bg-background z-10 border-b border-border text-sm">
-          <nav className="px-6 w-full">
+        <header className="h-8 min-h-8 max-h-8 w-full flex items-center justify-between fixed bg-background z-10 border-b border-border text-sm">
+          <nav className="px-6 flex-1">
             <ul className="flex items-center space-x-6">
               <li>
                 <NavLink to="/">
@@ -43,6 +46,16 @@ export default function Layout() {
               </li>
             </ul>
           </nav>
+          {process.env.NODE_ENV !== 'production' && (
+            <div className="pr-3">
+              <button
+                onClick={toggleTheme}
+                className="border-none outline-none text-muted-foreground hover:text-foreground font-semibold transition-colors"
+              >
+                {theme === 'light' ? '(DEV) Dark mode' : '(DEV) Light mode'}
+              </button>
+            </div>
+          )}
         </header>
         <div className="w-full max-w-[936px] mx-auto px-4 lg:px-0 py-12 mt-8">
           <Outlet />

--- a/packages/web/src/routes/session.tsx
+++ b/packages/web/src/routes/session.tsx
@@ -72,7 +72,6 @@ function SessionPage() {
 
 function Session(props: { session: SessionType; channel: SessionChannel }) {
   const { session, channel } = props;
-  const { toggleTheme } = useTheme();
 
   const { cells, setCells, updateCell, removeCell, createCodeCell, createMarkdownCell, setOutput } =
     useCells();
@@ -151,14 +150,7 @@ function Session(props: { session: SessionType; channel: SessionChannel }) {
   }
 
   return (
-    <div>
-      <p
-        className="fixed right-3 top-12 text-muted-foreground text-sm hover:cursor-pointer"
-        onClick={toggleTheme}
-      >
-        toggle theme
-      </p>
-
+    <>
       <SessionMenu session={session} />
 
       <div>
@@ -201,7 +193,7 @@ function Session(props: { session: SessionType; channel: SessionChannel }) {
           <div className="flex-grow border-t border-foreground"></div>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
This way it's available in all pages and we don't need to worry about it being there when we ship a version of the app.

<img width="1528" alt="Screenshot 2024-06-21 at 7 10 43 PM" src="https://github.com/axflow/srcbook/assets/606233/d8376a81-322b-4e31-8d82-f5f99052abd3">
