### PR TITLE
Add link to hub on home page

### DIFF
--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -20,6 +20,7 @@ import {
   ImportSrcbookButton,
 } from '@/components/srcbook-cards';
 import DeleteSrcbookModal from '@/components/delete-srcbook-dialog';
+import { ExternalLink } from 'lucide-react';
 
 export async function loader() {
   const [{ result: config }, { result: srcbooks }, { result: examples }] = await Promise.all([
@@ -100,6 +101,15 @@ export default function Home() {
               />
             ))}
           </div>
+
+          <a href="https://hub.srcbook.com" target="_blank">
+            <div className="flex gap-2 items-center mt-6 hover:-translate-y-0.5 transition-all">
+              <p className="px-2">
+                See more examples in <span className="underline font-medium">the hub</span>
+              </p>
+              <ExternalLink size={16} className="text-muted-foreground" />
+            </div>
+          </a>
         </div>
       )}
 


### PR DESCRIPTION
Adapted designs slightly since we renamed it from Library to Hub and it's an external link so updated the icon to make that more clear.

![CleanShot 2024-08-16 at 13 38 12](https://github.com/user-attachments/assets/e5ce9df5-a185-4898-859e-7ad6644f7614)
