### PR TITLE
Add PostHog analytics

### DIFF
--- a/PRIVACY-POLICY.md
+++ b/PRIVACY-POLICY.md
@@ -1,0 +1,40 @@
+# Privacy Policy
+
+## Introduction
+
+Srcbook is committed to protecting your privacy. This policy explains what data we collect, how we collect it, how we use it, and how you can opt-out.
+
+## Data We Collect
+
+We collect behavioral data to understand usage patterns and improve our application. This data includes:
+
+- Usage metrics (e.g., feature interactions, usage frequency)
+- Performance metrics (e.g., load times, error rates)
+
+## What We Do Not Collect
+
+We do not collect any personal information or personally identifiable information (PII).
+
+## How We Use the Data
+
+The data collected is used to:
+
+- Improve the functionality and performance of Srcbook
+- Identify and address issues
+- Understand user preferences and usage patterns
+
+## Opt-Out Option
+
+We respect your privacy and provide an option to opt-out of data collection. You can disable data collection at any time by going to the settings within the Srcbook application and toggling the data collection option off.
+
+## Data Storage and Security
+
+All collected data is stored securely and is only accessible by the development team.
+
+## Changes to This Policy
+
+We may update this policy from time to time. Any changes will be reflected in this document.
+
+## Contact Us
+
+If you have any questions about this policy, please contact us at feedback@srcbook.com.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pnpm dlx srcbook
 
 ## Analytics and tracking
 
-In order to improve Srcbook, we collect some behavior analytics. We don't collect anything personal or identifiable, our goals are simply to improve the application (the code is open-source so you don't have to trust us, you can verify!)
+In order to improve Srcbook, we collect some behavioral analytics. We don't collect anything personal or identifiable, our goals are simply to improve the application. The code is open source so you don't have to trust us, you can verify! You can find more information in our [privacy policy](./PRIVACY-POLICY.md).
 
 If you want to disable tracking, you can do so in the settings page of the application.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ npx srcbook
 pnpm dlx srcbook
 ```
 
+## Analytics and tracking
+
+In order to improve Srcbook, we collect some behavior analytics. We don't collect anything personal or identifiable, our goals are simply to improve the application (the code is open-source so you don't have to trust us, you can verify!)
+
+If you want to disable tracking, you can do so in the settings page of the application.
+
 ## Development
 
 For development instructions, see [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/packages/api/config.mts
+++ b/packages/api/config.mts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import { randomid } from '@srcbook/shared';
 import { configs, type Config, secrets, type Secret } from './db/schema.mjs';
 import { db } from './db/index.mjs';
 import { HOME_DIR } from './constants.mjs';
@@ -7,7 +8,11 @@ async function init() {
   const existingConfig = await db.select().from(configs).limit(1);
 
   if (existingConfig.length === 0) {
-    const defaultConfig = { baseDir: HOME_DIR, defaultLanguage: 'typescript' };
+    const defaultConfig = {
+      baseDir: HOME_DIR,
+      defaultLanguage: 'typescript',
+      distinctId: randomid(),
+    };
     console.log();
     console.log('Initializing application with the following configuration:\n');
     console.log(JSON.stringify(defaultConfig, null, 2));

--- a/packages/api/config.mts
+++ b/packages/api/config.mts
@@ -11,7 +11,7 @@ async function init() {
     const defaultConfig = {
       baseDir: HOME_DIR,
       defaultLanguage: 'typescript',
-      distinctId: randomid(),
+      installId: randomid(),
     };
     console.log();
     console.log('Initializing application with the following configuration:\n');

--- a/packages/api/constants.mts
+++ b/packages/api/constants.mts
@@ -13,3 +13,4 @@ export const SRCBOOK_DIR = path.join(HOME_DIR, '.srcbook');
 export const SRCBOOKS_DIR = path.join(SRCBOOK_DIR, 'srcbooks');
 export const DIST_DIR = _dirname;
 export const PROMPTS_DIR = path.join(DIST_DIR, 'prompts');
+export const IS_PRODUCTION = process.env.NODE_ENV === 'production';

--- a/packages/api/db/schema.mts
+++ b/packages/api/db/schema.mts
@@ -1,4 +1,5 @@
 import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+import { randomid } from '@srcbook/shared';
 
 export const configs = sqliteTable('config', {
   // Directory where .srcmd files will be stored and searched by default.
@@ -8,6 +9,8 @@ export const configs = sqliteTable('config', {
   // Default on for behavioral analytics.
   // Allows us to improve Srcbook, we don't collect any PII.
   enabledAnalytics: integer('enabled_analytics', { mode: 'boolean' }).notNull().default(true),
+  // Stable ID for posthog
+  distinctId: text('distinct_id').notNull().default(randomid()),
 });
 
 export type Config = typeof configs.$inferSelect;

--- a/packages/api/db/schema.mts
+++ b/packages/api/db/schema.mts
@@ -1,10 +1,13 @@
 import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
 
 export const configs = sqliteTable('config', {
-  // Directory where .srcmd files will be stored and searched by default
+  // Directory where .srcmd files will be stored and searched by default.
   baseDir: text('base_dir').notNull(),
   defaultLanguage: text('default_language').notNull().default('typescript'),
   openaiKey: text('openai_api_key'),
+  // Default on for behavioral analytics.
+  // Allows us to improve Srcbook, we don't collect any PII.
+  enabledAnalytics: integer('enabled_analytics', { mode: 'boolean' }).notNull().default(true),
 });
 
 export type Config = typeof configs.$inferSelect;

--- a/packages/api/db/schema.mts
+++ b/packages/api/db/schema.mts
@@ -10,7 +10,7 @@ export const configs = sqliteTable('config', {
   // Allows us to improve Srcbook, we don't collect any PII.
   enabledAnalytics: integer('enabled_analytics', { mode: 'boolean' }).notNull().default(true),
   // Stable ID for posthog
-  distinctId: text('distinct_id').notNull().default(randomid()),
+  installId: text('srcbook_installation_id').notNull().default(randomid()),
 });
 
 export type Config = typeof configs.$inferSelect;

--- a/packages/api/dev-server.mts
+++ b/packages/api/dev-server.mts
@@ -4,6 +4,8 @@ import { WebSocketServer as WsWebSocketServer } from 'ws';
 import app from './server/http.mjs';
 import webSocketServer from './server/ws.mjs';
 
+import { posthog } from './posthog-client.mjs';
+
 export { SRCBOOK_DIR } from './constants.mjs';
 
 const server = http.createServer(app);
@@ -14,4 +16,11 @@ wss.on('connection', webSocketServer.onConnection);
 const port = process.env.PORT || 2150;
 server.listen(port, () => {
   console.log(`Server is running at http://localhost:${port}`);
+});
+
+process.on('SIGINT', async function () {
+  console.log('Shutting down gracefully...');
+  await posthog.shutdown();
+  server.close();
+  process.exit();
 });

--- a/packages/api/dev-server.mts
+++ b/packages/api/dev-server.mts
@@ -19,7 +19,6 @@ server.listen(port, () => {
 });
 
 process.on('SIGINT', async function () {
-  console.log('Shutting down gracefully...');
   await posthog.shutdown();
   server.close();
   process.exit();

--- a/packages/api/drizzle/0003_enable_analytics.sql
+++ b/packages/api/drizzle/0003_enable_analytics.sql
@@ -1,1 +1,0 @@
-ALTER TABLE `config` ADD `enabled_analytics` integer DEFAULT true NOT NULL;

--- a/packages/api/drizzle/0003_enable_analytics.sql
+++ b/packages/api/drizzle/0003_enable_analytics.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `config` ADD `enabled_analytics` integer DEFAULT true NOT NULL;

--- a/packages/api/drizzle/0003_posthog_analytics.sql
+++ b/packages/api/drizzle/0003_posthog_analytics.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `config` ADD `enabled_analytics` integer DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE `config` ADD `distinct_id` text DEFAULT 's0llcp0p79kcmf7hajobdg3lhc' NOT NULL;

--- a/packages/api/drizzle/0003_posthog_analytics.sql
+++ b/packages/api/drizzle/0003_posthog_analytics.sql
@@ -1,2 +1,2 @@
 ALTER TABLE `config` ADD `enabled_analytics` integer DEFAULT true NOT NULL;--> statement-breakpoint
-ALTER TABLE `config` ADD `distinct_id` text DEFAULT 's0llcp0p79kcmf7hajobdg3lhc' NOT NULL;
+ALTER TABLE `config` ADD `srcbook_installation_id` text DEFAULT '18n70ookj0p2ht8c3aqfu2qjgo' NOT NULL;

--- a/packages/api/drizzle/meta/0003_snapshot.json
+++ b/packages/api/drizzle/meta/0003_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "1ac068b4-b95e-45ee-95d3-6f389cd064de",
+  "id": "59446000-b2a1-442d-8cd1-560a6a8fa7bf",
   "prevId": "fee9ddc3-ef67-45f3-a415-34fbb0b7779e",
   "tables": {
     "config": {
@@ -37,13 +37,13 @@
           "autoincrement": false,
           "default": true
         },
-        "distinct_id": {
-          "name": "distinct_id",
+        "srcbook_installation_id": {
+          "name": "srcbook_installation_id",
           "type": "text",
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false,
-          "default": "'s0llcp0p79kcmf7hajobdg3lhc'"
+          "default": "'18n70ookj0p2ht8c3aqfu2qjgo'"
         }
       },
       "indexes": {},

--- a/packages/api/drizzle/meta/0003_snapshot.json
+++ b/packages/api/drizzle/meta/0003_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "67411ea8-c18a-4c4b-a937-0f500b6eca78",
+  "id": "1ac068b4-b95e-45ee-95d3-6f389cd064de",
   "prevId": "fee9ddc3-ef67-45f3-a415-34fbb0b7779e",
   "tables": {
     "config": {
@@ -36,6 +36,14 @@
           "notNull": true,
           "autoincrement": false,
           "default": true
+        },
+        "distinct_id": {
+          "name": "distinct_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'s0llcp0p79kcmf7hajobdg3lhc'"
         }
       },
       "indexes": {},

--- a/packages/api/drizzle/meta/0003_snapshot.json
+++ b/packages/api/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,94 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "67411ea8-c18a-4c4b-a937-0f500b6eca78",
+  "prevId": "fee9ddc3-ef67-45f3-a415-34fbb0b7779e",
+  "tables": {
+    "config": {
+      "name": "config",
+      "columns": {
+        "base_dir": {
+          "name": "base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_language": {
+          "name": "default_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'typescript'"
+        },
+        "openai_api_key": {
+          "name": "openai_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled_analytics": {
+          "name": "enabled_analytics",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "secrets": {
+      "name": "secrets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "secrets_name_unique": {
+          "name": "secrets_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -26,7 +26,7 @@
     {
       "idx": 3,
       "version": "6",
-      "when": 1720654487367,
+      "when": 1720719921668,
       "tag": "0003_posthog_analytics",
       "breakpoints": true
     }

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -26,8 +26,8 @@
     {
       "idx": 3,
       "version": "6",
-      "when": 1720651509632,
-      "tag": "0003_enable_analytics",
+      "when": 1720654487367,
+      "tag": "0003_posthog_analytics",
       "breakpoints": true
     }
   ]

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1720548526434,
       "tag": "0002_add-openai-key",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1720651509632,
+      "tag": "0003_enable_analytics",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/index.mts
+++ b/packages/api/index.mts
@@ -1,5 +1,6 @@
 import app from './server/http.mjs';
 import wss from './server/ws.mjs';
 import { SRCBOOKS_DIR } from './constants.mjs';
+import { posthog } from './posthog-client.mjs';
 
-export { app, wss, SRCBOOKS_DIR };
+export { app, wss, SRCBOOKS_DIR, posthog };

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,7 +9,7 @@
     "dev": "vite-node dev-server.mts",
     "test": "vitest",
     "prebuild": "rm -rf ./dist",
-    "build": "tsc && cp -R ./drizzle ./dist/drizzle && cp -R ./srcbook/examples ./dist/srcbook/examples",
+    "build": "tsc && cp -R ./drizzle ./dist/drizzle && cp -R ./srcbook/examples ./dist/srcbook/examples && cp -R ./prompts ./dist/prompts",
     "check-types": "tsc",
     "depcheck": "depcheck",
     "generate": "drizzle-kit generate",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -29,6 +29,7 @@
     "drizzle-orm": "^0.31.2",
     "express": "^4.19.2",
     "marked": "^12.0.2",
+    "posthog-node": "^4.0.1",
     "typescript": "^5.4.5",
     "ws": "^8.17.0",
     "zod": "^3.23.8"

--- a/packages/api/posthog-client.mts
+++ b/packages/api/posthog-client.mts
@@ -8,14 +8,14 @@ type QueuedEvent = {
 };
 
 class PostHogClient {
-  private distinctId: string;
+  private installId: string;
   private client: PostHog | null = null;
   private isEnabled: boolean = false;
   private eventQueue: QueuedEvent[] = [];
 
-  constructor(config: { enabledAnalytics: boolean; distinctId: string }) {
+  constructor(config: { enabledAnalytics: boolean; installId: string }) {
     this.isEnabled = config.enabledAnalytics;
-    this.distinctId = config.distinctId;
+    this.installId = config.installId;
 
     if (this.isEnabled) {
       this.client = new PostHog(
@@ -37,7 +37,7 @@ class PostHogClient {
     while (this.eventQueue.length > 0) {
       const event = this.eventQueue.shift();
       if (event) {
-        this.client.capture({ ...event, distinctId: this.distinctId });
+        this.client.capture({ ...event, distinctId: this.installId });
       }
     }
   }
@@ -45,7 +45,7 @@ class PostHogClient {
   public capture(event: QueuedEvent): void {
     if (this.isEnabled && IS_PRODUCTION) {
       if (this.client) {
-        this.client.capture({ ...event, distinctId: this.distinctId });
+        this.client.capture({ ...event, distinctId: this.installId });
       }
     } else {
       this.eventQueue.push(event);

--- a/packages/api/posthog-client.mts
+++ b/packages/api/posthog-client.mts
@@ -1,0 +1,78 @@
+import { PostHog } from 'posthog-node';
+import { getConfig } from './config.mjs';
+
+type QueuedEvent = {
+  distinctId: string;
+  event: string;
+  properties?: Record<string, any>;
+};
+
+class PostHogClient {
+  private static instance: PostHogClient | null = null;
+  private client: PostHog | null = null;
+  private isEnabled: boolean = false;
+  private isInitialized: boolean = false;
+  private initializationPromise: Promise<void> | null = null;
+  private eventQueue: QueuedEvent[] = [];
+
+  private constructor() {
+    this.initializationPromise = this.initialize();
+  }
+
+  public static getInstance(): PostHogClient {
+    if (!PostHogClient.instance) {
+      PostHogClient.instance = new PostHogClient();
+    }
+    return PostHogClient.instance;
+  }
+
+  private async initialize(): Promise<void> {
+    const config = await getConfig();
+    this.isEnabled = config.enabledAnalytics;
+
+    if (this.isEnabled) {
+      this.client = new PostHog(
+        // We're sending over API key to GitHub and clients, but it's the only way.
+        'phc_bQjmPYXmbl76j8gW289Qj9XILuu1STRnIfgCSKlxdgu',
+        { host: 'https://us.i.posthog.com' },
+      );
+    }
+
+    this.isInitialized = true;
+    this.flushQueue();
+  }
+
+  private async flushQueue(): Promise<void> {
+    if (!this.isEnabled || !this.client) {
+      this.eventQueue = []; // Clear the queue if analytics are disabled
+      return;
+    }
+
+    while (this.eventQueue.length > 0) {
+      const event = this.eventQueue.shift();
+      if (event) {
+        this.client.capture(event);
+      }
+    }
+  }
+
+  public capture(event: QueuedEvent): void {
+    if (this.isInitialized) {
+      if (this.isEnabled && this.client) {
+        this.client.capture(event);
+      }
+    } else {
+      this.eventQueue.push(event);
+    }
+  }
+
+  public async shutdown(): Promise<void> {
+    await this.initializationPromise; // Ensure initialization is complete
+    await this.flushQueue();
+    if (this.client) {
+      await this.client.shutdown();
+    }
+  }
+}
+
+export const posthog = PostHogClient.getInstance();

--- a/packages/web/src/components/generate-srcbook-modal.tsx
+++ b/packages/web/src/components/generate-srcbook-modal.tsx
@@ -49,6 +49,7 @@ export default function GenerateSrcbookModal({
           <Textarea
             placeholder="Write a prompt to create a Srcbook..."
             className="focus-visible:ring-2"
+            rows={4}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
           />

--- a/packages/web/src/lib/server.ts
+++ b/packages/web/src/lib/server.ts
@@ -232,6 +232,7 @@ interface EditConfigRequestType {
   baseDir?: string;
   defaultLanguage?: 'typescript' | 'javascript';
   openaiKey?: string;
+  enabledAnalytics?: boolean;
 }
 
 export async function getConfig() {

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -125,8 +125,8 @@ function Settings() {
         <div>
           <h2 className="text-xl pb-2">Analytics tracking</h2>
           <label className="opacity-70 block pb-2">
-            We track behavior analytics to improve the Srcbook product. We track no personal
-            information.
+            We track behavioral analytics to improve Srcbook. We do not track any personally
+            identifiable information (PII).
           </label>
           <div className="flex items-center gap-2">
             <Switch

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -23,6 +23,7 @@ async function loader() {
     defaultLanguage: config.defaultLanguage,
     baseDir: config.baseDir,
     openaiKey: config.openaiKey,
+    enabledAnalytics: config.enabledAnalytics,
     ...diskResult,
   };
 }
@@ -40,9 +41,11 @@ function Settings() {
     entries,
     baseDir,
     defaultLanguage,
+    enabledAnalytics: configEnabledAnalytics,
   } = useLoaderData() as SettingsType & FsObjectResultType;
 
   const [openaiKey, setOpenaiKey] = useState(configOpenaiKey);
+  const [enabledAnalytics, setEnabledAnalytics] = useState(configEnabledAnalytics);
 
   const updateDefaultLanguage = async (value: CodeLanguageType) => {
     await updateConfig({ defaultLanguage: value });
@@ -116,6 +119,24 @@ function Settings() {
                 Save
               </Button>
             </div>
+          </div>
+        </div>
+
+        <div>
+          <h2 className="text-xl pb-2">Analytics tracking</h2>
+          <label className="opacity-70 block pb-2">
+            We track behavior analytics to improve the Srcbook product. We track no personal
+            information.
+          </label>
+          <div className="flex items-center gap-2">
+            <Switch
+              checked={enabledAnalytics}
+              onCheckedChange={() => {
+                setEnabledAnalytics(!enabledAnalytics);
+                updateConfig({ enabledAnalytics: !enabledAnalytics });
+              }}
+            />
+            <label>{enabledAnalytics ? 'enabled' : 'disabled'}</label>
           </div>
         </div>
       </div>

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -16,6 +16,7 @@ export type SettingsType = {
   baseDir: string;
   defaultLanguage: CodeLanguageType;
   openaiKey?: string;
+  enabledAnalytics: boolean;
 };
 
 export type StdoutOutputType = { type: 'stdout'; data: string };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,9 +251,15 @@ importers:
 
   srcbook:
     dependencies:
+      '@ai-sdk/openai':
+        specifier: ^0.0.34
+        version: 0.0.34(zod@3.23.8)
       '@srcbook/shared':
         specifier: workspace:^
         version: link:../packages/shared
+      ai:
+        specifier: ^3.2.16
+        version: 3.2.16(openai@4.52.3)(react@18.3.1)(svelte@4.2.18)(vue@3.4.31(typescript@5.4.5))(zod@3.23.8)
       better-sqlite3:
         specifier: ^11.0.0
         version: 11.0.0
@@ -275,6 +281,9 @@ importers:
       marked:
         specifier: ^12.0.2
         version: 12.0.2
+      posthog-node:
+        specifier: ^4.0.1
+        version: 4.0.1
       ws:
         specifier: ^8.17.0
         version: 8.17.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       marked:
         specifier: ^12.0.2
         version: 12.0.2
+      posthog-node:
+        specifier: ^4.0.1
+        version: 4.0.1
       typescript:
         specifier: ^5.4.5
         version: 5.4.5
@@ -2010,6 +2013,9 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  axios@1.7.2:
+    resolution: {integrity: sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==}
+
   axobject-query@4.0.0:
     resolution: {integrity: sha512-+60uv1hiVFhHZeO+Lz0RYzsVHy5Wr1ayX0mwda9KPDVLNJgZ1T9Ny7VmFbLDzxsH0D87I86vgj3gFrjTJUYznw==}
 
@@ -2627,6 +2633,15 @@ packages:
 
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
+
+  follow-redirects@1.15.6:
+    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   foreground-child@3.1.1:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
@@ -3288,6 +3303,10 @@ packages:
     resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-node@4.0.1:
+    resolution: {integrity: sha512-rtqm2h22QxLGBrW2bLYzbRhliIrqgZ0k+gF0LkQ1SNdeD06YE5eilV0MxZppFSxC8TfH0+B0cWCuebEnreIDgQ==}
+    engines: {node: '>=15.0.0'}
+
   prebuild-install@7.1.2:
     resolution: {integrity: sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==}
     engines: {node: '>=10'}
@@ -3316,6 +3335,9 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   pump@3.0.0:
     resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
@@ -3472,6 +3494,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rusha@0.8.14:
+    resolution: {integrity: sha512-cLgakCUf6PedEu15t8kbsjnwIFFR2D4RfL+W3iWFJ4iac7z4B0ZI8fxy4R3J956kAI68HclCFGL8MPoUVC3qVA==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -5601,8 +5626,7 @@ snapshots:
 
   assertion-error@1.1.0: {}
 
-  asynckit@0.4.0:
-    optional: true
+  asynckit@0.4.0: {}
 
   attr-accept@2.2.2: {}
 
@@ -5615,6 +5639,14 @@ snapshots:
       picocolors: 1.0.1
       postcss: 8.4.38
       postcss-value-parser: 4.2.0
+
+  axios@1.7.2:
+    dependencies:
+      follow-redirects: 1.15.6
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   axobject-query@4.0.0:
     dependencies:
@@ -5807,7 +5839,6 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
-    optional: true
 
   commander@4.1.1: {}
 
@@ -5881,8 +5912,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.0.1
 
-  delayed-stream@1.0.0:
-    optional: true
+  delayed-stream@1.0.0: {}
 
   depcheck@1.4.7:
     dependencies:
@@ -6311,6 +6341,8 @@ snapshots:
 
   flatted@3.3.1: {}
 
+  follow-redirects@1.15.6: {}
+
   foreground-child@3.1.1:
     dependencies:
       cross-spawn: 7.0.3
@@ -6324,7 +6356,6 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-    optional: true
 
   formdata-node@4.4.1:
     dependencies:
@@ -6899,6 +6930,13 @@ snapshots:
       picocolors: 1.0.1
       source-map-js: 1.2.0
 
+  posthog-node@4.0.1:
+    dependencies:
+      axios: 1.7.2
+      rusha: 0.8.14
+    transitivePeerDependencies:
+      - debug
+
   prebuild-install@7.1.2:
     dependencies:
       detect-libc: 2.0.3
@@ -6938,6 +6976,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@1.1.0: {}
 
   pump@3.0.0:
     dependencies:
@@ -7104,6 +7144,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rusha@0.8.14: {}
 
   safe-buffer@5.2.1: {}
 

--- a/srcbook/bin/start
+++ b/srcbook/bin/start
@@ -2,4 +2,6 @@
 
 process.env.NODE_ENV = 'production';
 
-import '../index.mjs';
+(async () => {
+  await import('../index.mjs');
+})();

--- a/srcbook/bin/start
+++ b/srcbook/bin/start
@@ -1,3 +1,5 @@
 #!/usr/bin/env node
 
+process.env.NODE_ENV = 'production';
+
 import '../index.mjs';

--- a/srcbook/index.mjs
+++ b/srcbook/index.mjs
@@ -19,7 +19,7 @@ import http from 'node:http';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import { WebSocketServer as WsWebSocketServer } from 'ws';
-import { wss, app } from './lib/index.mjs';
+import { wss, app, posthog } from './lib/index.mjs';
 import chalk from 'chalk';
 
 function clearScreen() {
@@ -56,6 +56,15 @@ app.get('*', (_req, res) => res.sendFile(INDEX_HTML));
 console.log(chalk.green('Initialization complete.'));
 
 const port = process.env.PORT || 2150;
+
+posthog.capture({ event: 'user started Srcbook application' });
+
 server.listen(port, () => {
   console.log(`Running at http://localhost:${port}`);
+});
+
+process.on('SIGINT', async function () {
+  await posthog.shutdown();
+  server.close();
+  process.exit();
 });

--- a/srcbook/package.json
+++ b/srcbook/package.json
@@ -13,7 +13,9 @@
     "postversion": "git push && git push --tags"
   },
   "dependencies": {
+    "@ai-sdk/openai": "^0.0.34",
     "@srcbook/shared": "workspace:^",
+    "ai": "^3.2.16",
     "better-sqlite3": "^11.0.0",
     "chalk": "^5.3.0",
     "cors": "^2.8.5",
@@ -21,6 +23,7 @@
     "drizzle-orm": "^0.31.2",
     "express": "^4.19.2",
     "marked": "^12.0.2",
+    "posthog-node": "^4.0.1",
     "ws": "^8.17.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR introduces posthog analytics for Srcbook. It's an opt-out mechanism, but we don't collect _any_ PII data. Location tracking is disabled, and the only metrics we collect are behavioral and explicit, in the goal of improving the Srcbook application. 

The user can disable tracking in settings.

I added some copy about this in the README. Down the line we might want a more formal document about the data we collect.

I collect on the node side of things (rather than the web side of things). This is a debatable option. It's great for source of truth, but won't help us understand things like clicks / pageViews, etc... It has the advantage of not being able to be blocked by ad-blockers, and won't show up in the network tab.

I do not collect in dev (I guard on `NODE_ENV === production`)

## Testing

This was tested manually, checking that it behaves correctly when enabled and disabled.

## Events

To begin, we track the following events:
 - session create (with TS/JS metadata)
 - generate with AI
 - added openAI API key (generic "changed a setting" event, obviously we don't track the value)
 - delete Srcbook
 - export Srcbook
