### PR TITLE
Use tsserver geterr command & events. reloadProjects for file renames

### DIFF
--- a/packages/api/srcbook/path.mts
+++ b/packages/api/srcbook/path.mts
@@ -20,3 +20,7 @@ export function pathToTsconfigJson(baseDir: string) {
 export function pathToCodeFile(baseDir: string, filename: string) {
   return Path.join(baseDir, 'src', filename);
 }
+
+export function filenameFromPath(filePath: string) {
+  return Path.basename(filePath);
+}

--- a/packages/api/tsserver/tsserver.mts
+++ b/packages/api/tsserver/tsserver.mts
@@ -1,14 +1,44 @@
-import { parseTsServerMessages } from './utils.mjs';
-import type { ChildProcess } from 'child_process';
+import EventEmitter from 'node:events';
+import type { ChildProcess } from 'node:child_process';
 import type { server as tsserver } from 'typescript';
+import { parseTsServerMessages } from './utils.mjs';
 
-export class TsServer {
+/**
+ * This class provides a wrapper around a process running tsserver and is used to communicate
+ * with the server, mainly to support diagnostics for user code (type errors, sytnax errors,
+ * type definitions, etc).
+ *
+ * tsserver is not documented. Here is a brief overview.
+ *
+ * tsserver is a process which listens for messages over stdin and
+ * sends messages over stdout. tsserver has three types of messages:
+ *
+ * 1. Request: A request from the client to the server.
+ * 2. Response: A response from the server to a specific client request.
+ * 3. Event: An event from the server to the client.
+ *
+ * Request and responses are identified a unique number called `seq`. `seq` is incremented
+ * for each request the client sends. The client will send a `seq` field with its request
+ * and the server will provide a `request_seq` in its response which is used to tie a message
+ * from the server to a specific request from the client.
+ *
+ * Events can arrive at any time but are often used as an asynchronous response from the server.
+ * For example, syntax and semantic diagnostics are sent as events when using the `geterr` command.
+ *
+ * Most of this is learned by reading through the source (protocol.ts) as well as trial
+ * and error. They also have an introduction, but it's hardly useful. See links below.
+ *
+ * - https://github.com/microsoft/TypeScript/blob/v5.5.3/src/server/protocol.ts
+ * - https://github.com/microsoft/TypeScript/wiki/Standalone-Server-(tsserver)
+ */
+export class TsServer extends EventEmitter {
   private _seq: number = 0;
   private buffered: Buffer = Buffer.from('');
   private readonly process: ChildProcess;
   private readonly resolvers: Record<number, (value: any) => void> = {};
 
   constructor(process: ChildProcess) {
+    super();
     this.process = process;
     this.process.stdout?.on('data', (chunk) => {
       const { messages, buffered } = parseTsServerMessages(chunk, this.buffered);
@@ -32,7 +62,7 @@ export class TsServer {
 
     if (!resolve) {
       console.warn(
-        `Received a response for command '${response.command}' and request_seq '${response.request_seq}' but no resolver was found. This may be a bug in the code.`,
+        `Received a response for command '${response.command}' and request_seq '${response.request_seq}' but no resolver was found. This may be a bug in the code.\n\nResponse:\n${JSON.stringify(response, null, 2)}\n`,
       );
 
       return;
@@ -43,8 +73,8 @@ export class TsServer {
     resolve(response);
   }
 
-  private handleEvent(_event: tsserver.protocol.Event) {
-    // Ignoring telemetry events for now
+  private handleEvent(event: tsserver.protocol.Event) {
+    this.emit(event.event, event);
   }
 
   private send(request: tsserver.protocol.Request) {
@@ -59,9 +89,31 @@ export class TsServer {
   }
 
   /**
+   * Wrapper around the `semanticDiag` event for convenience and type safety.
+   */
+  onSemanticDiag(callback: (event: tsserver.protocol.DiagnosticEvent) => void) {
+    this.on('semanticDiag', callback);
+  }
+
+  /**
+   * Wrapper around the `syntaxDiag` event for convenience and type safety.
+   */
+  onSyntaxDiag(callback: (event: tsserver.protocol.DiagnosticEvent) => void) {
+    this.on('syntaxDiag', callback);
+  }
+
+  /**
+   * Wrapper around the `suggestionDiag` event for convenience and type safety.
+   */
+  onSuggestionDiag(callback: (event: tsserver.protocol.DiagnosticEvent) => void) {
+    this.on('suggestionDiag', callback);
+  }
+
+  /**
    * Shutdown the underlying tsserver process.
    */
   shutdown() {
+    this.removeAllListeners();
     return this.process.kill('SIGTERM');
   }
 
@@ -94,6 +146,37 @@ export class TsServer {
   }
 
   /**
+   * Ask tsserver to send diagnostics for a set of files.
+   *
+   * This is used to get the errors for a set of files in a project.
+   *
+   * Note that the diagnostics are sent as asynchronous events instead of responding to this request.
+   */
+  geterr(args: tsserver.protocol.GeterrRequestArgs) {
+    this.send({
+      seq: this.seq,
+      type: 'request',
+      command: 'geterr',
+      arguments: args,
+    });
+  }
+
+  /**
+   * Reload the project in tsserver.
+   *
+   * This is used to tell tsserver to reload the project configuration
+   * which helps ensure that the project is up-to-date. This helps resolve
+   * errors that can occur when renaming files.
+   */
+  reloadProjects() {
+    this.send({
+      seq: this.seq,
+      type: 'request',
+      command: 'reloadProjects',
+    });
+  }
+
+  /**
    * Get info about the project.
    *
    * This can be useful during development to inspect the tsserver integration.
@@ -117,34 +200,6 @@ export class TsServer {
       seq: this.seq,
       type: 'request',
       command: 'quickinfo',
-      arguments: args,
-    });
-  }
-
-  /**
-   * Get semantic information about a file.
-   *
-   * This is used to report type errors in a file.
-   */
-  semanticDiagnosticsSync(args: tsserver.protocol.SemanticDiagnosticsSyncRequestArgs) {
-    return this.sendWithResponsePromise<tsserver.protocol.SemanticDiagnosticsSyncResponse>({
-      seq: this.seq,
-      type: 'request',
-      command: 'semanticDiagnosticsSync',
-      arguments: args,
-    });
-  }
-
-  /**
-   * Get syntactic information about a file.
-   *
-   * This is used to report syntax errors in a file.
-   */
-  syntacticDiagnosticsSync(args: tsserver.protocol.SyntacticDiagnosticsSyncRequestArgs) {
-    return this.sendWithResponsePromise<tsserver.protocol.SyntacticDiagnosticsSyncResponse>({
-      seq: this.seq,
-      type: 'request',
-      command: 'syntacticDiagnosticsSync',
       arguments: args,
     });
   }

--- a/packages/api/tsserver/utils.mts
+++ b/packages/api/tsserver/utils.mts
@@ -68,7 +68,7 @@ export function normalizeDiagnostic(
     };
   } else {
     return {
-      // From what I can tell, code should always be present depsite the type.
+      // From what I can tell, code should always be present despite the type.
       // If it's not, we use 1000 as the 'unknown' error code, which is not a
       // code defined in diagnosticMessages.json in TypeScript's source.
       code: diagnostic.code || 1000,


### PR DESCRIPTION
Lots of trial and error but looks like using `geterr` command is better than the `semanticDiagnosticSync` command:

1. It's more convenient since it accepts a list of files rather than one file
2. It sometimes fires events unprompted and so we can listen to those as well as ones we ask it for
3. Of the very little literature i've found on the internet about tsserver, I've seen this referenced

This PR also solves one annoying bug when renaming files

1. Rename a `a.ts` that is imported by `b.ts` to `c.ts`
2. Semantic diagnostics report an error in `b.ts` that `a.ts` doesn't exist
3. Great, all works so far.
4. Rename `c.ts` back to `a.ts`.
5. Semantic diagnostics still report an error in `b.ts` that `a.ts` doesn't exist.
6. This is wrong, `a.ts` does exist.

This PR issues the `reloadProjects` command which gets it back to a working state.

I also added more documentation.