### PR TITLE
Use same loading state pattern

### DIFF
--- a/packages/web/src/components/cells/code.tsx
+++ b/packages/web/src/components/cells/code.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { useHotkeys } from 'react-hotkeys-hook';
 import CodeMirror, { keymap, Prec } from '@uiw/react-codemirror';
 import { javascript } from '@codemirror/lang-javascript';
-import { Circle, Info, Play, Trash2, Sparkles, X, MessageCircleWarning } from 'lucide-react';
+import { Info, Play, Trash2, Sparkles, X, MessageCircleWarning, LoaderCircle } from 'lucide-react';
 import TextareaAutosize from 'react-textarea-autosize';
 import AiGenerateTipsDialog from '@/components/ai-generate-tips-dialog';
 import {
@@ -231,15 +231,21 @@ export default function CodeCell(props: {
               </Button>
             )}
             {promptMode === 'generating' && (
-              <Button variant="run" className="disabled:opacity-100" disabled tabIndex={1}>
-                Generating
+              <Button
+                variant="run"
+                size="default-with-icon"
+                className="disabled:opacity-100"
+                disabled
+                tabIndex={1}
+              >
+                <LoaderCircle size={16} className="animate-spin" /> Generating
               </Button>
             )}
             {promptMode === 'off' && (
               <>
                 {cell.status === 'running' && (
                   <Button variant="run" size="default-with-icon" onClick={stopCell} tabIndex={1}>
-                    <Circle size={16} /> Stop
+                    <LoaderCircle size={16} className="animate-spin" /> Stop
                   </Button>
                 )}
                 {cell.status === 'idle' && (


### PR DESCRIPTION
The code cell "Run" and "Generate" buttons should use the same pattern for loading. Currently, the "Generate" button does not use an icon which is inconsistent and not as good imo. I also switched these to use the loading spinner that we use in other places

<img width="187" alt="Screenshot 2024-07-23 at 6 36 17 PM" src="https://github.com/user-attachments/assets/033e5022-b46c-4b73-bfb3-882b17d736a1">

<img width="245" alt="Screenshot 2024-07-23 at 6 35 59 PM" src="https://github.com/user-attachments/assets/128fd251-73ec-4a6d-a1fe-034e57e7c4bd">
