### PR TITLE
Add support for importing srcbooks from the hub

### DIFF
--- a/packages/web/src/clients/websocket/index.ts
+++ b/packages/web/src/clients/websocket/index.ts
@@ -25,7 +25,7 @@ import Channel from '@/clients/websocket/channel';
 import WebSocketClient from '@/clients/websocket/client';
 
 // Establish websocket connection immediately.
-const client = new WebSocketClient('ws://localhost:2150/websocket');
+const client = new WebSocketClient(`ws://${window.location.host}/websocket`);
 
 export default client;
 const IncomingSessionEvents = {

--- a/packages/web/src/lib/server.ts
+++ b/packages/web/src/lib/server.ts
@@ -6,7 +6,7 @@ import type {
 } from '@srcbook/shared';
 import { SessionType, FsObjectResultType, ExampleSrcbookType } from '@/types';
 
-const API_BASE_URL = 'http://localhost:2150/api';
+const API_BASE_URL = `${window.location.origin}/api`;
 
 interface DiskRequestType {
   dirname?: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,33 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-catalogs:
-  default:
-    '@ai-sdk/anthropic':
-      specifier: ^0.0.37
-      version: 0.0.37
-    '@ai-sdk/openai':
-      specifier: ^0.0.34
-      version: 0.0.34
-    '@types/node':
-      specifier: ^20.14.2
-      version: 20.14.2
-    marked:
-      specifier: ^12.0.2
-      version: 12.0.2
-    prettier:
-      specifier: ^3.3.1
-      version: 3.3.1
-    typescript:
-      specifier: ^5.4.5
-      version: 5.4.5
-    ws:
-      specifier: ^8.17.0
-      version: 8.17.0
-    zod:
-      specifier: ^3.23.8
-      version: 3.23.8
-
 importers:
 
   .:
@@ -310,6 +283,9 @@ importers:
       chalk:
         specifier: ^5.3.0
         version: 5.3.0
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
       cors:
         specifier: ^2.8.5
         version: 2.8.5
@@ -2420,6 +2396,10 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -4305,6 +4285,33 @@ packages:
 
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
+catalogs:
+  default:
+    '@ai-sdk/anthropic':
+      specifier: ^0.0.37
+      version: 0.0.37
+    '@ai-sdk/openai':
+      specifier: ^0.0.34
+      version: 0.0.34
+    '@types/node':
+      specifier: ^20.14.2
+      version: 20.14.2
+    marked:
+      specifier: ^12.0.2
+      version: 12.0.2
+    prettier:
+      specifier: ^3.3.1
+      version: 3.3.1
+    typescript:
+      specifier: ^5.4.5
+      version: 5.4.5
+    ws:
+      specifier: ^8.17.0
+      version: 8.17.0
+    zod:
+      specifier: ^3.23.8
+      version: 3.23.8
 
 snapshots:
 
@@ -6348,6 +6355,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  commander@12.1.0: {}
 
   commander@4.1.1: {}
 

--- a/srcbook/bin/cli.mjs
+++ b/srcbook/bin/cli.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import program from '../src/cli.mjs';
+
+program();

--- a/srcbook/bin/start.js
+++ b/srcbook/bin/start.js
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-
-process.env.NODE_ENV = 'production';
-
-(async () => {
-  await import('../index.mjs');
-})();

--- a/srcbook/package.json
+++ b/srcbook/package.json
@@ -1,11 +1,11 @@
 {
   "name": "srcbook",
   "version": "0.0.1-alpha.14",
+  "description": "Srcbook is a interactive programming environment for TypeScript",
   "type": "module",
-  "main": "./index.mjs",
-  "bin": "./bin/start.js",
+  "bin": "./bin/cli.mjs",
   "scripts": {
-    "start": "./bin/start.js",
+    "start": "./bin/cli.mjs",
     "build": "pnpm run --workspace-root build",
     "depcheck": "depcheck",
     "prepublishOnly": "pnpm run --workspace-root build",
@@ -13,12 +13,13 @@
     "postversion": "git push && git push --tags"
   },
   "dependencies": {
-    "@ai-sdk/openai": "catalog:",
     "@ai-sdk/anthropic": "catalog:",
+    "@ai-sdk/openai": "catalog:",
     "@srcbook/shared": "workspace:^",
     "ai": "^3.2.16",
     "better-sqlite3": "^11.0.0",
     "chalk": "^5.3.0",
+    "commander": "^12.1.0",
     "cors": "^2.8.5",
     "depcheck": "^1.4.7",
     "drizzle-orm": "^0.31.2",

--- a/srcbook/src/cli.mjs
+++ b/srcbook/src/cli.mjs
@@ -1,0 +1,125 @@
+import { spawn } from 'node:child_process';
+import { Command } from 'commander';
+import { pathTo, getPackageJson, isPortAvailable } from './utils.mjs';
+import open from 'open';
+
+function openInBrowser(url) {
+  open(url).then(
+    () => {},
+    () => {},
+  );
+}
+
+function startServer(port, callback) {
+  const server = spawn('node', [pathTo('src', 'server.mjs')], {
+    // Inherit stdio configurations from CLI (parent) process and allow IPC
+    stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      PORT: port,
+    },
+  });
+
+  // Exit the CLI (parent) process when the server (child) process closes
+  server.on('close', (code) => {
+    process.exit(code);
+  });
+
+  // Listen to messages sent from the server (child) process
+  server.on('message', (data) => {
+    const message = JSON.parse(data);
+    if (message.type === 'init') {
+      callback();
+    }
+  });
+}
+
+export default function program() {
+  const { name, description, version } = getPackageJson();
+
+  const program = new Command();
+
+  program.name(name).description(description).version(version);
+
+  program
+    .command('start')
+    .description('Start the Srcbook server')
+    .option('-p, --port <port>', 'Port to run the server on', '2150')
+    .action(({ port }) => {
+      startServer(port, () => {
+        openInBrowser(`http://localhost:${port}`);
+      });
+    });
+
+  program
+    .command('import')
+    .description('Import a Srcbook')
+    .option('-p, --port <port>', 'Port of the server', '2150')
+    .argument('<specifier>', 'An identifier of a Srcbook on hub.srcbook.com')
+    .action(async (specifier, { port }) => {
+      const portAvailable = await isPortAvailable('localhost', port);
+
+      if (portAvailable) {
+        return doImport(specifier, port);
+      }
+
+      startServer(port, () => {
+        doImport(specifier, port);
+      });
+    });
+
+  program.parse();
+}
+
+async function doImport(specifier, port) {
+  const filepath = specifier.endsWith('.src.md') ? specifier : `${specifier}.src.md`;
+  const srcbookUrl = `https://hub.srcbook.com/srcbooks/${filepath}`;
+
+  const res = await fetch(srcbookUrl);
+
+  if (!res.ok || res.status !== 200) {
+    console.error(`Srcbook not found ${specifier}`);
+    process.exit(1);
+  }
+
+  const srcmd = await res.text();
+
+  const sessionId = await importSrcbook(srcmd, port, srcbookUrl);
+
+  openInBrowser(`http://localhost:${port}/srcbooks/${sessionId}`);
+}
+
+async function importSrcbook(srcmd, port, srcbookUrl) {
+  const importResponse = await fetch(`http://localhost:${port}/api/import`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ text: srcmd }),
+  });
+
+  if (!importResponse.ok || importResponse.status !== 200) {
+    console.error(`Cannot import ${srcbookUrl}`);
+    process.exit(1);
+  }
+
+  const importResponseBody = await importResponse.json();
+
+  const sessionsResponse = await fetch(`http://localhost:${port}/api/sessions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ path: importResponseBody.result.dir }),
+  });
+
+  if (!sessionsResponse.ok || sessionsResponse.status !== 200) {
+    console.error(`Failed to open ${srcbookUrl}`);
+    process.exit(1);
+  }
+
+  const sessionsResponseBody = await sessionsResponse.json();
+
+  return sessionsResponseBody.result.id;
+}

--- a/srcbook/src/utils.mjs
+++ b/srcbook/src/utils.mjs
@@ -1,0 +1,39 @@
+import fs from 'node:fs';
+import net from 'node:net';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const ROOT_PATH = path.join(__dirname, '../');
+
+export function pathTo(...paths) {
+  return path.join(ROOT_PATH, ...paths);
+}
+
+export function getPackageJson() {
+  const packageJson = fs.readFileSync(pathTo('package.json'), 'utf-8');
+  return JSON.parse(packageJson);
+}
+
+export function isPortAvailable(host, port) {
+  return new Promise((resolve, reject) => {
+    const client = new net.Socket();
+
+    client.once('error', (err) => {
+      if (err.code === 'ECONNREFUSED') {
+        resolve(false); // Port is not in use
+      } else {
+        reject(err); // Some other error occurred
+      }
+    });
+
+    client.once('connect', () => {
+      client.end();
+      resolve(true); // Port is in use
+    });
+
+    client.connect(port, host);
+  });
+}


### PR DESCRIPTION
This PR:

1. Introduces a more robust CLI with support for importing srcbooks from [https://hub.srcbook.com](https://hub.srcbook.com).
2. Removes the hardcoded localhost urls in the web package, which now means that we can configure port and leverage localhost aliases

CLI Examples:

```bash
npx srcbook start
npx srcbook start --port 5000   # or -p

npx srcbook import <hub-id>
npx srcbook import <hub-id> -p 5000  # or --port
```

### Main CLI help menu

```
Usage: srcbook [options] [command]

Srcbook is a interactive programming environment for TypeScript

Options:
  -V, --version                 output the version number
  -h, --help                    display help for command

Commands:
  start [options]               Start the Srcbook server
  import [options] <specifier>  Import a Srcbook
  help [command]                display help for command
```

### `import` command help menu

```
Usage: srcbook import [options] <specifier>

Import a Srcbook

Arguments:
  specifier          An identifier of a Srcbook on hub.srcbook.com

Options:
  -p, --port <port>  Port of the server (default: "2150")
  -h, --help         display help for command
```