### PR TITLE
Move language to top-level attr on session

### DIFF
--- a/packages/api/ai/generate.mts
+++ b/packages/api/ai/generate.mts
@@ -34,7 +34,7 @@ const makeGenerateCellUserPrompt = (session: SessionType, insertIdx: number, que
     text: '==== INTRODUCE CELL HERE ====',
   });
 
-  const inlineSrcbookWithPlaceholder = encode(cellsWithPlaceholder, session.metadata, {
+  const inlineSrcbookWithPlaceholder = encode(cellsWithPlaceholder, session.language, {
     inline: true,
   });
 
@@ -57,7 +57,7 @@ const makeGenerateCellEditUserPrompt = (
   session: SessionType,
   cell: CodeCellType,
 ) => {
-  const inlineSrcbook = encode(session.cells, session.metadata, { inline: true });
+  const inlineSrcbook = encode(session.cells, session.language, { inline: true });
 
   const prompt = `==== BEGIN SRCBOOK ====
 ${inlineSrcbook}
@@ -129,7 +129,7 @@ export async function generateCells(
 ): Promise<GenerateCellsResult> {
   const model = await getOpenAIModel();
 
-  const systemPrompt = makeGenerateCellSystemPrompt(session.metadata.language);
+  const systemPrompt = makeGenerateCellSystemPrompt(session.language);
   const userPrompt = makeGenerateCellUserPrompt(session, insertIdx, query);
   const result = await generateText({
     model: model,
@@ -157,7 +157,7 @@ export async function generateCells(
 export async function generateCellEdit(query: string, session: SessionType, cell: CodeCellType) {
   const model = await getOpenAIModel();
 
-  const systemPrompt = makeGenerateCellEditSystemPrompt(session.metadata.language);
+  const systemPrompt = makeGenerateCellEditSystemPrompt(session.language);
   const userPrompt = makeGenerateCellEditUserPrompt(query, session, cell);
   const result = await generateText({
     model: model,

--- a/packages/api/server/http.mts
+++ b/packages/api/server/http.mts
@@ -69,7 +69,7 @@ router.post('/srcbooks', cors(), async (req, res) => {
   }
 
   try {
-    const srcbookDir = await createSrcbook(name, { language });
+    const srcbookDir = await createSrcbook(name, language);
     return res.json({ error: false, result: { name, path: srcbookDir } });
   } catch (e) {
     const error = e as unknown as Error;

--- a/packages/api/server/ws.mts
+++ b/packages/api/server/ws.mts
@@ -250,7 +250,7 @@ async function depsInstall(payload: DepsInstallPayloadType) {
 
         wss.broadcast(`session:${updatedSession.id}`, 'cell:updated', { cell: updatedCell });
 
-        if (updatedSession.metadata.language === 'typescript') {
+        if (updatedSession.language === 'typescript') {
           const mustCreateTsServer = !tsservers.has(updatedSession.id);
 
           // Make sure to handle the following case here:
@@ -304,11 +304,7 @@ async function cellCreate(payload: CellCreatePayloadType) {
   // TODO: handle potential errors
   await addCell(session, cell, index);
 
-  if (
-    session.metadata.language === 'typescript' &&
-    cell.type === 'code' &&
-    tsservers.has(session.id)
-  ) {
+  if (session.language === 'typescript' && cell.type === 'code' && tsservers.has(session.id)) {
     const tsserver = tsservers.get(session.id);
 
     tsserver.open({
@@ -385,11 +381,7 @@ async function cellUpdate(payload: CellUpdatePayloadType) {
 
   const cell = result.cell as CodeCellType;
 
-  if (
-    session.metadata.language === 'typescript' &&
-    cell.type === 'code' &&
-    tsservers.has(session.id)
-  ) {
+  if (session.language === 'typescript' && cell.type === 'code' && tsservers.has(session.id)) {
     const tsserver = tsservers.get(session.id);
 
     // This isn't intended for renaming, so the filenames
@@ -432,7 +424,7 @@ async function cellRename(payload: CellRenamePayloadType) {
   }
 
   if (
-    session.metadata.language === 'typescript' &&
+    session.language === 'typescript' &&
     cellBeforeUpdate.type === 'code' &&
     tsservers.has(session.id)
   ) {
@@ -495,7 +487,7 @@ async function cellDelete(payload: CellDeletePayloadType) {
   if (cell.type === 'code') {
     removeCodeCellFromDisk(updatedSession.dir, cell.filename);
 
-    if (updatedSession.metadata.language === 'typescript' && tsservers.has(updatedSession.id)) {
+    if (updatedSession.language === 'typescript' && tsservers.has(updatedSession.id)) {
       const file = pathToCodeFile(updatedSession.dir, cell.filename);
       const tsserver = tsservers.get(updatedSession.id);
       tsserver.close({ file });
@@ -562,7 +554,7 @@ async function tsserverStart(payload: TsServerStartPayloadType) {
     throw new Error(`No session exists for session '${payload.sessionId}'`);
   }
 
-  if (session.metadata.language !== 'typescript') {
+  if (session.language !== 'typescript') {
     throw new Error(`tsserver can only be used with TypeScript Srcbooks.`);
   }
 

--- a/packages/api/srcmd.mts
+++ b/packages/api/srcmd.mts
@@ -52,7 +52,7 @@ export async function decodeDir(dir: string): Promise<DecodeResult> {
     // Wait for all file reads to complete
     await Promise.all(pendingFileReads);
 
-    return { error: false, metadata: readmeResult.metadata, cells };
+    return { error: false, language: readmeResult.language, cells };
   } catch (e) {
     const error = e as unknown as Error;
     return { error: true, errors: [error.message] };

--- a/packages/api/srcmd/decoding.mts
+++ b/packages/api/srcmd/decoding.mts
@@ -42,7 +42,7 @@ export function decode(contents: string): DecodeResult {
   // Finally, return either the set of errors or the tokens converted to cells if no errors were found.
   return errors.length > 0
     ? { error: true, errors: errors }
-    : { error: false, metadata, cells: convertToCells(groups) };
+    : { error: false, language: metadata.language, cells: convertToCells(groups) };
 }
 
 /**
@@ -50,7 +50,7 @@ export function decode(contents: string): DecodeResult {
  *
  * For example, we generate a subset of a Srcbook (1 or more cells) using AI.
  * When that happens, we do not have the entire .src.md contents, so we need
- * to ignore some aspects of it, like parsing the metadata.
+ * to ignore some aspects of it, like parsing the srcbook metadata comment.
  */
 export function decodeCells(contents: string): DecodeCellsResult {
   const tokens = marked.lexer(contents);

--- a/packages/api/srcmd/encoding.mts
+++ b/packages/api/srcmd/encoding.mts
@@ -3,14 +3,14 @@ import type {
   MarkdownCellType,
   PackageJsonCellType,
   TitleCellType,
-  SrcbookMetadataType,
   CellWithPlaceholderType,
   PlaceholderCellType,
+  CodeLanguageType,
 } from '@srcbook/shared';
 
 export function encode(
   allCells: CellWithPlaceholderType[],
-  metadata: SrcbookMetadataType,
+  language: CodeLanguageType,
   options: { inline: boolean },
 ) {
   const [firstCell, secondCell, ...remainingCells] = allCells;
@@ -19,7 +19,7 @@ export function encode(
   const cells = remainingCells as (MarkdownCellType | CodeCellType | PlaceholderCellType)[];
 
   const encoded = [
-    `<!-- srcbook:${JSON.stringify(metadata)} -->`,
+    `<!-- srcbook:${JSON.stringify({ language })} -->`,
     encodeTitleCell(titleCell),
     encodePackageJsonCell(packageJsonCell, options),
     ...cells.map((cell) => {

--- a/packages/api/srcmd/types.mts
+++ b/packages/api/srcmd/types.mts
@@ -1,4 +1,4 @@
-import { type CellType, type SrcbookMetadataType } from '@srcbook/shared';
+import { type CellType, type CodeLanguageType } from '@srcbook/shared';
 
 export type DecodeErrorResult = {
   error: true;
@@ -8,11 +8,11 @@ export type DecodeErrorResult = {
 export type DecodeSuccessResult = {
   error: false;
   cells: CellType[];
-  metadata: SrcbookMetadataType;
+  language: CodeLanguageType;
 };
 
 // This represents the result of decoding a complete .src.md file.
 export type DecodeResult = DecodeErrorResult | DecodeSuccessResult;
 
 // This represents the result of decoding a subset of content from a .src.md file.
-export type DecodeCellsResult = DecodeErrorResult | Omit<DecodeSuccessResult, 'metadata'>;
+export type DecodeCellsResult = DecodeErrorResult | Omit<DecodeSuccessResult, 'language'>;

--- a/packages/api/test/srcmd.test.mts
+++ b/packages/api/test/srcmd.test.mts
@@ -87,7 +87,7 @@ describe('encoding and decoding srcmd files', () => {
   it('can encode cells', () => {
     const result = decode(srcmd) as DecodeSuccessResult;
     expect(result.error).toBe(false);
-    expect(encode(result.cells, result.metadata, { inline: true })).toEqual(srcmd);
+    expect(encode(result.cells, result.language, { inline: true })).toEqual(srcmd);
   });
 });
 

--- a/packages/api/types.mts
+++ b/packages/api/types.mts
@@ -1,4 +1,4 @@
-import type { CellType, SrcbookMetadataType } from '@srcbook/shared';
+import type { CellType, CodeLanguageType } from '@srcbook/shared';
 
 export type SessionType = {
   id: string;
@@ -7,7 +7,11 @@ export type SessionType = {
    */
   dir: string;
   cells: CellType[];
-  metadata: SrcbookMetadataType;
+
+  /**
+   * The language of the srcbook, i.e.: 'typescript' or 'javascript'
+   */
+  language: CodeLanguageType;
 
   /**
    * The tsconfig.json file contents.

--- a/packages/shared/src/schemas/cells.ts
+++ b/packages/shared/src/schemas/cells.ts
@@ -51,6 +51,10 @@ export const CellWithPlaceholderSchema = z.union([
   PlaceholderCellSchema,
 ]);
 
+// Used to parse metadata from a srcbook header in .src.md.
+//
+// i.e. <!-- srcbook:{"language": "javascript"} -->
+//
 export const SrcbookMetadataSchema = z.object({
   language: z.enum(['javascript', 'typescript']),
 });

--- a/packages/web/src/components/settings-sheet.tsx
+++ b/packages/web/src/components/settings-sheet.tsx
@@ -34,11 +34,11 @@ export function SettingsSheet({ session, open, onOpenChange, openDepsInstallModa
           <div className="flex items-center justify-between gap-8 text-sm">
             <h5 className="font-medium max-w-72 truncate">{title.text}</h5>
             <p className="text-tertiary-foreground">
-              {session.metadata.language === 'typescript' ? 'TypeScript' : 'JavaScript'}
+              {session.language === 'typescript' ? 'TypeScript' : 'JavaScript'}
             </p>
           </div>
           <PackageJson openDepsInstallModal={openDepsInstallModal} />
-          {session.metadata.language === 'typescript' && <TsconfigJson session={session} />}
+          {session.language === 'typescript' && <TsconfigJson session={session} />}
         </div>
       </SheetContent>
     </Sheet>

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -126,7 +126,7 @@ export default function Home() {
                   key={srcbook.id}
                   title={(srcbook.cells[0] as TitleCellType).text}
                   running={srcbook.cells.some((c) => c.type === 'code' && c.status === 'running')}
-                  language={srcbook.metadata.language}
+                  language={srcbook.language}
                   cellCount={srcbook.cells.length}
                   onClick={() => navigate(`/srcbooks/${srcbook.id}`)}
                   onDelete={() => onDeleteSrcbook(srcbook)}

--- a/packages/web/src/routes/session.tsx
+++ b/packages/web/src/routes/session.tsx
@@ -46,14 +46,14 @@ function SessionPage() {
   useEffectOnce(() => {
     channel.subscribe();
 
-    if (session.metadata.language === 'typescript') {
+    if (session.language === 'typescript') {
       channel.push('tsserver:start', { sessionId: session.id });
     }
 
     return () => {
       channel.unsubscribe();
 
-      if (session.metadata.language === 'typescript') {
+      if (session.language === 'typescript') {
         channel.push('tsserver:stop', { sessionId: session.id });
       }
     };
@@ -152,7 +152,7 @@ function Session(props: { session: SessionType; channel: SessionChannel; config:
     let cell;
     switch (type) {
       case 'code':
-        cell = createCodeCell(index, session.metadata.language);
+        cell = createCodeCell(index, session.language);
         channel.push('cell:create', { sessionId: session.id, index, cell });
         break;
       case 'markdown':
@@ -172,7 +172,7 @@ function Session(props: { session: SessionType; channel: SessionChannel; config:
       let newCell;
       switch (cell.type) {
         case 'code':
-          newCell = createCodeCell(insertIdx, session.metadata.language, cell);
+          newCell = createCodeCell(insertIdx, session.language, cell);
           break;
         case 'markdown':
           newCell = createMarkdownCell(insertIdx, cell);
@@ -213,7 +213,7 @@ function Session(props: { session: SessionType; channel: SessionChannel; config:
         {cells.map((cell, idx) => (
           <div key={cell.id}>
             <InsertCellDivider
-              language={session.metadata.language}
+              language={session.language}
               createCodeCell={() => createNewCell('code', idx + 2)}
               createMarkdownCell={() => createNewCell('markdown', idx + 2)}
               createGenerateAiCodeCell={() => createNewCell('generate-ai', idx + 2)}
@@ -252,7 +252,7 @@ function Session(props: { session: SessionType; channel: SessionChannel; config:
 
         {/* There is always an insert cell divider after the last cell */}
         <InsertCellDivider
-          language={session.metadata.language}
+          language={session.language}
           createCodeCell={() => createNewCell('code', allCells.length)}
           createMarkdownCell={() => createNewCell('markdown', allCells.length)}
           createGenerateAiCodeCell={() => createNewCell('generate-ai', allCells.length)}

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -1,4 +1,4 @@
-import { CellType, SrcbookMetadataType, CodeLanguageType } from '@srcbook/shared';
+import { CellType, CodeLanguageType } from '@srcbook/shared';
 
 export interface FsObjectType {
   path: string;
@@ -26,7 +26,7 @@ export type OutputType = StdoutOutputType | StderrOutputType;
 export type SessionType = {
   id: string;
   cells: CellType[];
-  metadata: SrcbookMetadataType;
+  language: CodeLanguageType;
   // TODO: Better typing.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   'tsconfig.json'?: Record<string, any>;


### PR DESCRIPTION
I'm working towards a better type for a srcbook object (currently called session):

```typescript
export type SessionType = {
  id: string;
  dir: string;
  cells: CellType[];
  language: CodeLanguageType;
  'package.json': Record<string, any>;
  'tsconfig.json'?: Record<string, any>;
  openedAt: number;
};
```

This PR moves language top-level and gets rid of 'metadata' which seems unnecessary with the exception of the header in .src.md. This came about because I'm trying to make tsconfig.json and package.json behave consistently (eventually) and I started thinking I'd put it in the metadata but then they really aren't metadata. However, tsconfig might be put in the "metadata" header in .src.md. So my thinking is to put everything we have today top-level in the session object and only treat the header in .src.md as "metadata".