### PR TITLE
Generate tsconfig files for each typescript srcbook

### DIFF
--- a/packages/api/constants.mts
+++ b/packages/api/constants.mts
@@ -11,14 +11,4 @@ const _dirname = path.dirname(_filename);
 export const HOME_DIR = os.homedir();
 export const SRCBOOK_DIR = path.join(HOME_DIR, '.srcbook');
 export const SRCBOOKS_DIR = path.join(SRCBOOK_DIR, 'srcbooks');
-export const DEFAULT_TSCONFIG_PATH = path.join(SRCBOOK_DIR, 'tsconfig.json');
 export const DIST_DIR = _dirname;
-
-export const DEFAULT_TSCONFIG = {
-  module: 'nodenext',
-  moduleResolution: 'nodenext',
-  target: 'es2022',
-  resolveJsonModule: true,
-  noEmit: true,
-  allowImportingTsExtensions: true,
-};

--- a/packages/api/exec.mts
+++ b/packages/api/exec.mts
@@ -1,7 +1,5 @@
 import Path from 'node:path';
 import { spawn } from 'node:child_process';
-import { DEFAULT_TSCONFIG_PATH, DEFAULT_TSCONFIG } from './constants.mjs';
-import { tsConfigToArgs } from './utils.mjs';
 
 export type BaseExecRequestType = {
   cwd: string;
@@ -84,7 +82,18 @@ export function tsc(options: NodeRequestType) {
   return spawnCall({
     command: Path.join(cwd, 'node_modules', '.bin', 'tsc'),
     cwd,
-    args: [entry, ...tsConfigToArgs(DEFAULT_TSCONFIG)],
+    args: [
+      entry,
+      '--noEmit',
+      '--target',
+      'es2022',
+      '--module',
+      'nodenext',
+      '--moduleResolution',
+      'nodenext',
+      '--resolveJsonModule',
+      '--allowImportingTsExtensions',
+    ],
     stdout,
     stderr,
     onExit,
@@ -115,7 +124,7 @@ export function tsx(options: NodeRequestType) {
   return spawnCall({
     command: Path.join(cwd, 'node_modules', '.bin', 'tsx'),
     cwd,
-    args: ['--tsconfig', DEFAULT_TSCONFIG_PATH, entry],
+    args: [entry],
     stdout,
     stderr,
     onExit,

--- a/packages/api/initialization.mts
+++ b/packages/api/initialization.mts
@@ -5,8 +5,7 @@
  */
 
 import fs from 'node:fs';
-import Path from 'node:path';
-import { DEFAULT_TSCONFIG, DEFAULT_TSCONFIG_PATH, SRCBOOKS_DIR } from './constants.mjs';
+import { SRCBOOKS_DIR } from './constants.mjs';
 
 // This single mkdir is creating:
 //
@@ -17,9 +16,3 @@ import { DEFAULT_TSCONFIG, DEFAULT_TSCONFIG_PATH, SRCBOOKS_DIR } from './constan
 // behavior and make sure both get created during initialization
 // or the app will not work properly.
 fs.mkdirSync(SRCBOOKS_DIR, { recursive: true });
-
-fs.writeFileSync(
-  Path.join(DEFAULT_TSCONFIG_PATH),
-  JSON.stringify(DEFAULT_TSCONFIG, null, 2),
-  'utf8',
-);

--- a/packages/api/utils.mts
+++ b/packages/api/utils.mts
@@ -67,23 +67,3 @@ function isRootPath(path: string) {
 export function toFormattedJSON(o: any) {
   return JSON.stringify(o, null, 2);
 }
-
-/**
- * Given a configuration object like
- *  const defaultTsConfig = {
- *    target: 'es2022',
- *    resolveJsonModule: true,
- *    noEmit: true,
- *   };
- *
- * Return an array of CLI args:
- *   ['--target', 'es2022', '--resolveJsonModule', '--noEmit']
- */
-export function tsConfigToArgs(config: Record<string, any>): string[] {
-  return Object.entries(config).flatMap(([key, value]) => {
-    if (typeof value === 'boolean') {
-      return value ? [`--${key}`] : [];
-    }
-    return [`--${key}`, String(value)];
-  });
-}


### PR DESCRIPTION
This will allow each project to have its own tsconfig and eventually allow customization of these values. It is a prerequisite for [tsserver](https://github.com/srcbookdev/srcbook/pull/119).

This is also a backwards incompatible change. We'll group this with the other backwards incompat change in https://github.com/srcbookdev/srcbook/pull/121