### PR TITLE
Drag and drop srcmd files

### DIFF
--- a/packages/api/server/http.mts
+++ b/packages/api/server/http.mts
@@ -20,9 +20,10 @@ import { disk } from '../utils.mjs';
 import { getConfig, updateConfig, getSecrets, addSecret, removeSecret } from '../config.mjs';
 import {
   createSrcbook,
-  importSrcbookFromSrcmdFile,
   removeSrcbook,
   fullSrcbookDir,
+  importSrcbookFromSrcmdFile,
+  importSrcbookFromSrcmdText,
 } from '../srcbook.mjs';
 import { readdir } from '../fs-utils.mjs';
 
@@ -81,18 +82,23 @@ router.delete('/srcbooks/:dir', cors(), async (req, res) => {
   return res.json({ error: false, deleted: true });
 });
 
-// Import a srcbook from a .srcmd file.
+// Import a srcbook from a .srcmd file or srcmd text.
 router.options('/import', cors());
 router.post('/import', cors(), async (req, res) => {
-  const { path } = req.body;
+  const { path, text } = req.body;
 
-  if (Path.extname(path) !== '.srcmd') {
+  if (path && Path.extname(path) !== '.srcmd') {
     return res.json({ error: true, result: 'Importing only works with .srcmd files' });
   }
 
   try {
-    const srcbookDir = await importSrcbookFromSrcmdFile(path);
-    return res.json({ error: false, result: { dir: srcbookDir } });
+    if (typeof path === 'string') {
+      const srcbookDir = await importSrcbookFromSrcmdFile(path);
+      return res.json({ error: false, result: { dir: srcbookDir } });
+    } else {
+      const srcbookDir = await importSrcbookFromSrcmdText(text);
+      return res.json({ error: false, result: { dir: srcbookDir } });
+    }
   } catch (e) {
     const error = e as unknown as Error;
     console.error(error);

--- a/packages/api/srcbook.mts
+++ b/packages/api/srcbook.mts
@@ -75,14 +75,22 @@ export async function importSrcbookFromSrcmdFile(srcmdPath: string) {
   // When we import tutorials, we don't have absolute paths but rather want to
   // import them from the vendored srcbook application.
   const finalPath = srcmdPath.startsWith('tutorials') ? Path.join(DIST_DIR, srcmdPath) : srcmdPath;
-  const [srcmd, dirname] = await Promise.all([fs.readFile(finalPath, 'utf8'), newSrcbookDir()]);
+  const srcmd = await fs.readFile(finalPath, 'utf8');
+  return importSrcbookFromSrcmdText(srcmd);
+}
 
-  const result = decode(srcmd);
+/**
+ * Creates a srcbook directory from a srcmd text.
+ */
+export async function importSrcbookFromSrcmdText(text: string) {
+  const result = decode(text);
 
   if (result.error) {
     console.error(result.error);
-    throw new Error(`Cannot decode invalid srcmd in ${srcmdPath}`);
+    throw new Error(`Cannot decode invalid srcmd`);
   }
+
+  const dirname = await newSrcbookDir();
 
   await writeToDisk(dirname, result.metadata, result.cells);
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -38,6 +38,7 @@
     "match-sorter": "^6.3.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-dropzone": "^14.2.3",
     "react-hotkeys-hook": "^4.5.0",
     "react-router-dom": "^6.23.0",
     "sonner": "^1.4.41",

--- a/packages/web/src/Layout.tsx
+++ b/packages/web/src/Layout.tsx
@@ -1,9 +1,9 @@
-import { Outlet, NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import { Toaster } from '@/components/ui/sonner';
 import { SrcbookLogo } from './components/logos';
 import useTheme from './components/use-theme';
 
-export default function Layout() {
+export default function Layout(props: { children: React.ReactNode }) {
   const { theme, toggleTheme } = useTheme();
 
   return (
@@ -57,9 +57,7 @@ export default function Layout() {
             </div>
           )}
         </header>
-        <div className="w-full max-w-[936px] mx-auto px-4 lg:px-0 py-12 mt-8">
-          <Outlet />
-        </div>
+        <div className="w-full max-w-[936px] mx-auto px-4 lg:px-0 py-12 mt-8">{props.children}</div>
       </div>
       <Toaster position="top-right" />
     </>

--- a/packages/web/src/components/drag-and-drop-srcmd-modal.tsx
+++ b/packages/web/src/components/drag-and-drop-srcmd-modal.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { useDropzone } from 'react-dropzone';
+import { useNavigate } from 'react-router-dom';
+import { Upload } from 'lucide-react';
+import { CardContainer } from './srcbook-cards';
+import { createSession, importSrcbook } from '@/lib/server';
+
+function Modal(props: { open: boolean }) {
+  if (!props.open) {
+    return null;
+  }
+
+  const state = props.open ? 'open' : 'closed';
+
+  return (
+    <>
+      <div
+        aria-hidden="true"
+        data-state={state}
+        className="fixed inset-0 z-50 bg-sb-core-130/90 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+      ></div>
+      <CardContainer
+        role="dialog"
+        data-state={state}
+        className="focus-within:outline-none fixed w-full max-w-sm h-48 p-6 left-[50%] top-[50%] z-50 grid gap-4 bg-background border rounded-md shadow-xl translate-x-[-50%] translate-y-[-50%] duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]"
+      >
+        <div className="flex flex-col h-full gap-3">
+          <div className="flex-1 flex items-center justify-center">
+            <div className="w-14 h-14 flex items-center justify-center bg-primary text-primary-foreground rounded-full">
+              <Upload size={18} />
+            </div>
+          </div>
+          <div className="flex-1 flex flex-col items-center justify-center gap-2">
+            <strong className="text-lg font-semibold leading-tight">Open Srcbook</strong>
+            <p className="text-tertiary-foreground">
+              Drop <code className="code">.srcmd</code> file to open
+            </p>
+          </div>
+        </div>
+      </CardContainer>
+    </>
+  );
+}
+
+export function DragAndDropSrcmdModal(props: { children: React.ReactNode }) {
+  const [showDndModal, setShowDndModal] = useState(false);
+
+  const navigate = useNavigate();
+
+  async function onDrop(files: File[]) {
+    // TODO: Error handling
+    if (files.length !== 1) {
+      return;
+    }
+
+    const file = files[0];
+
+    // TODO: Error handling
+    if (!file.name.endsWith('.srcmd')) {
+      return;
+    }
+
+    const text = await file.text();
+
+    // TODO: Error handling
+    const { result } = await importSrcbook({ text });
+    const { result: session } = await createSession({ path: result.dir });
+
+    setShowDndModal(false);
+
+    return navigate(`/srcbooks/${session.id}`);
+  }
+
+  const { getRootProps } = useDropzone({
+    onDrop,
+    noClick: true,
+    multiple: false,
+    maxFiles: 1,
+    onDragEnter: () => setShowDndModal(true),
+    onDragLeave: () => setShowDndModal(false),
+  });
+
+  return (
+    <div {...getRootProps()}>
+      {props.children}
+      <Modal open={showDndModal} />
+    </div>
+  );
+}

--- a/packages/web/src/components/srcbook-cards.tsx
+++ b/packages/web/src/components/srcbook-cards.tsx
@@ -1,6 +1,6 @@
+import { Circle, PlusIcon, Trash2, Upload } from 'lucide-react';
 import { CodeLanguageType } from '@srcbook/shared';
 import { SrcbookLogo } from './logos';
-import { Circle, PlusIcon, Trash2, Upload } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useRef, useState } from 'react';
 import { Button } from './ui/button';
@@ -56,24 +56,28 @@ export function MainCTACard(props: { title: string; description: string; onClick
   );
 }
 
-function CardContainer(props: {
-  onClick: () => void;
-  className?: string;
-  children: React.ReactNode;
+export function CardContainer({
+  className,
+  onClick,
+  children,
+  ...props
+}: React.ComponentPropsWithoutRef<'div'> & {
+  onClick?: () => void;
 }) {
   return (
     <div
-      onClick={props.onClick}
+      {...props}
+      onClick={onClick}
       className={cn(
-        'group border relative rounded-sm min-w-52 h-[108px] overflow-clip cursor-pointer transition-colors',
-        props.className,
+        'group border relative rounded-sm h-[108px] overflow-clip cursor-pointer transition-colors text-sm',
+        className,
       )}
     >
       <LongDashedHorizontalLine className="absolute top-[10px] text-border" />
       <LongDashedHorizontalLine className="absolute bottom-[10px] text-border" />
       <LongDashedVerticalLine className="absolute left-[10px] text-border" />
       <LongDashedVerticalLine className="absolute right-[10px] text-border" />
-      <div className="px-5 py-4 h-full flex flex-col justify-between text-sm">{props.children}</div>
+      <div className="px-5 py-4 h-full flex flex-col justify-between">{children}</div>
     </div>
   );
 }
@@ -243,7 +247,7 @@ export function ImportSrcbookCTA(props: { onClick: () => void }) {
       <div>
         <h5 className="font-semibold leading-[18px]">Open Srcbook</h5>
         <p className="mt-2 leading-none text-[13px] text-tertiary-foreground">
-          import from <code className="code text-[12px]">.srcmd</code> file
+          or drag 'n drop <code className="code text-[13px]">.srcmd</code> file
         </p>
       </div>
       <Upload size={20} />

--- a/packages/web/src/components/ui/dialog.tsx
+++ b/packages/web/src/components/ui/dialog.tsx
@@ -19,7 +19,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-sb-core-130/90 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}
@@ -29,23 +29,25 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { closeButtonDisabled?: boolean }
+>(({ className, closeButtonDisabled, children, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'focus-within:outline-none fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-sm',
+        'focus-within:outline-none fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-md',
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <Cross2Icon className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      {!closeButtonDisabled && (
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <Cross2Icon className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      )}
     </DialogPrimitive.Content>
   </DialogPortal>
 ));

--- a/packages/web/src/lib/server.ts
+++ b/packages/web/src/lib/server.ts
@@ -68,7 +68,8 @@ export async function deleteSrcbook(request: { dir: string }) {
 }
 
 interface ImportSrcbookRequestType {
-  path: string;
+  path?: string;
+  text?: string;
 }
 
 interface ImportSrcbookResponseType {

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,26 +1,37 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import Layout from './Layout';
+import { createBrowserRouter, RouterProvider, Outlet } from 'react-router-dom';
 import './index.css';
+import Layout from './Layout';
 import Home, { loader as homeLoader } from './routes/home';
 import Session from './routes/session';
 import Settings from './routes/settings';
 import Secrets from './routes/secrets';
 import ErrorPage from './error';
+import { DragAndDropSrcmdModal } from './components/drag-and-drop-srcmd-modal';
 
 const router = createBrowserRouter([
   {
     path: '/',
-    element: <Layout />,
+    element: (
+      <DragAndDropSrcmdModal>
+        <Layout>
+          <Home />
+        </Layout>
+      </DragAndDropSrcmdModal>
+    ),
+    errorElement: <ErrorPage />,
+    loader: homeLoader,
+  },
+  {
+    path: '/',
+    element: (
+      <Layout>
+        <Outlet />
+      </Layout>
+    ),
     errorElement: <ErrorPage />,
     children: [
-      {
-        path: '/',
-        element: <Home />,
-        loader: homeLoader,
-        errorElement: <ErrorPage />,
-      },
       {
         path: '/srcbooks/:id',
         loader: Session.loader,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      react-dropzone:
+        specifier: ^14.2.3
+        version: 14.2.3(react@18.3.1)
       react-hotkeys-hook:
         specifier: ^4.5.0
         version: 4.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1846,6 +1849,10 @@ packages:
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
+  attr-accept@2.2.2:
+    resolution: {integrity: sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==}
+    engines: {node: '>=4'}
+
   autoprefixer@10.4.19:
     resolution: {integrity: sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2407,6 +2414,10 @@ packages:
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
+
+  file-selector@0.6.0:
+    resolution: {integrity: sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==}
+    engines: {node: '>= 12'}
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -3060,6 +3071,9 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -3095,11 +3109,20 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-dropzone@14.2.3:
+    resolution: {integrity: sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==}
+    engines: {node: '>= 10.13'}
+    peerDependencies:
+      react: '>= 16.8 || 18.0.0'
+
   react-hotkeys-hook@4.5.0:
     resolution: {integrity: sha512-Samb85GSgAWFQNvVt3PS90LPPGSf9mkH/r4au81ZP1yOIFayLC3QAvqTgGtJ8YEDMXtPmaVBs6NgipHO6h4Mug==}
     peerDependencies:
       react: '>=16.8.1'
       react-dom: '>=16.8.1'
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -5108,6 +5131,8 @@ snapshots:
 
   assertion-error@1.1.0: {}
 
+  attr-accept@2.2.2: {}
+
   autoprefixer@10.4.19(postcss@8.4.38):
     dependencies:
       browserslist: 4.23.0
@@ -5737,6 +5762,10 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
+  file-selector@0.6.0:
+    dependencies:
+      tslib: 2.6.3
+
   file-uri-to-path@1.0.0: {}
 
   fill-range@7.1.1:
@@ -6325,6 +6354,12 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -6365,10 +6400,19 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-dropzone@14.2.3(react@18.3.1):
+    dependencies:
+      attr-accept: 2.2.2
+      file-selector: 0.6.0
+      prop-types: 15.8.1
+      react: 18.3.1
+
   react-hotkeys-hook@4.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  react-is@16.13.1: {}
 
   react-is@18.3.1: {}
 


### PR DESCRIPTION
* Add drag and drop functionality and styles
* Tweak dialog designs to match Justin's styles (diff bg overlay color and rounded-md radius)

### TODO

- [ ] Lots of error handling is needed
- [ ] (minor) We now have three places where we implement importSrcbook functionality on the client side (guides, file picker, and drag and drop). We can probably refactor the code a bit to remove some duplication

<img width="1437" alt="Screenshot 2024-06-23 at 4 31 45 PM" src="https://github.com/axflow/srcbook/assets/606233/894def84-0541-4d65-ad75-2d8eeb9c771b">

<img width="1437" alt="Screenshot 2024-06-23 at 4 31 59 PM" src="https://github.com/axflow/srcbook/assets/606233/4adc2b15-7809-475a-9691-e4b95486d1c7">
