### PR TITLE
Update tsserver when deps are updated. Dont crash on missing tsserver

### DIFF
--- a/packages/api/tsserver/tsservers.mts
+++ b/packages/api/tsserver/tsservers.mts
@@ -39,6 +39,11 @@ export class TsServers {
     }
 
     // This is using the TypeScript dependency in the user's Srcbook.
+    //
+    // Note: If a user creates a typescript Srcbook, when it is first
+    // created, the dependencies are not installed and thus this will
+    // shut down immediately. Make sure that we handle this case after
+    // package.json has finished installing its deps.
     const child = spawn('npx', ['tsserver'], {
       cwd: options.cwd,
     });
@@ -55,14 +60,13 @@ export class TsServers {
   }
 
   shutdown(id: string) {
-    const server = this.get(id);
-
-    if (!server) {
-      throw new Error(`tsserver for ${id} does not exist.`);
+    if (!this.has(id)) {
+      console.warn(`tsserver for ${id} does not exist. Skipping shutdown.`);
+      return;
     }
 
     // The server is removed from this.servers in the
     // process exit handler which covers all exit cases.
-    return server.shutdown();
+    return this.get(id).shutdown();
   }
 }


### PR DESCRIPTION
This PR:

1. Updates tsserver diagnostics when dependencies are installed. This fixes a bug where you import from a third party dep that isn't yet installed, get diagnostic errors, install deps, and still see errors about the module not found. 
2. This fixes a bug where the server crashes if you create a new typescript srcbook (or import from one), do NOT install deps, and then navigate away from the srcbook page.
3. To fix above bug and generally be more lenient, we do not error if we try to shutdown a tsserver that does not exist.