### PR TITLE
Support disabling analytics through env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ rm -rf ~/.srcbook
 
 ## Analytics and tracking
 
-In order to improve Srcbook, we collect some behavioral analytics. We don't collect anything personal or identifiable, our goals are simply to improve the application. The code is open source so you don't have to trust us, you can verify! You can find more information in our [privacy policy](./PRIVACY-POLICY.md).
+In order to improve Srcbook, we collect some behavioral analytics. We don't collect any Personal Identifiable Information (PII), our goals are simply to improve the application. The code is open source so you don't have to trust us, you can verify! You can find more information in our [privacy policy](./PRIVACY-POLICY.md).
 
-If you want to disable tracking, you can do so in the settings page of the application.
+If you want to disable tracking, you can run Srcbook with `SRCBOOK_DISABLE_ANALYTICS=true` set in the environment.
 
 ## Development
 

--- a/packages/api/db/schema.mts
+++ b/packages/api/db/schema.mts
@@ -7,8 +7,7 @@ export const configs = sqliteTable('config', {
   defaultLanguage: text('default_language').notNull().default('typescript'),
   openaiKey: text('openai_api_key'),
   anthropicKey: text('anthropic_api_key'),
-  // Default on for behavioral analytics.
-  // Allows us to improve Srcbook, we don't collect any PII.
+  // TODO: This is deprecated in favor of SRCBOOK_DISABLE_ANALYTICS env variable. Remove this.
   enabledAnalytics: integer('enabled_analytics', { mode: 'boolean' }).notNull().default(true),
   // Stable ID for posthog
   installId: text('srcbook_installation_id').notNull().default(randomid()),

--- a/packages/api/dev-server.mts
+++ b/packages/api/dev-server.mts
@@ -4,8 +4,6 @@ import { WebSocketServer as WsWebSocketServer } from 'ws';
 import app from './server/http.mjs';
 import webSocketServer from './server/ws.mjs';
 
-import { posthog } from './posthog-client.mjs';
-
 export { SRCBOOK_DIR } from './constants.mjs';
 
 const server = http.createServer(app);
@@ -19,7 +17,6 @@ server.listen(port, () => {
 });
 
 process.on('SIGINT', async function () {
-  await posthog.shutdown();
   server.close();
   process.exit();
 });

--- a/packages/api/posthog-client.mts
+++ b/packages/api/posthog-client.mts
@@ -2,63 +2,44 @@ import { PostHog } from 'posthog-node';
 import { getConfig } from './config.mjs';
 import { IS_PRODUCTION } from './constants.mjs';
 
-type QueuedEvent = {
+const POSTHOG_API_KEY = 'phc_bQjmPYXmbl76j8gW289Qj9XILuu1STRnIfgCSKlxdgu';
+const POSTHOG_HOST = 'https://us.i.posthog.com';
+
+type EventType = {
   event: string;
   properties?: Record<string, any>;
 };
 
 class PostHogClient {
   private installId: string;
-  private client: PostHog | null = null;
-  private isEnabled: boolean = false;
-  private eventQueue: QueuedEvent[] = [];
+  private client: PostHog;
 
-  constructor(config: { enabledAnalytics: boolean; installId: string }) {
-    this.isEnabled = config.enabledAnalytics;
+  constructor(config: { installId: string }) {
     this.installId = config.installId;
-
-    if (this.isEnabled) {
-      this.client = new PostHog(
-        // We're sending over API key to GitHub and clients, but it's the only way.
-        'phc_bQjmPYXmbl76j8gW289Qj9XILuu1STRnIfgCSKlxdgu',
-        { host: 'https://us.i.posthog.com' },
-      );
-    }
-
-    this.flushQueue();
+    this.client = new PostHog(POSTHOG_API_KEY, { host: POSTHOG_HOST });
   }
 
-  private flushQueue(): void {
-    if (!this.isEnabled || !this.client) {
-      this.eventQueue = []; // Clear the queue if analytics are disabled
+  private get analyticsEnabled(): boolean {
+    const disabled = process.env.SRCBOOK_DISABLE_ANALYTICS || '';
+    return disabled.toLowerCase() !== 'true';
+  }
+
+  private get isEnabled(): boolean {
+    console.log({ analyticsEnabled: this.analyticsEnabled });
+    return this.analyticsEnabled && IS_PRODUCTION;
+  }
+
+  public capture(event: EventType): void {
+    if (!this.isEnabled) {
       return;
     }
 
-    while (this.eventQueue.length > 0) {
-      const event = this.eventQueue.shift();
-      if (event) {
-        this.client.capture({ ...event, distinctId: this.installId });
-      }
-    }
+    this.client.capture({ ...event, distinctId: this.installId });
   }
 
-  public capture(event: QueuedEvent): void {
-    if (this.isEnabled && IS_PRODUCTION) {
-      if (this.client) {
-        this.client.capture({ ...event, distinctId: this.installId });
-      }
-    } else {
-      this.eventQueue.push(event);
-    }
-  }
-
-  public async shutdown(): Promise<void> {
-    this.flushQueue();
-    if (this.client) {
-      await this.client.shutdown();
-    }
+  public shutdown() {
+    this.client.shutdown();
   }
 }
 
-const config = await getConfig();
-export const posthog = new PostHogClient(config);
+export const posthog = new PostHogClient(await getConfig());

--- a/packages/api/server/http.mts
+++ b/packages/api/server/http.mts
@@ -242,10 +242,12 @@ router.get('/settings', cors(), async (_req, res) => {
 router.post('/settings', cors(), async (req, res) => {
   try {
     const updated = await updateConfig(req.body);
+
     posthog.capture({
       event: 'user updated settings',
       properties: { setting_changed: Object.keys(req.body) },
     });
+
     return res.json({ result: updated });
   } catch (e) {
     const error = e as unknown as Error;

--- a/packages/web/src/lib/server.ts
+++ b/packages/web/src/lib/server.ts
@@ -235,7 +235,6 @@ interface EditConfigRequestType {
   defaultLanguage?: 'typescript' | 'javascript';
   openaiKey?: string;
   anthropicKey?: string;
-  enabledAnalytics?: boolean;
   aiBaseUrl?: string;
   aiModel?: string;
   aiProvider?: AiProviderType;

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -43,12 +43,10 @@ function Settings() {
     anthropicKey: configAnthropicKey,
     updateConfig: updateConfigContext,
     defaultLanguage,
-    enabledAnalytics: configEnabledAnalytics,
   } = useSettings();
 
   const [openaiKey, setOpenaiKey] = useState<string>(configOpenaiKey ?? '');
   const [anthropicKey, setAnthropicKey] = useState<string>(configAnthropicKey ?? '');
-  const [enabledAnalytics, setEnabledAnalytics] = useState(configEnabledAnalytics);
   const [model, setModel] = useState<string>(aiModel);
   const [baseUrl, setBaseUrl] = useState<string>(aiBaseUrl || '');
 
@@ -212,24 +210,6 @@ function Settings() {
             The default directory to look for Srcbooks when importing.
           </label>
           <DirPicker dirname={baseDir} entries={entries} cta="Change" />
-        </div>
-
-        <div>
-          <h2 className="text-xl pb-2">Analytics tracking</h2>
-          <label className="opacity-70 block pb-4 text-sm">
-            We track behavioral analytics to improve Srcbook. We do not track any personally
-            identifiable information (PII).
-          </label>
-          <div className="flex items-center gap-2">
-            <Switch
-              checked={enabledAnalytics}
-              onCheckedChange={() => {
-                setEnabledAnalytics(!enabledAnalytics);
-                updateConfigContext({ enabledAnalytics: !enabledAnalytics });
-              }}
-            />
-            <label>{enabledAnalytics ? 'enabled' : 'disabled'}</label>
-          </div>
         </div>
       </div>
     </div>

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -17,7 +17,6 @@ export type SettingsType = {
   defaultLanguage: CodeLanguageType;
   openaiKey?: string | null;
   anthropicKey?: string | null;
-  enabledAnalytics: boolean;
   aiProvider: AiProviderType;
   aiModel: string;
   aiBaseUrl?: string | null;

--- a/srcbook/README.md
+++ b/srcbook/README.md
@@ -86,9 +86,9 @@ rm -rf ~/.srcbook
 
 ## Analytics and tracking
 
-In order to improve Srcbook, we collect some behavioral analytics. We don't collect anything personal or identifiable, our goals are simply to improve the application. The code is open source so you don't have to trust us, you can verify! You can find more information in our [privacy policy](./PRIVACY-POLICY.md).
+In order to improve Srcbook, we collect some behavioral analytics. We don't collect any Personal Identifiable Information (PII), our goals are simply to improve the application. The code is open source so you don't have to trust us, you can verify! You can find more information in our [privacy policy](./PRIVACY-POLICY.md).
 
-If you want to disable tracking, you can do so in the settings page of the application.
+If you want to disable tracking, you can run Srcbook with `SRCBOOK_DISABLE_ANALYTICS=true` set in the environment.
 
 ## Development
 

--- a/srcbook/src/server.mjs
+++ b/srcbook/src/server.mjs
@@ -64,7 +64,8 @@ server.listen(port, () => {
 });
 
 process.on('SIGINT', async () => {
-  await posthog.shutdown();
+  // Ensure we gracefully shutdown posthog since it may need to flush events
+  posthog.shutdown();
   server.close();
   process.exit();
 });


### PR DESCRIPTION
Removed settings page analytics.

To disable analytics, run srcbook with the `SRCBOOK_DISABLE_ANALYTICS=true` env var set