### PR TITLE
Specify required Node.js version

### DIFF
--- a/srcbook/package.json
+++ b/srcbook/package.json
@@ -31,5 +31,8 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
# Description

Improve error message when the Node.js version is incorrect.

https://x.com/faisalilaiwi/status/1823177420247310543
![image](https://github.com/user-attachments/assets/1d21b2b5-2abe-43a2-af09-5cde3c775814)

I had a similar issue when trying to run `pnpm run start` within the `srcbook` repo locally:
![Screenshot 2024-08-13 at 7 49 21 AM](https://github.com/user-attachments/assets/20b6f5ed-7469-4886-9e4d-a19f5a683c7b)

# After 
![Screenshot 2024-08-13 at 7 51 39 AM](https://github.com/user-attachments/assets/70f3a67e-4eb8-4d4f-a596-fe54ee25eb6e)

When you use the correct Node.js version:
![Screenshot 2024-08-13 at 7 52 04 AM](https://github.com/user-attachments/assets/59344732-6b2f-4f6f-820b-177291258214)

