### PR TITLE
Add auto-fix diagnostics with AI feature

### DIFF
--- a/packages/api/prompts/fix-cell-diagnostics.txt
+++ b/packages/api/prompts/fix-cell-diagnostics.txt
@@ -1,0 +1,16 @@
+You are tasked with suggesting a bug fix to a code block (or "cell") in a Srcbook.
+
+A Srcbook is a TypeScript notebook which follows a markdown-compatible format.
+
+The user is already working on an existing Srcbook, and the TypeScript linter has flagged an issue in one of the cells.
+
+You will be given:
+ * the entire Srcbook as useful context
+ * the specific code cell that needs to be fixed
+ * the diagnostics output from tsserver
+
+The user's Srcbook will be passed to you, surrounded with "==== BEGIN SRCBOOK ====" and "==== END SRCBOOK ====".
+The specific code cell they want updated will also be passed to you, surrounded with "==== BEGIN CODE CELL ====" and "==== END CODE CELL ====".
+The linter's diagnostics output will be passed to you, surrounded with "==== BEGIN DIAGNOSTICS ====" and "==== END DIAGNOSTICS ====".
+Your job is to fix the issues and suggest new code for the cell. Your response will be fed to a diffing algorithm and presented to the user, so you have to replace all of the code in the cell.
+ONLY RETURN THE CODE. NO PREAMBULE, NO BACKTICKS, NO MARKDOWN, NO SUFFIX, ONLY THE TYPESCRIPT CODE.

--- a/packages/api/prompts/fix-cell-diagnostics.txt
+++ b/packages/api/prompts/fix-cell-diagnostics.txt
@@ -1,16 +1,13 @@
-You are tasked with suggesting a bug fix to a code block (or "cell") in a Srcbook.
+You are tasked with suggesting a TypeScript diagnostics fix to a code block (or "cell") in a Srcbook.
 
 A Srcbook is a TypeScript notebook which follows a markdown-compatible format.
 
 The user is already working on an existing Srcbook, and the TypeScript linter has flagged an issue in one of the cells.
 
 You will be given:
- * the entire Srcbook as useful context
- * the specific code cell that needs to be fixed
- * the diagnostics output from tsserver
+ * the entire Srcbook as useful context, surrounded with "==== BEGIN SRCBOOK ====" and "==== END SRCBOOK ====".
+ * the specific code cell that needs to be fixed, surrounded with "==== BEGIN CODE CELL ====" and "==== END CODE CELL ====".
+ * the diagnostics output from tsserver, surrounded with "==== BEGIN DIAGNOSTICS ====" and "==== END DIAGNOSTICS ====".
 
-The user's Srcbook will be passed to you, surrounded with "==== BEGIN SRCBOOK ====" and "==== END SRCBOOK ====".
-The specific code cell they want updated will also be passed to you, surrounded with "==== BEGIN CODE CELL ====" and "==== END CODE CELL ====".
-The linter's diagnostics output will be passed to you, surrounded with "==== BEGIN DIAGNOSTICS ====" and "==== END DIAGNOSTICS ====".
-Your job is to fix the issues and suggest new code for the cell. Your response will be fed to a diffing algorithm and presented to the user, so you have to replace all of the code in the cell.
+Your job is to fix the issues and suggest new code for the cell. Your response will be fed to a diffing algorithm against the original cell code, so you *have* to replace all of the code in the cell.
 ONLY RETURN THE CODE. NO PREAMBULE, NO BACKTICKS, NO MARKDOWN, NO SUFFIX, ONLY THE TYPESCRIPT CODE.

--- a/packages/shared/src/schemas/websockets.ts
+++ b/packages/shared/src/schemas/websockets.ts
@@ -37,6 +37,12 @@ export const AiGenerateCellPayloadSchema = z.object({
   prompt: z.string(),
 });
 
+export const AiFixDiagnosticsPayloadSchema = z.object({
+  sessionId: z.string(),
+  cellId: z.string(),
+  diagnostics: z.string(),
+});
+
 export const CellRenamePayloadSchema = z.object({
   sessionId: z.string(),
   cellId: z.string(),

--- a/packages/shared/src/types/websockets.ts
+++ b/packages/shared/src/types/websockets.ts
@@ -20,6 +20,7 @@ import {
   TsServerCellDiagnosticsPayloadSchema,
   TsConfigUpdatePayloadSchema,
   TsConfigUpdatedPayloadSchema,
+  AiFixDiagnosticsPayloadSchema,
 } from '../schemas/websockets.js';
 
 export type CellExecPayloadType = z.infer<typeof CellExecPayloadSchema>;
@@ -32,6 +33,7 @@ export type CellDeletePayloadType = z.infer<typeof CellDeletePayloadSchema>;
 export type CellOutputPayloadType = z.infer<typeof CellOutputPayloadSchema>;
 export type AiGenerateCellPayloadType = z.infer<typeof AiGenerateCellPayloadSchema>;
 export type AiGeneratedCellPayloadType = z.infer<typeof AiGeneratedCellPayloadSchema>;
+export type AiFixDiagnosticsPayloadType = z.infer<typeof AiFixDiagnosticsPayloadSchema>;
 
 export type DepsInstallPayloadType = z.infer<typeof DepsInstallPayloadSchema>;
 export type DepsValidateResponsePayloadType = z.infer<typeof DepsValidateResponsePayloadSchema>;

--- a/packages/web/src/clients/websocket/index.ts
+++ b/packages/web/src/clients/websocket/index.ts
@@ -18,6 +18,7 @@ import {
   CellRenamePayloadSchema,
   TsConfigUpdatePayloadSchema,
   TsConfigUpdatedPayloadSchema,
+  AiFixDiagnosticsPayloadSchema,
 } from '@srcbook/shared';
 
 import Channel from '@/clients/websocket/channel';
@@ -45,6 +46,7 @@ const OutgoingSessionEvents = {
   'cell:rename': CellRenamePayloadSchema,
   'cell:delete': CellDeletePayloadSchema,
   'ai:generate': AiGenerateCellPayloadSchema,
+  'ai:fix_diagnostics': AiFixDiagnosticsPayloadSchema,
   'deps:install': DepsInstallPayloadSchema,
   'deps:validate': DepsValidatePayloadSchema,
   'tsserver:start': TsServerStartPayloadSchema,

--- a/packages/web/src/components/cells/code.tsx
+++ b/packages/web/src/components/cells/code.tsx
@@ -56,6 +56,7 @@ export default function CodeCell(props: {
   const [filenameError, _setFilenameError] = useState<string | null>(null);
   const [showStdio, setShowStdio] = useState(false);
   const [cellMode, setCellMode] = useState<CellModeType>('off');
+  const [generationType, setGenerationType] = useState<'edit' | 'fix'>('edit');
   const [prompt, setPrompt] = useState('');
   const [newSource, setNewSource] = useState('');
   const [fullscreen, setFullscreen] = useState(false);
@@ -131,6 +132,7 @@ export default function CodeCell(props: {
   }, [cell.id, channel]);
 
   const generate = () => {
+    setGenerationType('edit');
     channel.push('ai:generate', {
       sessionId: session.id,
       cellId: cell.id,
@@ -141,6 +143,7 @@ export default function CodeCell(props: {
 
   const aiFixDiagnostics = (diagnostics: string) => {
     setCellMode('fixing');
+    setGenerationType('fix');
     channel.push('ai:fix_diagnostics', { sessionId: session.id, cellId: cell.id, diagnostics });
   };
 
@@ -170,8 +173,7 @@ export default function CodeCell(props: {
   }
 
   function onRevertDiff() {
-    // TODO fix me, what about reverting a fix diff?
-    setCellMode('prompting');
+    setCellMode(generationType === 'edit' ? 'prompting' : 'off');
     setNewSource('');
   }
 

--- a/packages/web/src/components/ui/button.tsx
+++ b/packages/web/src/components/ui/button.tsx
@@ -13,6 +13,7 @@ const buttonVariants = cva(
           'bg-primary border border-primary text-primary-foreground hover:bg-primary-hover disabled:opacity-100 disabled:bg-muted disabled:text-muted-foreground disabled:border-muted-foreground',
         destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         run: 'bg-run text-run-foreground border border-run hover:bg-sb-yellow-30',
+        ai: 'bg-ai text-ai-foreground border border-ai-border hover:bg-ai/90',
         secondary:
           'bg-secondary text-secondary-foreground border border-border hover:bg-muted hover:text-secondary-hover',
         link: 'text-primary underline-offset-4 hover:underline',


### PR DESCRIPTION
Ability to one click get a diff with a fix for Diagnostics.

I did not have designs for this. 
Happy to iterate if you have suggestions, but I think we can merge for a couple of reasons:
- good to get the feature out to start testing it and using it
- it's hidden in the diagnostics tab

I reused the purple color which Justin suggested we use for the AI features. I think this is a good idea, although it needs some improvements in dark mode.

I have QA'd the feature a little but it's hard to know what accuracy the prompt has without more rigorous eval testing.

## Video of the experience

https://github.com/user-attachments/assets/1adc3950-54f8-4436-ba30-db03eab7af4a

## Notes

 - The state on the code cell is getting intense. Refactoring leads to bugs, which is a smell 
 - I reused a websocket message for the diff mechanism. Did not add a new message because it felt that it's the same mechanism of the AI suggesting a diff. Had to add a tiny bit of state since the behavior on revert is slightly different for a diagnostics fix vs an 'ai edit'.
 - Renamed some of the state vars in code.tsx, which I think is an improvement
