### PR TITLE
Create utility class for inline code

### DIFF
--- a/packages/web/src/components/srcbook-cards.tsx
+++ b/packages/web/src/components/srcbook-cards.tsx
@@ -225,7 +225,7 @@ export function ImportSrcbookCTA(props: { onClick: () => void }) {
       <div>
         <h5 className="font-semibold leading-[18px]">Open Srcbook</h5>
         <p className="mt-2 leading-none text-[13px] text-tertiary-foreground">
-          import from .srcmd file
+          import from <code className="code text-[12px]">.srcmd</code> file
         </p>
       </div>
       <Upload size={20} />

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -60,6 +60,8 @@
     --run: var(--sb-yellow-50);
     --run-foreground: var(--sb-core-100);
     --run-ring: var(--sb-yellow-50);
+    --inline-code: var(--sb-core-20);
+    --inline-code-foreground: var(--foreground);
   }
 
   .dark {
@@ -70,6 +72,8 @@
     --run: var(--sb-yellow-50);
     --run-foreground: var(--sb-core-100);
     --run-ring: var(--sb-yellow-50);
+    --inline-code: var(--sb-core-110);
+    --inline-code-foreground: var(--foreground);
   }
 
   /* shadcn variables light */
@@ -155,6 +159,16 @@
     line-height: 1.75rem;
     font-weight: 700;
   }
+
+  .code {
+    @apply text-sm;
+    @apply rounded-sm;
+    @apply px-1;
+    @apply py-0.5;
+    @apply mx-0.5;
+    @apply bg-inline-code;
+    @apply text-inline-code-foreground;
+  }
 }
 
 @layer base {
@@ -225,22 +239,7 @@
 }
 
 .sb-prose code:not(pre code) {
-  @apply text-sm;
-  @apply rounded-sm;
-  @apply bg-sb-core-20;
-  @apply px-1;
-  @apply py-0.5;
-  @apply mx-0.5;
-}
-
-/* LIGHT */
-.sb-prose code:not(pre code) {
-  @apply bg-sb-core-20;
-}
-
-/* DARK */
-.dark .sb-prose code:not(pre code) {
-  @apply bg-sb-core-110;
+  @apply code;
 }
 
 .sb-prose h1 > code,

--- a/packages/web/src/routes/secrets.tsx
+++ b/packages/web/src/routes/secrets.tsx
@@ -42,9 +42,7 @@ function Secrets() {
       <p>
         Secrets are a safe way to share credentials and tokens with notebooks. You can think of
         these as environment variables, and access them with{' '}
-        <code className="px-1 py-0.5 border border-gray-200 rounded-sm">
-          process.env.SECRET_NAME
-        </code>{' '}
+        <code className="code">process.env.SECRET_NAME</code>
       </p>
       {secrets && (
         <div>

--- a/packages/web/tailwind.config.js
+++ b/packages/web/tailwind.config.js
@@ -82,6 +82,10 @@ module.exports = {
           foreground: 'hsl(var(--run-foreground))',
           ring: 'hsl(var(--run-ring))',
         },
+        'inline-code': {
+          DEFAULT: 'hsl(var(--inline-code))',
+          foreground: 'hsl(var(--inline-code-foreground))',
+        },
         sb: {
           'core-0': 'hsl(var(--sb-core-0))',
           'core-10': 'hsl(var(--sb-core-10))',


### PR DESCRIPTION
There's a few places where we have used or where I have wanted to use an inline code style (beyond markdown/prose). This creates a `code` tailwind class that applies the same styles as the markdown prose styles and can be used anywhere, like:

<img width="1188" alt="Screenshot 2024-06-21 at 8 02 49 PM" src="https://github.com/axflow/srcbook/assets/606233/208a5bb9-75b2-4105-a16a-772fd9e69194">

<img width="1188" alt="Screenshot 2024-06-21 at 8 02 44 PM" src="https://github.com/axflow/srcbook/assets/606233/bd616c85-4436-40a0-a4d6-69c2802962e3">
