### PR TITLE
Rework cell creation flow

### DIFF
--- a/packages/api/session.mts
+++ b/packages/api/session.mts
@@ -76,6 +76,23 @@ export async function listSessions(): Promise<Record<string, SessionType>> {
   return sessions;
 }
 
+export async function addCell(
+  session: SessionType,
+  cell: MarkdownCellType | CodeCellType,
+  index: number,
+) {
+  const cells = insertCellAt(session, cell, index);
+
+  session.cells = cells;
+
+  switch (cell.type) {
+    case 'markdown':
+      return writeReadmeToDisk(session.dir, session.metadata, session.cells);
+    case 'code':
+      return writeCellToDisk(session.dir, session.metadata, session.cells, cell);
+  }
+}
+
 export async function updateSession(
   session: SessionType,
   updates: Partial<SessionType>,

--- a/packages/shared/src/schemas/websockets.ts
+++ b/packages/shared/src/schemas/websockets.ts
@@ -1,5 +1,5 @@
 import z from 'zod';
-import { CellSchema, CellUpdateAttrsSchema } from './cells.js';
+import { CellSchema, MarkdownCellSchema, CodeCellSchema, CellUpdateAttrsSchema } from './cells.js';
 import { TsServerDiagnosticSchema } from './tsserver.js';
 
 export const CellExecPayloadSchema = z.object({
@@ -10,6 +10,12 @@ export const CellExecPayloadSchema = z.object({
 export const CellStopPayloadSchema = z.object({
   sessionId: z.string(),
   cellId: z.string(),
+});
+
+export const CellCreatePayloadSchema = z.object({
+  sessionId: z.string(),
+  index: z.number(),
+  cell: z.union([MarkdownCellSchema, CodeCellSchema]),
 });
 
 export const CellUpdatePayloadSchema = z.object({

--- a/packages/shared/src/types/websockets.ts
+++ b/packages/shared/src/types/websockets.ts
@@ -3,6 +3,7 @@ import z from 'zod';
 import {
   CellExecPayloadSchema,
   CellStopPayloadSchema,
+  CellCreatePayloadSchema,
   CellUpdatePayloadSchema,
   CellUpdatedPayloadSchema,
   CellRenamePayloadSchema,
@@ -19,6 +20,7 @@ import {
 
 export type CellExecPayloadType = z.infer<typeof CellExecPayloadSchema>;
 export type CellStopPayloadType = z.infer<typeof CellStopPayloadSchema>;
+export type CellCreatePayloadType = z.infer<typeof CellCreatePayloadSchema>;
 export type CellUpdatePayloadType = z.infer<typeof CellUpdatePayloadSchema>;
 export type CellUpdatedPayloadType = z.infer<typeof CellUpdatedPayloadSchema>;
 export type CellRenamePayloadType = z.infer<typeof CellRenamePayloadSchema>;

--- a/packages/web/src/clients/websocket/index.ts
+++ b/packages/web/src/clients/websocket/index.ts
@@ -1,5 +1,6 @@
 import {
   CellOutputPayloadSchema,
+  CellCreatePayloadSchema,
   CellUpdatedPayloadSchema,
   DepsValidateResponsePayloadSchema,
   CellExecPayloadSchema,
@@ -33,6 +34,7 @@ const IncomingSessionEvents = {
 const OutgoingSessionEvents = {
   'cell:exec': CellExecPayloadSchema,
   'cell:stop': CellStopPayloadSchema,
+  'cell:create': CellCreatePayloadSchema,
   'cell:update': CellUpdatePayloadSchema,
   'cell:rename': CellRenamePayloadSchema,
   'cell:delete': CellDeletePayloadSchema,

--- a/packages/web/src/lib/server.ts
+++ b/packages/web/src/lib/server.ts
@@ -1,4 +1,4 @@
-import { CellType, CodeCellType, MarkdownCellType, CodeLanguageType } from '@srcbook/shared';
+import { CodeLanguageType } from '@srcbook/shared';
 import { SessionType, FsObjectResultType, ExampleSrcbookType } from '@/types';
 
 const API_BASE_URL = 'http://localhost:2150/api';
@@ -191,32 +191,6 @@ export async function exportSrcmdFile(sessionId: string, request: ExportSrcmdFil
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(request),
-  });
-
-  if (!response.ok) {
-    console.error(response);
-    throw new Error('Request failed');
-  }
-
-  return response.json();
-}
-
-interface CreateCellRequestType {
-  sessionId: string;
-  cell: CodeCellType | MarkdownCellType;
-  index?: number;
-}
-
-interface CreateCellResponseType {
-  error: boolean;
-  result: CellType;
-}
-
-export async function createCell(request: CreateCellRequestType): Promise<CreateCellResponseType> {
-  const response = await fetch(API_BASE_URL + '/sessions/' + request.sessionId + '/cells', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ cell: request.cell, index: request.index }),
   });
 
   if (!response.ok) {


### PR DESCRIPTION
This PR:

1. Moves cell creation (insert new cell) to a websocket event like all other cell operations
2. Does not flush the whole session to disk on creation. The only disk writes are: 1) the new cell's file and 2) the updated readme
3. Updates tsserver when a new cell is created, making tsserver aware of the new file. This fixes a scenario where the user has an import statement with a non-existent import path and they then add the file with that path (previously it would still show an error the import doesn't exist when it does. This is now fixed)
4. Updates the insert cell UI component design to the new design (see below)

<img width="1444" alt="Screenshot 2024-07-14 at 8 16 05 PM" src="https://github.com/user-attachments/assets/09c41855-9373-4595-ac21-59211f7f5d67">
