### PR TITLE
Update settings input UX

### DIFF
--- a/packages/web/src/routes/secrets.tsx
+++ b/packages/web/src/routes/secrets.tsx
@@ -26,6 +26,8 @@ function Secrets() {
   const { secrets } = useLoaderData() as { secrets: Record<string, string> };
 
   const [error, _setError] = useState<string | null>(null);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const timeoutRef = useRef<any>(null);
 
   function setError(message: string | null, clearAfter: number | null = null) {

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -15,7 +15,7 @@ export interface FsObjectResultType {
 export type SettingsType = {
   baseDir: string;
   defaultLanguage: CodeLanguageType;
-  openaiKey?: string;
+  openaiKey?: string | null;
   enabledAnalytics: boolean;
 };
 


### PR DESCRIPTION
Enabled / disabled "Save" button for openai key in settings. 

Also removes a lint warning from secrets page.