### PR TITLE
Add purple colors and 'Use AI in Srcbook nudge'

### DIFF
--- a/packages/web/src/components/session-menu.tsx
+++ b/packages/web/src/components/session-menu.tsx
@@ -37,6 +37,7 @@ type Props = {
   setShowSettings: (value: boolean) => void;
   openDepsInstallModal: () => void;
   channel: SessionChannel;
+  aiEnabled: boolean;
 };
 
 marked.use({ gfm: true });
@@ -68,6 +69,7 @@ export default function SessionMenu({
   setShowSettings,
   openDepsInstallModal,
   channel,
+  aiEnabled,
 }: Props) {
   const [showShortcuts, setShowShortcuts] = useState(false);
   const [showFeedback, setShowFeedback] = useState(false);
@@ -173,6 +175,7 @@ export default function SessionMenu({
         openDepsInstallModal={openDepsInstallModal}
         session={session}
         channel={channel}
+        aiEnabled={aiEnabled}
       />
       <div className="fixed xl:hidden top-[100px] left-6 group z-20">
         <NavigationMenu>

--- a/packages/web/src/components/settings-sheet.tsx
+++ b/packages/web/src/components/settings-sheet.tsx
@@ -1,11 +1,11 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { SessionType } from '@/types';
 import { TitleCellType, TsConfigUpdatedPayloadType } from '@srcbook/shared';
 import { useCells } from './use-cell';
-import { ChevronRight, Info, LoaderCircle, Play } from 'lucide-react';
+import { ChevronRight, X, Info, LoaderCircle, Play } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { useState } from 'react';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import CodeMirror, { keymap, Prec } from '@uiw/react-codemirror';
 import { json } from '@codemirror/lang-json';
@@ -21,6 +21,7 @@ type PropsType = {
   onOpenChange: (value: boolean) => void;
   openDepsInstallModal: () => void;
   channel: SessionChannel;
+  aiEnabled: boolean;
 };
 
 export function SettingsSheet({
@@ -29,8 +30,11 @@ export function SettingsSheet({
   onOpenChange,
   openDepsInstallModal,
   channel,
+  aiEnabled,
 }: PropsType) {
   const { cells } = useCells();
+  const navigate = useNavigate();
+  const [showAiNudge, setShowAiNudge] = useState(!aiEnabled);
 
   const title = cells.find((cell) => cell.type === 'title') as TitleCellType;
 
@@ -38,6 +42,28 @@ export function SettingsSheet({
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent side="left" className="pt-12">
         <SheetHeader>
+          {showAiNudge && (
+            <div className="relative flex flex-col px-3 py-3.5 border border-ai-border bg-ai text-ai-foreground rounded-sm text-sm">
+              <div
+                className="absolute top-2 right-2 cursor-pointer text-sb-purple-60"
+                onClick={() => setShowAiNudge(false)}
+              >
+                <X size={16} />
+              </div>
+              <h2 className="font-bold">Use AI in Srcbook</h2>
+              <p>
+                AI features not enabled. To enable them, set up in{' '}
+                <a
+                  className="font-medium underline cursor-pointer"
+                  onClick={() => navigate('/settings')}
+                >
+                  {' '}
+                  global settings
+                </a>
+                .
+              </p>
+            </div>
+          )}
           <SheetTitle className="font-bold">Settings</SheetTitle>
         </SheetHeader>
         <div className="text-foreground mt-2 space-y-6">

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -50,6 +50,11 @@
     --sb-blue-60: 202 100% 40%;
     --sb-blue-70: 202 100% 30%;
     --sb-blue-80: 202 100% 20%;
+
+    --sb-purple-10: 270 62% 96%;
+    --sb-purple-20: 270 78% 91%;
+    --sb-purple-60: 270 42% 57%;
+    --sb-purple-80: 277 38% 38%;
   }
 
   :root {
@@ -57,6 +62,9 @@
     --secondary-hover: var(--sb-core-80);
     --tertiary: var(--sb-core-0);
     --tertiary-foreground: var(--sb-core-60);
+    --ai: var(--sb-purple-10);
+    --ai-foreground: var(--sb-purple-80);
+    --ai-border: var(--sb-purple-20);
     --run: var(--sb-yellow-50);
     --run-foreground: var(--sb-core-100);
     --run-ring: var(--sb-yellow-50);
@@ -73,6 +81,9 @@
     --secondary-hover: var(--sb-core-30);
     --tertiary: var(--sb-core-130);
     --tertiary-foreground: var(--sb-core-60);
+    --ai: var(--sb-purple-10);
+    --ai-foreground: var(--sb-purple-80);
+    --ai-border: var(--sb-purple-20);
     --run: var(--sb-yellow-50);
     --run-foreground: var(--sb-core-100);
     --run-ring: var(--sb-yellow-50);

--- a/packages/web/src/routes/session.tsx
+++ b/packages/web/src/routes/session.tsx
@@ -208,6 +208,7 @@ function Session(props: { session: SessionType; channel: SessionChannel; config:
         session={session}
         openDepsInstallModal={() => setDepsInstallModalOpen(true)}
         channel={channel}
+        aiEnabled={!!props.config.openaiKey}
       />
 
       {/* At the xl breakpoint, the sessionMenu appears inline so we pad left to balance*/}

--- a/packages/web/tailwind.config.js
+++ b/packages/web/tailwind.config.js
@@ -94,6 +94,11 @@ module.exports = {
           DEFAULT: 'hsl(var(--warning))',
           foreground: 'hsl(var(--warning-foreground))',
         },
+        ai: {
+          DEFAULT: 'hsl(var(--ai))',
+          foreground: 'hsl(var(--ai-foreground))',
+          border: 'hsl(var(--ai-border))',
+        },
         sb: {
           'core-0': 'hsl(var(--sb-core-0))',
           'core-10': 'hsl(var(--sb-core-10))',
@@ -139,6 +144,11 @@ module.exports = {
           'blue-60': 'hsl(var(--sb-blue-60))',
           'blue-70': 'hsl(var(--sb-blue-70))',
           'blue-80': 'hsl(var(--sb-blue-80))',
+
+          'purple-10': 'hsl(var(--sb-purple-10))',
+          'purple-20': 'hsl(var(--sb-purple-20))',
+          'purple-60': 'hsl(var(--sb-purple-60))',
+          'purple-80': 'hsl(var(--sb-purple-80))',
         },
       },
       dropShadow: {


### PR DESCRIPTION
Following designs, but only had light mode in the design file.
I'm therefore following the pattern that we have for `error` and `warning` colors, which are stable in light/dark mode (I believe that this is how the design system works).
![CleanShot 2024-08-05 at 18 17 53](https://github.com/user-attachments/assets/c555dcd2-7246-4e4a-b674-99628b15463d)
![CleanShot 2024-08-05 at 18 18 00](https://github.com/user-attachments/assets/0fd25c2e-7015-42e0-ab36-55e1d9321517)
