### PR TITLE
Improve diff visuals

### DIFF
--- a/packages/web/src/components/cells/code.tsx
+++ b/packages/web/src/components/cells/code.tsx
@@ -556,6 +556,7 @@ function DiffEditor({
           unifiedMergeView({
             original: original,
             mergeControls: false,
+            highlightChanges: false,
           }),
         ]}
       />

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -372,6 +372,15 @@
   text-decoration: none;
 }
 
+.cm-editor .cm-deletedChunk {
+  background-color: rgba(248, 81, 73, 0.15);
+}
+
+.cm-editor.cm-merge-a .cm-changedLine,
+.cm-editor.cm-merge-b .cm-changedLine {
+  background-color: rgba(46, 160, 67, 0.15);
+}
+
 .cm-editor * {
   font-family: 'IBM Plex Mono', ui-monospace, 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas',
     'Liberation Mono', 'Courier New', 'monospace';


### PR DESCRIPTION
The colors have been bothering me, as well as the underlined code. This is an improvement, but we can likely improve further...

Could not used figma designs as they do not have a dark mode and don't support transparency, so instead i took github's values.

Did not yet separate light and dark mode, I think it looks alright for now.

## Before and after
![CleanShot 2024-08-08 at 11 28 26](https://github.com/user-attachments/assets/19124a60-6f46-4172-bf7e-7492e0e8ce2b)
![CleanShot 2024-08-08 at 11 27 07](https://github.com/user-attachments/assets/5f5b8627-2ca2-41ab-96a6-9cbef4141d09)
![CleanShot 2024-08-08 at 11 28 13](https://github.com/user-attachments/assets/75dfb005-6d1f-4820-b8de-16552b09cb47)
![CleanShot 2024-08-08 at 11 27 26](https://github.com/user-attachments/assets/c9944dba-a300-4cae-a11d-1b1729c0f8a8)
