### PR TITLE
Reorder settings to have baseDir be lower

### DIFF
--- a/packages/web/src/routes/secrets.tsx
+++ b/packages/web/src/routes/secrets.tsx
@@ -53,7 +53,7 @@ function Secrets() {
 
   return (
     <>
-      <h1 className="text-2xl my-4">Secrets</h1>
+      <h4 className="h4 mx-auto mb-6">Secrets</h4>
 
       <p>
         Secrets are a safe way utilize API tokens or other private credentials in Srcbooks. These

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -84,7 +84,7 @@ function Settings() {
 
   return (
     <div>
-      <h1 className="text-4xl pb-4">Settings</h1>
+      <h4 className="h4 mx-auto mb-6">Settings</h4>
       <div className="space-y-10">
         <div>
           <h2 className="text-xl pb-2">Theme</h2>

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -87,14 +87,6 @@ function Settings() {
       <h1 className="text-4xl pb-4">Settings</h1>
       <div className="space-y-10">
         <div>
-          <h2 className="text-xl pb-2">Base Directory</h2>
-          <label className="opacity-70 text-sm">
-            The default directory to look for Srcbooks when importing.
-          </label>
-          <DirPicker dirname={baseDir} entries={entries} cta="Change" />
-        </div>
-
-        <div>
           <h2 className="text-xl pb-2">Theme</h2>
           <label className="opacity-70 text-sm">
             Select light or dark mode for the Srcbook app.
@@ -212,6 +204,14 @@ function Settings() {
               </div>
             )}
           </div>
+        </div>
+
+        <div>
+          <h2 className="text-xl pb-2">Base Directory</h2>
+          <label className="opacity-70 text-sm">
+            The default directory to look for Srcbooks when importing.
+          </label>
+          <DirPicker dirname={baseDir} entries={entries} cta="Change" />
         </div>
 
         <div>


### PR DESCRIPTION
I want the theme, default lang and AI to be higher up.
Also fixed inconsistent headers on Home, Secrets, Settings

![CleanShot 2024-08-15 at 17 22 41](https://github.com/user-attachments/assets/561ffe60-791d-40f0-8075-c846cd602dde)
