### PR TITLE
Add visual indicator that tsconfig was updated

### DIFF
--- a/packages/api/server/ws.mts
+++ b/packages/api/server/ws.mts
@@ -52,6 +52,7 @@ import {
   TsServerCellDiagnosticsPayloadSchema,
   CellCreatePayloadSchema,
   TsConfigUpdatePayloadSchema,
+  TsConfigUpdatedPayloadSchema,
 } from '@srcbook/shared';
 import tsservers from '../tsservers.mjs';
 import { TsServer } from '../tsserver/tsserver.mjs';
@@ -584,6 +585,10 @@ async function tsconfigUpdate(payload: TsConfigUpdatePayloadType) {
     tsserver.reloadProjects();
     requestAllDiagnostics(tsserver, updatedSession);
   }
+
+  wss.broadcast(`session:${updatedSession.id}`, 'tsconfig.json:updated', {
+    source: payload.source,
+  });
 }
 
 wss
@@ -605,6 +610,7 @@ wss
   .outgoing('cell:output', CellOutputPayloadSchema)
   .outgoing('ai:generated', AiGeneratedCellPayloadSchema)
   .outgoing('deps:validate:response', DepsValidateResponsePayloadSchema)
-  .outgoing('tsserver:cell:diagnostics', TsServerCellDiagnosticsPayloadSchema);
+  .outgoing('tsserver:cell:diagnostics', TsServerCellDiagnosticsPayloadSchema)
+  .outgoing('tsconfig.json:updated', TsConfigUpdatedPayloadSchema);
 
 export default wss;

--- a/packages/shared/src/schemas/websockets.ts
+++ b/packages/shared/src/schemas/websockets.ts
@@ -106,3 +106,7 @@ export const TsConfigUpdatePayloadSchema = z.object({
   sessionId: z.string(),
   source: z.string(),
 });
+
+export const TsConfigUpdatedPayloadSchema = z.object({
+  source: z.string(),
+});

--- a/packages/shared/src/types/websockets.ts
+++ b/packages/shared/src/types/websockets.ts
@@ -19,6 +19,7 @@ import {
   TsServerStopPayloadSchema,
   TsServerCellDiagnosticsPayloadSchema,
   TsConfigUpdatePayloadSchema,
+  TsConfigUpdatedPayloadSchema,
 } from '../schemas/websockets.js';
 
 export type CellExecPayloadType = z.infer<typeof CellExecPayloadSchema>;
@@ -45,3 +46,4 @@ export type TsServerCellDiagnosticsPayloadType = z.infer<
 >;
 
 export type TsConfigUpdatePayloadType = z.infer<typeof TsConfigUpdatePayloadSchema>;
+export type TsConfigUpdatedPayloadType = z.infer<typeof TsConfigUpdatedPayloadSchema>;

--- a/packages/web/src/clients/websocket/index.ts
+++ b/packages/web/src/clients/websocket/index.ts
@@ -17,6 +17,7 @@ import {
   TsServerCellDiagnosticsPayloadSchema,
   CellRenamePayloadSchema,
   TsConfigUpdatePayloadSchema,
+  TsConfigUpdatedPayloadSchema,
 } from '@srcbook/shared';
 
 import Channel from '@/clients/websocket/channel';
@@ -33,6 +34,7 @@ const IncomingSessionEvents = {
   'deps:validate:response': DepsValidateResponsePayloadSchema,
   'tsserver:cell:diagnostics': TsServerCellDiagnosticsPayloadSchema,
   'ai:generated': AiGeneratedCellPayloadSchema,
+  'tsconfig.json:updated': TsConfigUpdatedPayloadSchema,
 };
 
 const OutgoingSessionEvents = {

--- a/packages/web/src/components/session-menu.tsx
+++ b/packages/web/src/components/session-menu.tsx
@@ -3,6 +3,7 @@ import { cn } from '@/lib/utils';
 import { useHotkeys } from 'react-hotkeys-hook';
 import type { Tokens } from 'marked';
 import { useState } from 'react';
+import { SessionChannel } from '@/clients/websocket';
 import {
   Upload,
   Trash2,
@@ -35,6 +36,7 @@ type Props = {
   showSettings: boolean;
   setShowSettings: (value: boolean) => void;
   openDepsInstallModal: () => void;
+  channel: SessionChannel;
 };
 
 marked.use({ gfm: true });
@@ -65,6 +67,7 @@ export default function SessionMenu({
   showSettings,
   setShowSettings,
   openDepsInstallModal,
+  channel,
 }: Props) {
   const [showShortcuts, setShowShortcuts] = useState(false);
   const [showFeedback, setShowFeedback] = useState(false);
@@ -169,6 +172,7 @@ export default function SessionMenu({
         onOpenChange={setShowSettings}
         openDepsInstallModal={openDepsInstallModal}
         session={session}
+        channel={channel}
       />
       <div className="fixed xl:hidden top-[100px] left-6 group z-20">
         <NavigationMenu>

--- a/packages/web/src/components/use-tsconfig-json.tsx
+++ b/packages/web/src/components/use-tsconfig-json.tsx
@@ -27,7 +27,7 @@ type ProviderPropsType = {
 };
 
 /**
- * An interface for working with tsconifg.json.
+ * An interface for working with tsconfig.json.
  */
 export function TsConfigProvider({ channel, session, children }: ProviderPropsType) {
   const [source, setSource] = useState(session['tsconfig.json'] || '');

--- a/packages/web/src/routes/session.tsx
+++ b/packages/web/src/routes/session.tsx
@@ -207,6 +207,7 @@ function Session(props: { session: SessionType; channel: SessionChannel; config:
         setShowSettings={setShowSettings}
         session={session}
         openDepsInstallModal={() => setDepsInstallModalOpen(true)}
+        channel={channel}
       />
 
       {/* At the xl breakpoint, the sessionMenu appears inline so we pad left to balance*/}


### PR DESCRIPTION
Added a response message, which powers a visual indicator that tsconfig was updated.

Note: I debated adding a more generic `<sessionId>:notification` message type, which could send a code or something down, since adding all the @srcbook/shared types feels super heavy just for such a basic interaction... but stuck with existing patterns for now.

![CleanShot 2024-08-01 at 16 36 50](https://github.com/user-attachments/assets/68b8d994-f3fb-4ef8-aa52-783c661352ce)
