### PR TITLE
Move delete to the left, fix markdown jitter on hover -> click

### DIFF
--- a/packages/web/src/components/cells/code.tsx
+++ b/packages/web/src/components/cells/code.tsx
@@ -114,6 +114,11 @@ export default function CodeCell(props: {
                   : 'border-transparent hover:border-input group-hover:border-input ',
               )}
             />
+            <DeleteCellWithConfirmation onDeleteCell={() => onDeleteCell(cell)}>
+              <Button className="hidden group-hover:flex" variant="icon" size="icon" tabIndex={1}>
+                <Trash2 size={16} />
+              </Button>
+            </DeleteCellWithConfirmation>
             {filenameError && (
               <div className="bg-error text-error-foreground flex items-center rounded-sm border border-transparent px-[10px] py-2 text-sm leading-none font-medium">
                 <Info size={14} className="mr-1.5" />
@@ -128,11 +133,6 @@ export default function CodeCell(props: {
               cell.status === 'running' ? 'opacity-100' : '',
             )}
           >
-            <DeleteCellWithConfirmation onDeleteCell={() => onDeleteCell(cell)}>
-              <Button variant="icon" size="icon" tabIndex={1}>
-                <Trash2 size={16} />
-              </Button>
-            </DeleteCellWithConfirmation>
             {cell.status === 'running' && (
               <Button variant="run" size="default-with-icon" onClick={stopCell} tabIndex={1}>
                 <Circle size={16} /> Stop

--- a/packages/web/src/components/cells/markdown.tsx
+++ b/packages/web/src/components/cells/markdown.tsx
@@ -84,9 +84,16 @@ export default function MarkdownCell(props: {
       )}
     >
       {status === 'view' ? (
-        <div>
-          <div className="p-1 w-full h-11 hidden group-hover/cell:flex items-center justify-between z-10">
-            <h5 className="pl-2 text-sm font-mono font-bold">Markdown</h5>
+        <div className="flex flex-col">
+          <div className="p-1 w-full hidden group-hover/cell:flex items-center justify-between z-10">
+            <div className="flex items-center gap-2">
+              <h5 className="pl-2 text-sm font-mono font-bold">Markdown</h5>
+              <DeleteCellWithConfirmation onDeleteCell={() => props.onDeleteCell(cell)}>
+                <Button variant="secondary" size="icon" className="border-transparent">
+                  <Trash2 size={16} />
+                </Button>
+              </DeleteCellWithConfirmation>
+            </div>
             <div className="flex items-center gap-1">
               <Button
                 variant="secondary"
@@ -96,15 +103,9 @@ export default function MarkdownCell(props: {
               >
                 <Pencil size={16} />
               </Button>
-
-              <DeleteCellWithConfirmation onDeleteCell={() => props.onDeleteCell(cell)}>
-                <Button variant="secondary" size="icon" className="border-transparent">
-                  <Trash2 size={16} />
-                </Button>
-              </DeleteCellWithConfirmation>
             </div>
           </div>
-          <div className="sb-prose px-3 pt-11 group-hover/cell:pt-0">
+          <div className="sb-prose px-3 pt-10 group-hover/cell:pt-0">
             <Markdown>{cell.text}</Markdown>
           </div>
         </div>
@@ -118,18 +119,15 @@ export default function MarkdownCell(props: {
           )}
           <div className="flex flex-col">
             <div className="p-1 w-full flex items-center justify-between z-10">
-              <h5 className="pl-4 text-sm font-mono font-bold">Markdown</h5>
-              <div className="flex items-center gap-1">
+              <div className="flex items-center gap-2">
+                <h5 className="pl-2 text-sm font-mono font-bold">Markdown</h5>
                 <DeleteCellWithConfirmation onDeleteCell={() => props.onDeleteCell(cell)}>
-                  <Button
-                    variant="secondary"
-                    size="icon"
-                    className="border-secondary hover:border-muted"
-                  >
+                  <Button variant="secondary" size="icon" className="border-transparent">
                     <Trash2 size={16} />
                   </Button>
                 </DeleteCellWithConfirmation>
-
+              </div>
+              <div className="flex items-center gap-1">
                 <Button variant="secondary" onClick={() => setStatus('view')}>
                   Cancel
                 </Button>


### PR DESCRIPTION
Design moved the trash icon to the left. I am not sure I love it but there are UX reasons for this change. Separating this out + some other hover to click fixes before adding in the bigger AI edit-code change.