### PR TITLE
Support node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you upgrade and are having trouble launching the application, you can `rm -rf
 
 ## Requirements
 
-Srcbook requires node v22+. We highly recommend using [nvm](https://github.com/nvm-sh/nvm) to manage local node versions.
+Srcbook requires node v20+. We highly recommend using [nvm](https://github.com/nvm-sh/nvm) to manage local node versions.
 
 ## Install
 

--- a/packages/api/session.mts
+++ b/packages/api/session.mts
@@ -325,8 +325,10 @@ async function load() {
   const loadedSessions = srcbookDirs
     .filter((entry) => entry.isDirectory())
     .map(async (entry) => {
+      // .path -> .parentPath from node21 onwards.
+      const parentPath = entry.parentPath || entry.path;
       try {
-        const session = await createSession(Path.join(entry.parentPath, entry.name));
+        const session = await createSession(Path.join(parentPath, entry.name));
         sessions[session.id] = session;
         return session;
       } catch (e) {

--- a/packages/api/utils.mts
+++ b/packages/api/utils.mts
@@ -21,9 +21,11 @@ export async function disk(dirname: string, ext: string) {
       return entry.isDirectory() || entry.name.endsWith(ext);
     })
     .map((entry) => {
+      // .path -> .parentPath from node21 onwards.
+      const parentPath = entry.parentPath || entry.path;
       return {
-        path: Path.join(entry.parentPath, entry.name),
-        dirname: entry.parentPath,
+        path: Path.join(parentPath, entry.name),
+        dirname: entry.path,
         basename: entry.name,
         isDirectory: entry.isDirectory(),
       };

--- a/srcbook/README.md
+++ b/srcbook/README.md
@@ -37,3 +37,7 @@ npm uninstall -g srcbook
 # Clear up srcbook files on disk
 rm -rf ~/.srcbook/
 ```
+
+## Requirements
+
+Srcbook requires node v20+. We highly recommend using [nvm](https://github.com/nvm-sh/nvm) to manage local node versions.


### PR DESCRIPTION
Users have expressed desire to support earlier versions of node. This commit makes srcbook backwards and forwards compatible with 20+

## testing
tested with node 20 and 22.

