### PR TITLE
Support openai-compatible ai providers. Ability to pick AI models

### DIFF
--- a/packages/api/ai/config.mts
+++ b/packages/api/ai/config.mts
@@ -1,0 +1,44 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { getConfig } from '../config.mjs';
+import type { LanguageModel } from 'ai';
+import { AiProvider, getDefaultModel, type AiProviderType } from '@srcbook/shared';
+
+/**
+ * Get the correct client and model configuration.
+ * Throws an error if the given API key is not set in the settings.
+ */
+export async function getModel(): Promise<LanguageModel> {
+  const config = await getConfig();
+  const { aiModel, aiProvider } = config;
+  const model = aiModel || getDefaultModel(aiProvider as AiProviderType);
+  switch (aiProvider as AiProviderType) {
+    case 'openai':
+      if (!config.openaiKey) {
+        throw new Error('OpenAI API key is not set');
+      }
+
+      const openai = createOpenAI({
+        compatibility: 'strict', // strict mode, enabled when using the OpenAI API
+        apiKey: config.openaiKey,
+      });
+
+      return openai(model);
+    case 'anthropic':
+      if (!config.anthropicKey) {
+        throw new Error('Anthropic API key is not set');
+      }
+      const anthropic = createAnthropic({
+        apiKey: config.anthropicKey,
+      });
+
+      return anthropic(model);
+
+    case 'local':
+      const openaiCompatible = createOpenAI({
+        compatibility: 'compatible',
+        apiKey: 'bogus', // required but unused
+      });
+      return openaiCompatible(model);
+  }
+}

--- a/packages/api/ai/config.mts
+++ b/packages/api/ai/config.mts
@@ -34,7 +34,7 @@ export async function getModel(): Promise<LanguageModel> {
 
       return anthropic(model);
 
-    case 'local':
+    case 'custom':
       if (typeof aiBaseUrl !== 'string') {
         throw new Error('Local AI base URL is not set');
       }

--- a/packages/api/ai/config.mts
+++ b/packages/api/ai/config.mts
@@ -17,21 +17,17 @@ export async function getModel(): Promise<LanguageModel> {
       if (!config.openaiKey) {
         throw new Error('OpenAI API key is not set');
       }
-
       const openai = createOpenAI({
         compatibility: 'strict', // strict mode, enabled when using the OpenAI API
         apiKey: config.openaiKey,
       });
-
       return openai(model);
+
     case 'anthropic':
       if (!config.anthropicKey) {
         throw new Error('Anthropic API key is not set');
       }
-      const anthropic = createAnthropic({
-        apiKey: config.anthropicKey,
-      });
-
+      const anthropic = createAnthropic({ apiKey: config.anthropicKey });
       return anthropic(model);
 
     case 'custom':

--- a/packages/api/ai/config.mts
+++ b/packages/api/ai/config.mts
@@ -2,7 +2,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { getConfig } from '../config.mjs';
 import type { LanguageModel } from 'ai';
-import { AiProvider, getDefaultModel, type AiProviderType } from '@srcbook/shared';
+import { getDefaultModel, type AiProviderType } from '@srcbook/shared';
 
 /**
  * Get the correct client and model configuration.
@@ -10,7 +10,7 @@ import { AiProvider, getDefaultModel, type AiProviderType } from '@srcbook/share
  */
 export async function getModel(): Promise<LanguageModel> {
   const config = await getConfig();
-  const { aiModel, aiProvider } = config;
+  const { aiModel, aiProvider, aiBaseUrl } = config;
   const model = aiModel || getDefaultModel(aiProvider as AiProviderType);
   switch (aiProvider as AiProviderType) {
     case 'openai':
@@ -35,9 +35,13 @@ export async function getModel(): Promise<LanguageModel> {
       return anthropic(model);
 
     case 'local':
+      if (typeof aiBaseUrl !== 'string') {
+        throw new Error('Local AI base URL is not set');
+      }
       const openaiCompatible = createOpenAI({
         compatibility: 'compatible',
         apiKey: 'bogus', // required but unused
+        baseURL: aiBaseUrl,
       });
       return openaiCompatible(model);
   }

--- a/packages/api/ai/generate.mts
+++ b/packages/api/ai/generate.mts
@@ -133,6 +133,16 @@ export async function generateSrcbook(query: string): Promise<NoToolsGenerateTex
   return result;
 }
 
+export async function healthcheck(): Promise<string> {
+  const model = await getModel();
+  const result = await generateText({
+    model,
+    system: 'This is a test, simply respond "yes" to confirm the model is working.',
+    prompt: 'Are you working?',
+  });
+  return result.text;
+}
+
 type GenerateCellsResult = {
   error: boolean;
   errors?: string[];

--- a/packages/api/ai/generate.mts
+++ b/packages/api/ai/generate.mts
@@ -1,4 +1,5 @@
 import { generateText, type GenerateTextResult } from 'ai';
+import { getModel } from './config.mjs';
 import {
   type CodeLanguageType,
   type CellType,
@@ -9,11 +10,8 @@ import {
 import { type SessionType } from '../types.mjs';
 import { readFileSync } from 'node:fs';
 import Path from 'node:path';
-import { createOpenAI } from '@ai-sdk/openai';
-import { createAnthropic } from '@ai-sdk/anthropic';
 import { PROMPTS_DIR } from '../constants.mjs';
 import { encode, decodeCells } from '../srcmd.mjs';
-import { getConfig } from '../config.mjs';
 
 const makeGenerateSrcbookSystemPrompt = () => {
   return readFileSync(Path.join(PROMPTS_DIR, 'srcbook-generator.txt'), 'utf-8');
@@ -110,37 +108,6 @@ ${query}
   return prompt;
 };
 
-/**
- * Get the correct client and model configuration.
- * Throws an error if the given API key is not set in the settings.
- */
-async function getModel() {
-  const config = await getConfig();
-  const { model, provider } = config.aiConfig;
-  switch (provider) {
-    case 'openai':
-      if (!config.openaiKey) {
-        throw new Error('OpenAI API key is not set');
-      }
-
-      const openai = createOpenAI({
-        compatibility: 'strict', // strict mode, enabled when using the OpenAI API
-        apiKey: config.openaiKey,
-      });
-
-      return openai(model);
-    case 'anthropic':
-      if (!config.anthropicKey) {
-        throw new Error('Anthropic API key is not set');
-      }
-      const anthropic = createAnthropic({
-        apiKey: config.anthropicKey,
-      });
-
-      return anthropic(model);
-  }
-}
-
 type NoToolsGenerateTextResult = GenerateTextResult<{}>;
 /*
  * Given a user request, which is free form text describing their intent,
@@ -154,7 +121,7 @@ type NoToolsGenerateTextResult = GenerateTextResult<{}>;
 export async function generateSrcbook(query: string): Promise<NoToolsGenerateTextResult> {
   const model = await getModel();
   const result = await generateText({
-    model: model,
+    model,
     system: makeGenerateSrcbookSystemPrompt(),
     prompt: query,
   });
@@ -181,7 +148,7 @@ export async function generateCells(
   const systemPrompt = makeGenerateCellSystemPrompt(session.language);
   const userPrompt = makeGenerateCellUserPrompt(session, insertIdx, query);
   const result = await generateText({
-    model: model,
+    model,
     system: systemPrompt,
     prompt: userPrompt,
   });
@@ -209,7 +176,7 @@ export async function generateCellEdit(query: string, session: SessionType, cell
   const systemPrompt = makeGenerateCellEditSystemPrompt(session.language);
   const userPrompt = makeGenerateCellEditUserPrompt(query, session, cell);
   const result = await generateText({
-    model: model,
+    model,
     system: systemPrompt,
     prompt: userPrompt,
   });
@@ -228,7 +195,7 @@ export async function fixDiagnostics(
   const userPrompt = makeFixDiagnosticsUserPrompt(session, cell, diagnostics);
 
   const result = await generateText({
-    model: model,
+    model,
     system: systemPrompt,
     prompt: userPrompt,
   });

--- a/packages/api/config.mts
+++ b/packages/api/config.mts
@@ -13,6 +13,8 @@ async function init() {
       defaultLanguage: 'typescript',
       installId: randomid(),
       aiConfig: { provider: 'openai', model: 'gpt-4o' } as const,
+      aiProvider: 'openai',
+      aiModel: 'gpt-4o',
     };
     console.log();
     console.log('Initializing application with the following configuration:\n');

--- a/packages/api/db/schema.mts
+++ b/packages/api/db/schema.mts
@@ -1,11 +1,13 @@
 import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
 import { randomid } from '@srcbook/shared';
 
+// Deprecated. Remove me when migration is complete
 // Opening us up for different types of configuration:
 // supporting different models, local models and openAI url compatible providers
 type AiConfig =
   | { provider: 'openai'; model: 'gpt-4o' }
-  | { provider: 'anthropic'; model: 'claude-3-5-sonnet-20240620' };
+  | { provider: 'anthropic'; model: 'claude-3-5-sonnet-20240620' }
+  | { provider: 'local'; model: 'llama3' };
 
 export const configs = sqliteTable('config', {
   // Directory where .src.md files will be stored and searched by default.
@@ -22,6 +24,8 @@ export const configs = sqliteTable('config', {
     .$type<AiConfig>()
     .notNull()
     .default({ provider: 'openai', model: 'gpt-4o' }),
+  aiProvider: text('ai_provider').notNull().default('openai'),
+  aiModel: text('ai_model').default('gpt-4o'),
 });
 
 export type Config = typeof configs.$inferSelect;

--- a/packages/api/db/schema.mts
+++ b/packages/api/db/schema.mts
@@ -1,13 +1,12 @@
 import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
 import { randomid } from '@srcbook/shared';
 
-// Deprecated. Remove me when migration is complete
-// Opening us up for different types of configuration:
+// Deprecated. Remove me when migration of AI config is stable.
+// Opening us up for different types of configuration
 // supporting different models, local models and openAI url compatible providers
 type AiConfig =
   | { provider: 'openai'; model: 'gpt-4o' }
-  | { provider: 'anthropic'; model: 'claude-3-5-sonnet-20240620' }
-  | { provider: 'local'; model: 'llama3' };
+  | { provider: 'anthropic'; model: 'claude-3-5-sonnet-20240620' };
 
 export const configs = sqliteTable('config', {
   // Directory where .src.md files will be stored and searched by default.
@@ -20,6 +19,7 @@ export const configs = sqliteTable('config', {
   enabledAnalytics: integer('enabled_analytics', { mode: 'boolean' }).notNull().default(true),
   // Stable ID for posthog
   installId: text('srcbook_installation_id').notNull().default(randomid()),
+  // Deprecated. Remove me when migration of AI config is stable.
   aiConfig: text('ai_config', { mode: 'json' })
     .$type<AiConfig>()
     .notNull()

--- a/packages/api/db/schema.mts
+++ b/packages/api/db/schema.mts
@@ -26,6 +26,7 @@ export const configs = sqliteTable('config', {
     .default({ provider: 'openai', model: 'gpt-4o' }),
   aiProvider: text('ai_provider').notNull().default('openai'),
   aiModel: text('ai_model').default('gpt-4o'),
+  aiBaseUrl: text('ai_base_url'),
 });
 
 export type Config = typeof configs.$inferSelect;

--- a/packages/api/drizzle/0005_new_provider_ai_models.sql
+++ b/packages/api/drizzle/0005_new_provider_ai_models.sql
@@ -1,2 +1,3 @@
 ALTER TABLE `config` ADD `ai_provider` text DEFAULT 'openai' NOT NULL;--> statement-breakpoint
-ALTER TABLE `config` ADD `ai_model` text DEFAULT 'gpt-4o';
+ALTER TABLE `config` ADD `ai_model` text DEFAULT 'gpt-4o';--> statement-breakpoint
+ALTER TABLE `config` ADD `ai_base_url` text;

--- a/packages/api/drizzle/0005_new_provider_ai_models.sql
+++ b/packages/api/drizzle/0005_new_provider_ai_models.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `config` ADD `ai_provider` text DEFAULT 'openai' NOT NULL;--> statement-breakpoint
+ALTER TABLE `config` ADD `ai_model` text DEFAULT 'gpt-4o';

--- a/packages/api/drizzle/meta/0005_snapshot.json
+++ b/packages/api/drizzle/meta/0005_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "933a6a2a-6bb5-4d9d-b98c-df8bb9ab5fe2",
+  "id": "3b9a5cbb-0675-4de3-9030-e3305e3cd7b9",
   "prevId": "60f5c930-2a73-4a40-ac7b-ccbe02696f87",
   "tables": {
     "config": {
@@ -50,7 +50,7 @@
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false,
-          "default": "'k5lm3pjkjhmcr57la1m3jnc1ig'"
+          "default": "'udjl51v4fi960i2rdoh5o6r8rc'"
         },
         "ai_config": {
           "name": "ai_config",
@@ -75,6 +75,13 @@
           "notNull": false,
           "autoincrement": false,
           "default": "'gpt-4o'"
+        },
+        "ai_base_url": {
+          "name": "ai_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
         }
       },
       "indexes": {},

--- a/packages/api/drizzle/meta/0005_snapshot.json
+++ b/packages/api/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,133 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "933a6a2a-6bb5-4d9d-b98c-df8bb9ab5fe2",
+  "prevId": "60f5c930-2a73-4a40-ac7b-ccbe02696f87",
+  "tables": {
+    "config": {
+      "name": "config",
+      "columns": {
+        "base_dir": {
+          "name": "base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_language": {
+          "name": "default_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'typescript'"
+        },
+        "openai_api_key": {
+          "name": "openai_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anthropic_api_key": {
+          "name": "anthropic_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled_analytics": {
+          "name": "enabled_analytics",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "srcbook_installation_id": {
+          "name": "srcbook_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'k5lm3pjkjhmcr57la1m3jnc1ig'"
+        },
+        "ai_config": {
+          "name": "ai_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"provider\":\"openai\",\"model\":\"gpt-4o\"}'"
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openai'"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'gpt-4o'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "secrets": {
+      "name": "secrets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "secrets_name_unique": {
+          "name": "secrets_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -40,7 +40,7 @@
     {
       "idx": 5,
       "version": "6",
-      "when": 1723673710230,
+      "when": 1723676786701,
       "tag": "0005_new_provider_ai_models",
       "breakpoints": true
     }

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1722982500003,
       "tag": "0004_add_ai_config",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1723673710230,
+      "tag": "0005_new_provider_ai_models",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/server/http.mts
+++ b/packages/api/server/http.mts
@@ -13,7 +13,7 @@ import {
   sessionToResponse,
   listSessions,
 } from '../session.mjs';
-import { generateCells, generateSrcbook } from '../ai/generate.mjs';
+import { generateCells, generateSrcbook, healthcheck } from '../ai/generate.mjs';
 import { disk } from '../utils.mjs';
 import { getConfig, updateConfig, getSecrets, addSecret, removeSecret } from '../config.mjs';
 import {
@@ -141,6 +141,19 @@ router.post('/sessions/:id/generate_cells', cors(), async (req, res) => {
     const { error, errors, cells } = await generateCells(query, session, insertIdx);
     const result = error ? errors : cells;
     return res.json({ error, result });
+  } catch (e) {
+    const error = e as unknown as Error;
+    console.error(error);
+    return res.json({ error: true, result: error.stack });
+  }
+});
+
+// Test that the AI generation is working with the current configuration
+router.options('/ai/healthcheck', cors());
+router.get('/ai/healthcheck', cors(), async (_req, res) => {
+  try {
+    const result = await healthcheck();
+    return res.json({ error: false, result });
   } catch (e) {
     const error = e as unknown as Error;
     console.error(error);

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -5,3 +5,4 @@ export * from './src/types/cells.js';
 export * from './src/types/tsserver.js';
 export * from './src/types/websockets.js';
 export * from './src/utils.js';
+export * from './src/ai.js';

--- a/packages/shared/src/ai.ts
+++ b/packages/shared/src/ai.ts
@@ -1,0 +1,21 @@
+export const AiProvider = {
+  OpenAI: 'openai',
+  Anthropic: 'anthropic',
+  Local: 'local',
+} as const;
+
+export type AiProviderType = (typeof AiProvider)[keyof typeof AiProvider];
+
+export const defaultModels: Record<AiProviderType, string> = {
+  [AiProvider.OpenAI]: 'gpt-4o',
+  [AiProvider.Anthropic]: 'claude-3-5-sonnet-20240620',
+  [AiProvider.Local]: 'llama3:7b',
+} as const;
+
+export function isValidProvider(provider: string): provider is AiProviderType {
+  return Object.values(AiProvider).includes(provider as AiProviderType);
+}
+
+export function getDefaultModel(provider: AiProviderType): string {
+  return defaultModels[provider];
+}

--- a/packages/shared/src/ai.ts
+++ b/packages/shared/src/ai.ts
@@ -9,7 +9,7 @@ export type AiProviderType = (typeof AiProvider)[keyof typeof AiProvider];
 export const defaultModels: Record<AiProviderType, string> = {
   [AiProvider.OpenAI]: 'gpt-4o',
   [AiProvider.Anthropic]: 'claude-3-5-sonnet-20240620',
-  [AiProvider.Local]: 'llama3:7b',
+  [AiProvider.Local]: 'mistral-nemo',
 } as const;
 
 export function isValidProvider(provider: string): provider is AiProviderType {

--- a/packages/shared/src/ai.ts
+++ b/packages/shared/src/ai.ts
@@ -1,7 +1,7 @@
 export const AiProvider = {
   OpenAI: 'openai',
   Anthropic: 'anthropic',
-  Local: 'local',
+  Custom: 'custom',
 } as const;
 
 export type AiProviderType = (typeof AiProvider)[keyof typeof AiProvider];
@@ -9,7 +9,7 @@ export type AiProviderType = (typeof AiProvider)[keyof typeof AiProvider];
 export const defaultModels: Record<AiProviderType, string> = {
   [AiProvider.OpenAI]: 'gpt-4o',
   [AiProvider.Anthropic]: 'claude-3-5-sonnet-20240620',
-  [AiProvider.Local]: 'mistral-nemo',
+  [AiProvider.Custom]: 'mistral-nemo',
 } as const;
 
 export function isValidProvider(provider: string): provider is AiProviderType {

--- a/packages/web/src/components/use-settings.tsx
+++ b/packages/web/src/components/use-settings.tsx
@@ -34,7 +34,7 @@ export function SettingsProvider({ config, children }: ProviderPropsType) {
   const aiEnabled =
     (config.openaiKey && config.aiProvider === 'openai') ||
     (config.anthropicKey && config.aiProvider === 'anthropic') ||
-    (config.aiProvider === 'local' && !!config.aiBaseUrl) ||
+    (config.aiProvider === 'custom' && !!config.aiBaseUrl) ||
     false;
 
   const context: SettingsContextValue = {

--- a/packages/web/src/components/use-settings.tsx
+++ b/packages/web/src/components/use-settings.tsx
@@ -2,10 +2,8 @@ import React, { createContext, useContext } from 'react';
 import { useRevalidator } from 'react-router-dom';
 import { updateConfig as updateConfigServer } from '@/lib/server';
 import type { SettingsType } from '@/types';
-import { OPENAI_CONFIG, ANTHROPIC_CONFIG } from '@/types';
 
 export type SettingsContextValue = SettingsType & {
-  setAiProvider: (provider: 'openai' | 'anthropic') => void;
   aiEnabled: boolean;
   updateConfig: (newConfig: Partial<SettingsType>) => Promise<void>;
 };
@@ -33,19 +31,14 @@ export function SettingsProvider({ config, children }: ProviderPropsType) {
     revalidator.revalidate();
   };
 
-  const setAiProvider = async (provider: 'openai' | 'anthropic') => {
-    const val = provider === 'openai' ? OPENAI_CONFIG : ANTHROPIC_CONFIG;
-    await updateConfig({ aiConfig: val });
-  };
-
   const aiEnabled =
-    (config.openaiKey && config.aiConfig.provider === 'openai') ||
-    (config.anthropicKey && config.aiConfig.provider === 'anthropic') ||
+    (config.openaiKey && config.aiProvider === 'openai') ||
+    (config.anthropicKey && config.aiProvider === 'anthropic') ||
+    (config.aiProvider === 'local' && !!config.aiBaseUrl) ||
     false;
 
   const context: SettingsContextValue = {
     ...config,
-    setAiProvider,
     aiEnabled,
     updateConfig,
   };

--- a/packages/web/src/lib/server.ts
+++ b/packages/web/src/lib/server.ts
@@ -379,3 +379,14 @@ export async function sendFeedback({ feedback, email }: FeedbackRequestType) {
     console.error(response);
   }
 }
+
+export async function aiHealthcheck() {
+  const response = await fetch(API_BASE_URL + '/ai/healthcheck', {
+    method: 'GET',
+    headers: { 'content-type': 'application/json' },
+  });
+  if (!response.ok) {
+    console.error(response);
+  }
+  return response.json();
+}

--- a/packages/web/src/lib/server.ts
+++ b/packages/web/src/lib/server.ts
@@ -1,5 +1,10 @@
-import type { CodeLanguageType, MarkdownCellType, CodeCellType } from '@srcbook/shared';
-import { AiConfigType, SessionType, FsObjectResultType, ExampleSrcbookType } from '@/types';
+import type {
+  AiProviderType,
+  CodeLanguageType,
+  MarkdownCellType,
+  CodeCellType,
+} from '@srcbook/shared';
+import { SessionType, FsObjectResultType, ExampleSrcbookType } from '@/types';
 
 const API_BASE_URL = 'http://localhost:2150/api';
 
@@ -230,7 +235,9 @@ interface EditConfigRequestType {
   openaiKey?: string;
   anthropicKey?: string;
   enabledAnalytics?: boolean;
-  aiConfig?: AiConfigType;
+  aiBaseUrl?: string;
+  aiModel?: string;
+  aiProvider?: AiProviderType;
 }
 
 export async function getConfig() {

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { cn } from '@/lib/utils';
 import { CircleCheck, Loader2, CircleX } from 'lucide-react';
 import { disk, updateConfig, aiHealthcheck } from '@/lib/server';
 import { useSettings } from '@/components/use-settings';
@@ -137,7 +136,7 @@ function Settings() {
                   <SelectContent>
                     <SelectItem value="openai">openai</SelectItem>
                     <SelectItem value="anthropic">anthropic</SelectItem>
-                    <SelectItem value="local">custom</SelectItem>
+                    <SelectItem value="custom">custom</SelectItem>
                   </SelectContent>
                 </Select>
                 <Input
@@ -189,7 +188,7 @@ function Settings() {
               </div>
             )}
 
-            {aiProvider === 'local' && (
+            {aiProvider === 'custom' && (
               <div>
                 <p className="opacity-70 text-sm mb-4">
                   If you want to use an openai-compatible model (for example when running local
@@ -266,7 +265,7 @@ function AiInfoBanner() {
           </div>
         );
 
-      case 'local':
+      case 'custom':
         return (
           <div className="flex items-center gap-10 bg-sb-yellow-20 text-sb-yellow-80 rounded-sm text-sm font-medium px-3 py-2">
             <p>Base URL required</p>

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -1,4 +1,4 @@
-import { CellType, CodeLanguageType } from '@srcbook/shared';
+import { CellType, CodeLanguageType, AiProviderType } from '@srcbook/shared';
 
 export interface FsObjectType {
   path: string;
@@ -12,20 +12,15 @@ export interface FsObjectResultType {
   entries: FsObjectType[];
 }
 
-export const OPENAI_CONFIG = { provider: 'openai', model: 'gpt-4o' } as const;
-export const ANTHROPIC_CONFIG = {
-  provider: 'anthropic',
-  model: 'claude-3-5-sonnet-20240620',
-} as const;
-export type AiConfigType = typeof OPENAI_CONFIG | typeof ANTHROPIC_CONFIG;
-
 export type SettingsType = {
   baseDir: string;
   defaultLanguage: CodeLanguageType;
   openaiKey?: string | null;
   anthropicKey?: string | null;
   enabledAnalytics: boolean;
-  aiConfig: AiConfigType;
+  aiProvider: AiProviderType;
+  aiModel: string;
+  aiBaseUrl?: string | null;
 };
 
 export type StdoutOutputType = { type: 'stdout'; data: string };


### PR DESCRIPTION
We want users to be able to use open-source models locally, with tools like [Ollama](https://ollama.ai).

This PR allows to connect to openai-api-compatible models, by specifying the baseURL. Video of experience below:


https://github.com/user-attachments/assets/cd79a0bb-57b1-49c7-a797-8f58a07b115f


## Notes
* Currently, users cannot change anything but the `baseURL` parameter. In particular this means that we don't yet support adding auth-headers to third party hosted services like Groq, fireworks et.al. We absolutely could support them, but I'm waiting to see if we get customer demand.
* I added a "test AI" button. This isn't yet the `aiEnabled` source of truth, but I think that would be a nice improvement later.
* We don't show logs to the user in the UI if testing fails: we point them to the server logs instead.
* I have not yet updated to the new AI accent color. Will do that in a follow up PR when I update all of the AI stuff.
* This contains a migration. The old column is deprecated, but I'm not deleting in case something goes wrong and we want to roll back.
* I tested a couple of small models and they kind of suck. Mistral-nemo did best. Down the line we could fine-tune one and publish it to ollama...


fixes #161 