### PR TITLE
Add full screen modal for code and output editing with resizable panels

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,6 +43,7 @@
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
     "react-hotkeys-hook": "^4.5.0",
+    "react-resizable-panels": "^2.0.22",
     "react-router-dom": "^6.23.0",
     "react-textarea-autosize": "^8.5.3",
     "sonner": "^1.4.41",

--- a/packages/web/src/components/cell-output.tsx
+++ b/packages/web/src/components/cell-output.tsx
@@ -23,16 +23,17 @@ export function CellOutput({ cell, show, setShow, fullscreen }: PropsType) {
   const diagnostics = getTsServerDiagnostics(cell.id);
 
   return (
-    <div className="font-mono text-sm relative">
+    <div className={cn('font-mono text-sm', fullscreen && !show && 'border-b')}>
       <Tabs
         value={activeTab}
         onValueChange={(value) => setActiveTab(value as 'stdout' | 'stderr' | 'problems')}
+        defaultValue="stdout"
       >
         <div
           className={cn(
-            'border-t px-3 flex items-center justify-between bg-muted text-tertiary-foreground rounded-md',
+            'border-t px-3 flex items-center justify-between bg-muted text-tertiary-foreground rounded-b-md',
             show && 'border-b rounded-none',
-            fullscreen && 'sticky top-0',
+            fullscreen && 'sticky top-0 border-t',
           )}
         >
           <TabsList className={cn('h-full', !show && '')}>

--- a/packages/web/src/components/cells/code.tsx
+++ b/packages/web/src/components/cells/code.tsx
@@ -204,6 +204,7 @@ export default function CodeCell(props: {
             setFilenameError={setFilenameError}
             fullscreen={fullscreen}
             setFullscreen={setFullscreen}
+            setShowStdio={setShowStdio}
           />
 
           {promptMode === 'reviewing' ? (
@@ -215,11 +216,7 @@ export default function CodeCell(props: {
             />
           ) : (
             <ResizablePanelGroup direction="vertical">
-              <ResizablePanel
-                className="overflow-scroll"
-                style={{ overflow: 'scroll' }}
-                defaultSize={60}
-              >
+              <ResizablePanel style={{ overflow: 'scroll' }} defaultSize={60}>
                 <div className={cn(promptMode !== 'off' && 'opacity-50')}>
                   <CodeEditor
                     cell={cell}
@@ -230,12 +227,8 @@ export default function CodeCell(props: {
                 </div>
               </ResizablePanel>
 
-              <ResizableHandle withHandle />
-              <ResizablePanel
-                className="overflow-scroll"
-                defaultSize={40}
-                style={{ overflow: 'scroll' }}
-              >
+              <ResizableHandle withHandle className="border-none" />
+              <ResizablePanel defaultSize={40} style={{ overflow: 'scroll' }}>
                 <CellOutput cell={cell} show={showStdio} setShow={setShowStdio} fullscreen />
               </ResizablePanel>
             </ResizablePanelGroup>
@@ -267,6 +260,7 @@ export default function CodeCell(props: {
             setFilenameError={setFilenameError}
             fullscreen={fullscreen}
             setFullscreen={setFullscreen}
+            setShowStdio={setShowStdio}
           />
 
           {promptMode === 'reviewing' ? (
@@ -306,6 +300,7 @@ function Header(props: {
   setFilenameError: (error: string | null) => void;
   fullscreen: boolean;
   setFullscreen: (open: boolean) => void;
+  setShowStdio: (open: boolean) => void;
   generate: () => void;
   prompt: string;
   setPrompt: (prompt: string) => void;
@@ -322,6 +317,7 @@ function Header(props: {
     setFilenameError,
     fullscreen,
     setFullscreen,
+    setShowStdio,
     generate,
     prompt,
     setPrompt,
@@ -371,7 +367,11 @@ function Header(props: {
                 <Button
                   variant="icon"
                   size="icon"
-                  onClick={() => setFullscreen(!fullscreen)}
+                  onClick={() => {
+                    // Open stdout drawer in fullscreen mode.
+                    if (!fullscreen) setShowStdio(true);
+                    setFullscreen(!fullscreen);
+                  }}
                   tabIndex={1}
                 >
                   {fullscreen ? <Minimize size={16} /> : <Maximize size={16} />}

--- a/packages/web/src/components/ui/dialog.tsx
+++ b/packages/web/src/components/ui/dialog.tsx
@@ -29,8 +29,8 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { hideClose?: boolean }
+>(({ className, children, hideClose, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -42,10 +42,12 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <Cross2Icon className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      {!hideClose && (
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <Cross2Icon className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      )}
     </DialogPrimitive.Content>
   </DialogPortal>
 ));

--- a/packages/web/src/components/ui/resizable.tsx
+++ b/packages/web/src/components/ui/resizable.tsx
@@ -1,0 +1,40 @@
+import { DragHandleDots2Icon } from '@radix-ui/react-icons';
+import * as ResizablePrimitive from 'react-resizable-panels';
+
+import { cn } from '@/lib/utils';
+
+const ResizablePanelGroup = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) => (
+  <ResizablePrimitive.PanelGroup
+    className={cn('flex h-full w-full data-[panel-group-direction=vertical]:flex-col', className)}
+    {...props}
+  />
+);
+
+const ResizablePanel = ResizablePrimitive.Panel;
+
+const ResizableHandle = ({
+  withHandle,
+  className,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+  withHandle?: boolean;
+}) => (
+  <ResizablePrimitive.PanelResizeHandle
+    className={cn(
+      'relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90',
+      className,
+    )}
+    {...props}
+  >
+    {withHandle && (
+      <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm border bg-border">
+        <DragHandleDots2Icon className="h-2.5 w-2.5" />
+      </div>
+    )}
+  </ResizablePrimitive.PanelResizeHandle>
+);
+
+export { ResizablePanelGroup, ResizablePanel, ResizableHandle };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       react-hotkeys-hook:
         specifier: ^4.5.0
         version: 4.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-resizable-panels:
+        specifier: ^2.0.22
+        version: 2.0.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom:
         specifier: ^6.23.0
         version: 6.23.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3675,6 +3678,12 @@ packages:
       '@types/react':
         optional: true
 
+  react-resizable-panels@2.0.22:
+    resolution: {integrity: sha512-G8x8o7wjQxCG+iF4x4ngKVBpe0CY+DAZ/SaiDoqBEt0yuKJe9OE/VVYMBMMugQ3GyQ65NnSJt23tujlaZZe75A==}
+    peerDependencies:
+      react: ^16.14.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0
+
   react-router-dom@6.23.1:
     resolution: {integrity: sha512-utP+K+aSTtEdbWpC+4gxhdlPFwuEfDKq8ZrPFU65bbRJY+l706qjR7yaidBpo3MSeA/fzwbXWbKBI6ftOnP3OQ==}
     engines: {node: '>=14.0.0'}
@@ -5698,7 +5707,7 @@ snapshots:
 
   '@types/node-fetch@2.6.11':
     dependencies:
-      '@types/node': 18.19.43
+      '@types/node': 20.14.2
       form-data: 4.0.0
     optional: true
 
@@ -7559,6 +7568,11 @@ snapshots:
       use-sidecar: 1.1.2(@types/react@18.3.3)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.3
+
+  react-resizable-panels@2.0.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-router-dom@6.23.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:


### PR DESCRIPTION
Client side only change. Used a shadCN dialog, and the `Resizable` shadCN component, based on [react-resizable-panels](https://github.com/bvaughn/react-resizable-panels).

It was a little finnicky to get the scrolling behavior working, so make sure to QA that part if you make changes (you should be able to scroll both resizable areas and the tab group should remain where it is (uses tailwind's lovely `sticky` property).

Tested with AI & light/dark mode. Here's a video showing the experience:

https://github.com/user-attachments/assets/51c40321-61f8-4586-a920-503f5e63ba91

