### PR TITLE
Add dynamic build vars for web's index.html

### DIFF
--- a/packages/web/.env.development
+++ b/packages/web/.env.development
@@ -1,0 +1,2 @@
+VITE_SRCBOOK_API_HOST="'localhost:2150'"
+VITE_SRCBOOK_API_ORIGIN="'http://localhost:2150'"

--- a/packages/web/.env.production
+++ b/packages/web/.env.production
@@ -1,0 +1,2 @@
+VITE_SRCBOOK_API_HOST="window.location.host"
+VITE_SRCBOOK_API_ORIGIN="window.location.origin"

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -19,6 +19,14 @@
         }
       })(localStorage.getItem('sb:theme'));
     </script>
+    <script type="text/javascript">
+      globalThis.SRCBOOK_CONFIG = {
+        api: {
+          host: %VITE_SRCBOOK_API_HOST%,
+          origin: %VITE_SRCBOOK_API_ORIGIN%,
+        },
+      };
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/web/src/clients/websocket/index.ts
+++ b/packages/web/src/clients/websocket/index.ts
@@ -20,12 +20,12 @@ import {
   TsConfigUpdatedPayloadSchema,
   AiFixDiagnosticsPayloadSchema,
 } from '@srcbook/shared';
-
 import Channel from '@/clients/websocket/channel';
 import WebSocketClient from '@/clients/websocket/client';
+import SRCBOOK_CONFIG from '@/config';
 
 // Establish websocket connection immediately.
-const client = new WebSocketClient(`ws://${window.location.host}/websocket`);
+const client = new WebSocketClient(`ws://${SRCBOOK_CONFIG.api.host}/websocket`);
 
 export default client;
 const IncomingSessionEvents = {

--- a/packages/web/src/config.ts
+++ b/packages/web/src/config.ts
@@ -1,0 +1,13 @@
+// Expected to be defined in index.html
+declare global {
+  interface Window {
+    SRCBOOK_CONFIG: {
+      api: {
+        host: string;
+        origin: string;
+      };
+    };
+  }
+}
+
+export default window.SRCBOOK_CONFIG;

--- a/packages/web/src/lib/server.ts
+++ b/packages/web/src/lib/server.ts
@@ -5,8 +5,9 @@ import type {
   CodeCellType,
 } from '@srcbook/shared';
 import { SessionType, FsObjectResultType, ExampleSrcbookType } from '@/types';
+import SRCBOOK_CONFIG from '@/config';
 
-const API_BASE_URL = `${window.location.origin}/api`;
+const API_BASE_URL = `${SRCBOOK_CONFIG.api.origin}/api`;
 
 interface DiskRequestType {
   dirname?: string;


### PR DESCRIPTION
Locally we run dev server and API on separate hosts. In prod, these are the same and also should be computed at runtime (window.location.*) to account for localhost aliases.

See https://vitejs.dev/guide/env-and-mode#html-env-replacement

(they can also be overridden with an env file with a `.local` suffix).