### PR TITLE
Line clamp titles in cards. Fix inline code in titles

### DIFF
--- a/packages/web/src/components/srcbook-cards.tsx
+++ b/packages/web/src/components/srcbook-cards.tsx
@@ -111,7 +111,7 @@ export function SrcbookCard(props: SrcbookCardPropsType) {
         props.running ? 'border-run' : 'hover:border-foreground',
       )}
     >
-      <h5 className="font-semibold leading-[18px]">{props.title}</h5>
+      <h5 className="font-semibold leading-[18px] line-clamp-3">{props.title}</h5>
       <div className="flex items-center justify-between text-tertiary-foreground">
         <div className="text-[13px] flex items-center gap-2">
           {props.running ? (

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -248,7 +248,10 @@
 .sb-prose h4 > code,
 .sb-prose h5 > code {
   @apply font-mono;
-  font-size: inherit;
+  /* No way to avoid !important given specificity priority and the fact that we don't generate the HTML */
+  font-size: 80% !important;
+  @apply px-1.5 !important;
+  @apply font-normal;
 }
 
 .sb-prose h1 {


### PR DESCRIPTION
## Before / after on the titles
![CleanShot 2024-07-11 at 10 08 55](https://github.com/srcbookdev/srcbook/assets/1666947/b75ab4c4-75a1-4445-99f3-ad1755fdaf8d)
![CleanShot 2024-07-11 at 10 08 26](https://github.com/srcbookdev/srcbook/assets/1666947/5f26120e-4157-43a4-bbbb-d38c59b9f407)


## Before after on the line clamp
![CleanShot 2024-07-11 at 10 10 46](https://github.com/srcbookdev/srcbook/assets/1666947/8b4761c1-106f-4c81-8f54-4fc851cc2802)
![CleanShot 2024-07-11 at 10 10 55](https://github.com/srcbookdev/srcbook/assets/1666947/0b879cf6-391e-412f-8122-73d34f2ac3d1)
