### PR TITLE
Nest all srcbook code files under src directory

### DIFF
--- a/packages/api/exec.mts
+++ b/packages/api/exec.mts
@@ -55,9 +55,9 @@ export function spawnCall(options: SpawnCallRequestType) {
  * Example:
  *
  *     node({
- *       cwd: '/Users/ben/.srcbook/foo',
+ *       cwd: '/Users/ben/.srcbook/30v2av4eee17m59dg2c29758to',
  *       env: {FOO_ENV_VAR: 'foooooooo'},
- *       entry: 'foo.js',
+ *       entry: '/Users/ben/.srcbook/30v2av4eee17m59dg2c29758to/src/foo.js',
  *       stdout(data) {console.log(data.toString('utf8'))},
  *       stderr(data) {console.error(data.toString('utf8'))},
  *       onExit(code) {console.log(`Exit code: ${code}`)}
@@ -67,12 +67,10 @@ export function spawnCall(options: SpawnCallRequestType) {
 export function node(options: NodeRequestType) {
   const { cwd, env, entry, stdout, stderr, onExit } = options;
 
-  const filepath = Path.isAbsolute(entry) ? entry : Path.join(cwd, entry);
-
   return spawnCall({
     command: 'node',
     cwd,
-    args: [filepath],
+    args: [entry],
     stdout,
     stderr,
     onExit,
@@ -83,12 +81,10 @@ export function node(options: NodeRequestType) {
 export function tsc(options: NodeRequestType) {
   const { cwd, env, entry, stdout, stderr, onExit } = options;
 
-  const filepath = Path.isAbsolute(entry) ? entry : Path.join(cwd, entry);
-
   return spawnCall({
     command: Path.join(cwd, 'node_modules', '.bin', 'tsc'),
     cwd,
-    args: [filepath, ...tsConfigToArgs(DEFAULT_TSCONFIG)],
+    args: [entry, ...tsConfigToArgs(DEFAULT_TSCONFIG)],
     stdout,
     stderr,
     onExit,
@@ -102,9 +98,9 @@ export function tsc(options: NodeRequestType) {
  * Example:
  *
  *     tsx({
- *       cwd: '/Users/ben/.srcbook/foo',
+ *       cwd: '/Users/ben/.srcbook/30v2av4eee17m59dg2c29758to',
  *       env: {FOO_ENV_VAR: 'foooooooo'},
- *       entry: 'foo.ts',
+ *       entry: '/Users/ben/.srcbook/30v2av4eee17m59dg2c29758to/src/foo.ts',
  *       stdout(data) {console.log(data.toString('utf8'))},
  *       stderr(data) {console.error(data.toString('utf8'))},
  *       onExit(code) {console.log(`Exit code: ${code}`)}
@@ -114,15 +110,12 @@ export function tsc(options: NodeRequestType) {
 export function tsx(options: NodeRequestType) {
   const { cwd, env, entry, stdout, stderr, onExit } = options;
 
-  const filepath = Path.isAbsolute(entry) ? entry : Path.join(cwd, entry);
-
   // We are making an assumption about `tsx` being the tool of choice
   // for running TypeScript, as well as where it's located on the file system.
-
   return spawnCall({
     command: Path.join(cwd, 'node_modules', '.bin', 'tsx'),
     cwd,
-    args: ['--tsconfig', DEFAULT_TSCONFIG_PATH, filepath],
+    args: ['--tsconfig', DEFAULT_TSCONFIG_PATH, entry],
     stdout,
     stderr,
     onExit,

--- a/packages/api/server/http.mts
+++ b/packages/api/server/http.mts
@@ -21,12 +21,12 @@ import { getConfig, updateConfig, getSecrets, addSecret, removeSecret } from '..
 import {
   createSrcbook,
   removeSrcbook,
-  fullSrcbookDir,
   importSrcbookFromSrcmdFile,
   importSrcbookFromSrcmdText,
-} from '../srcbook.mjs';
+} from '../srcbook/index.mjs';
 import { readdir } from '../fs-utils.mjs';
 import { EXAMPLE_SRCBOOKS } from '../srcbook/examples.mjs';
+import { pathToSrcbook } from '../srcbook/path.mjs';
 
 const app: Application = express();
 
@@ -79,12 +79,12 @@ router.post('/srcbooks', cors(), async (req, res) => {
   }
 });
 
-router.options('/srcbooks/:dir', cors());
-router.delete('/srcbooks/:dir', cors(), async (req, res) => {
-  const { dir } = req.params;
-  const fullDir = fullSrcbookDir(dir);
-  await removeSrcbook(fullDir);
-  await deleteSessionByDirname(fullDir);
+router.options('/srcbooks/:id', cors());
+router.delete('/srcbooks/:id', cors(), async (req, res) => {
+  const { id } = req.params;
+  const srcbookDir = pathToSrcbook(id);
+  await removeSrcbook(srcbookDir);
+  await deleteSessionByDirname(srcbookDir);
   return res.json({ error: false, deleted: true });
 });
 

--- a/packages/api/server/ws.mts
+++ b/packages/api/server/ws.mts
@@ -33,6 +33,7 @@ import {
   DepsValidateResponsePayloadSchema,
 } from '@srcbook/shared';
 import WebSocketServer from './ws-client.mjs';
+import { pathToCodeFile } from '../srcbook/path.mjs';
 
 const wss = new WebSocketServer();
 
@@ -120,7 +121,7 @@ async function jsExec({ session, cell, secrets }: ExecRequestType) {
     node({
       cwd: session.dir,
       env: secrets,
-      entry: cell.filename,
+      entry: pathToCodeFile(session.dir, cell.filename),
       stdout(data) {
         wss.broadcast(`session:${session.id}`, 'cell:output', {
           cellId: cell.id,
@@ -154,7 +155,7 @@ async function tsxExec({ session, cell, secrets }: ExecRequestType) {
     tsx({
       cwd: session.dir,
       env: secrets,
-      entry: cell.filename,
+      entry: pathToCodeFile(session.dir, cell.filename),
       stdout(data) {
         wss.broadcast(`session:${session.id}`, 'cell:output', {
           cellId: cell.id,
@@ -191,7 +192,7 @@ async function tscExec({ session, cell, secrets }: ExecRequestType) {
   tsc({
     cwd: session.dir,
     env: secrets,
-    entry: cell.filename,
+    entry: pathToCodeFile(session.dir, cell.filename),
     stdout(data) {
       wss.broadcast(`session:${session.id}`, 'cell:output', {
         cellId: cell.id,

--- a/packages/api/session.mts
+++ b/packages/api/session.mts
@@ -20,7 +20,12 @@ import {
 import { encode, decodeDir } from './srcmd.mjs';
 import { SRCBOOKS_DIR } from './constants.mjs';
 import type { SessionType } from './types.mjs';
-import { writeToDisk, writeCellToDisk, writeReadmeToDisk, moveCodeCellOnDisk } from './srcbook.mjs';
+import {
+  writeToDisk,
+  writeCellToDisk,
+  writeReadmeToDisk,
+  moveCodeCellOnDisk,
+} from './srcbook/index.mjs';
 import { fileExists } from './fs-utils.mjs';
 import { validFilename } from '@srcbook/shared';
 

--- a/packages/api/srcbook/path.mts
+++ b/packages/api/srcbook/path.mts
@@ -1,0 +1,22 @@
+import Path from 'node:path';
+import { SRCBOOKS_DIR } from '../constants.mjs';
+
+export function pathToSrcbook(id: string) {
+  return Path.join(SRCBOOKS_DIR, id);
+}
+
+export function pathToReadme(baseDir: string) {
+  return Path.join(baseDir, 'README.md');
+}
+
+export function pathToPackageJson(baseDir: string) {
+  return Path.join(baseDir, 'package.json');
+}
+
+export function pathToTsconfigJson(baseDir: string) {
+  return Path.join(baseDir, 'tsconfig.json');
+}
+
+export function pathToCodeFile(baseDir: string, filename: string) {
+  return Path.join(baseDir, 'src', filename);
+}

--- a/packages/web/src/components/delete-srcbook-dialog.tsx
+++ b/packages/web/src/components/delete-srcbook-dialog.tsx
@@ -26,7 +26,7 @@ export default function DeleteSrcbookModal({
   if (!session) return;
 
   const onConfirmDelete = async () => {
-    deleteSrcbook({ dir: session.dir })
+    deleteSrcbook({ id: session.dir })
       .then(() => {
         onOpenChange(false);
         navigate('/', { replace: true });

--- a/packages/web/src/lib/server.ts
+++ b/packages/web/src/lib/server.ts
@@ -55,8 +55,8 @@ export async function createSrcbook(
   return response.json();
 }
 
-export async function deleteSrcbook(request: { dir: string }) {
-  const response = await fetch(API_BASE_URL + '/srcbooks/' + request.dir, {
+export async function deleteSrcbook(request: { id: string }) {
+  const response = await fetch(API_BASE_URL + '/srcbooks/' + request.id, {
     method: 'DELETE',
     headers: { 'content-type': 'application/json' },
   });


### PR DESCRIPTION
We're nesting code files under the `src` directory because:

1. It keeps the srcbook's directory a bit more organized
2. it helps separate user code from other files
3. Makes things like tsconfig `include`s easy

### Compatibility

**This does mean existing srcbook directories _will not work_, at least not in all cases.** We'll want to give folks a heads up here about this backwards-incompatible change (though we are in alpha for this reason). The solution is to export then re-import the srcbook, or just delete if no longer using.

**The .srcmd format we import from / export to _should still work_ because we do not put filepaths in those, only filenames.**

### Unrelated

While working on this PR, I noticed:

* Now that we always use the same id for session / srcbook directory, we should see if we can kill the `dir` field we pass to the client which should always be the same as the `id` and is more confusing than using `id` (especially because on the backend, the `dir` field is the absolute path, not the basename).