### PR TITLE
Slight border radius on images in markdown

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -337,6 +337,10 @@
   @apply my-1;
 }
 
+.sb-prose img {
+  border-radius: 3px;
+}
+
 .cm-editor {
   @apply rounded-b;
   max-height: 80vh;


### PR DESCRIPTION
I think this is nicer.
## before / after
![CleanShot 2024-08-18 at 10 40 04](https://github.com/user-attachments/assets/55f8680e-8f72-44c7-a053-19852d8d7e5e)
![CleanShot 2024-08-18 at 10 39 54](https://github.com/user-attachments/assets/8e649cc7-0409-4836-9ccd-fd0713634023)

