### PR TITLE
Updates to cell renaming behavior and UI

### DIFF
--- a/packages/shared/src/schemas/cells.ts
+++ b/packages/shared/src/schemas/cells.ts
@@ -56,9 +56,10 @@ export const PackageJsonCellUpdateAttrsSchema = z.object({
   source: z.string(),
 });
 
+// filename not allowed here because renaming
+// a file has a separate websocket message.
 export const CodeCellUpdateAttrsSchema = z.object({
-  source: z.string().optional(),
-  filename: z.string().optional(),
+  source: z.string(),
 });
 
 export const CellUpdateAttrsSchema = z.union([

--- a/packages/shared/src/schemas/websockets.ts
+++ b/packages/shared/src/schemas/websockets.ts
@@ -18,6 +18,12 @@ export const CellUpdatePayloadSchema = z.object({
   updates: CellUpdateAttrsSchema,
 });
 
+export const CellRenamePayloadSchema = z.object({
+  sessionId: z.string(),
+  cellId: z.string(),
+  filename: z.string(),
+});
+
 export const CellDeletePayloadSchema = z.object({
   sessionId: z.string(),
   cellId: z.string(),

--- a/packages/shared/src/types/websockets.ts
+++ b/packages/shared/src/types/websockets.ts
@@ -5,6 +5,7 @@ import {
   CellStopPayloadSchema,
   CellUpdatePayloadSchema,
   CellUpdatedPayloadSchema,
+  CellRenamePayloadSchema,
   CellDeletePayloadSchema,
   CellOutputPayloadSchema,
   DepsInstallPayloadSchema,
@@ -20,6 +21,7 @@ export type CellExecPayloadType = z.infer<typeof CellExecPayloadSchema>;
 export type CellStopPayloadType = z.infer<typeof CellStopPayloadSchema>;
 export type CellUpdatePayloadType = z.infer<typeof CellUpdatePayloadSchema>;
 export type CellUpdatedPayloadType = z.infer<typeof CellUpdatedPayloadSchema>;
+export type CellRenamePayloadType = z.infer<typeof CellRenamePayloadSchema>;
 export type CellDeletePayloadType = z.infer<typeof CellDeletePayloadSchema>;
 export type CellOutputPayloadType = z.infer<typeof CellOutputPayloadSchema>;
 

--- a/packages/web/src/clients/websocket/index.ts
+++ b/packages/web/src/clients/websocket/index.ts
@@ -12,6 +12,7 @@ import {
   TsServerStopPayloadSchema,
   CellDeletePayloadSchema,
   TsServerCellDiagnosticsPayloadSchema,
+  CellRenamePayloadSchema,
 } from '@srcbook/shared';
 
 import Channel from '@/clients/websocket/channel';
@@ -33,6 +34,7 @@ const OutgoingSessionEvents = {
   'cell:exec': CellExecPayloadSchema,
   'cell:stop': CellStopPayloadSchema,
   'cell:update': CellUpdatePayloadSchema,
+  'cell:rename': CellRenamePayloadSchema,
   'cell:delete': CellDeletePayloadSchema,
   'deps:install': DepsInstallPayloadSchema,
   'deps:validate': DepsValidatePayloadSchema,

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -62,6 +62,8 @@
     --run-ring: var(--sb-yellow-50);
     --inline-code: var(--sb-core-20);
     --inline-code-foreground: var(--foreground);
+    --error: var(--sb-red-30);
+    --error-foreground: var(--sb-red-80);
   }
 
   .dark {
@@ -74,6 +76,8 @@
     --run-ring: var(--sb-yellow-50);
     --inline-code: var(--sb-core-110);
     --inline-code-foreground: var(--foreground);
+    --error: var(--sb-red-30);
+    --error-foreground: var(--sb-red-80);
   }
 
   /* shadcn variables light */

--- a/packages/web/src/routes/session.tsx
+++ b/packages/web/src/routes/session.tsx
@@ -120,9 +120,9 @@ function Session(props: { session: SessionType; channel: SessionChannel }) {
     getValidationError?: (cell: T) => string | null,
   ) {
     getValidationError = getValidationError || (() => null);
-    updateCell({ ...cell, ...(updates as Partial<T>) });
+    updateCell({ ...cell, ...updates });
 
-    const error = getValidationError({ ...cell, ...(updates as Partial<T>) });
+    const error = getValidationError({ ...cell, ...updates });
     if (typeof error === 'string') {
       return error;
     }

--- a/packages/web/tailwind.config.js
+++ b/packages/web/tailwind.config.js
@@ -86,6 +86,10 @@ module.exports = {
           DEFAULT: 'hsl(var(--inline-code))',
           foreground: 'hsl(var(--inline-code-foreground))',
         },
+        error: {
+          DEFAULT: 'hsl(var(--error))',
+          foreground: 'hsl(var(--error-foreground))',
+        },
         sb: {
           'core-0': 'hsl(var(--sb-core-0))',
           'core-10': 'hsl(var(--sb-core-10))',


### PR DESCRIPTION
* Make cell renaming its own websocket event in an attempt to keep that complexity isolated
* Fix bug where renaming a cell to the name of an existing cell 1) overwrote that cells file and 2) subsequently crashed server on next page load
* Fix presentation of errors resulting from failed file renames (see before+after below).

### Before

<img width="803" alt="Screenshot 2024-07-14 at 2 31 40 PM" src="https://github.com/user-attachments/assets/eb912910-423f-4592-a4bc-1f84730f8567">

### After

<img width="804" alt="Screenshot 2024-07-14 at 3 04 31 PM" src="https://github.com/user-attachments/assets/ff6dd60e-1aa6-4186-b5d0-19df939e32e5">

Note that we have limited space to the right of the file input. Thus, we go with a generic error name "Invalid filename" which is not super helpful. I think we can solve this by having a popup on hover with detailed error, though I did not do that in this PR.
