### PR TITLE
Support typescript syntax highlighting

### DIFF
--- a/packages/web/src/routes/session.tsx
+++ b/packages/web/src/routes/session.tsx
@@ -700,7 +700,7 @@ function CodeCell(props: {
           value={cell.source}
           theme={codeTheme}
           extensions={[
-            javascript(),
+            javascript({ typescript: true }),
             Prec.highest(keymap.of([{ key: 'Mod-Enter', run: evaluateModEnter }])),
           ]}
           onChange={onChangeSource}


### PR DESCRIPTION
Realized while making a srcbook that TS highlighting was not working, it's because it wasn't enabled.