### PR TITLE
Add minimize/maximise functionality in the output bar

### DIFF
--- a/packages/web/src/components/cell-output.tsx
+++ b/packages/web/src/components/cell-output.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useSettings } from '@/components/use-settings';
-import { Ban, PanelBottomClose, PanelBottomOpen, Sparkles } from 'lucide-react';
+import { Ban, Maximize, Minimize, PanelBottomClose, PanelBottomOpen, Sparkles } from 'lucide-react';
 import { CodeCellType, PackageJsonCellType, TsServerDiagnosticType } from '@srcbook/shared';
 import { cn } from '@/lib/utils';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/underline-flat-tabs';
@@ -14,7 +14,8 @@ type PropsType = {
   setShow: (show: boolean) => void;
   fixDiagnostics: (diagnostics: string) => void;
   cellMode: 'off' | 'generating' | 'reviewing' | 'prompting' | 'fixing';
-  fullscreen?: boolean;
+  setFullscreen: (fullscreen: boolean) => void;
+  fullscreen: boolean;
 };
 
 export function CellOutput({
@@ -24,6 +25,7 @@ export function CellOutput({
   fixDiagnostics,
   cellMode,
   fullscreen,
+  setFullscreen,
 }: PropsType) {
   const { getOutput, clearOutput, getTsServerDiagnostics } = useCells();
 
@@ -94,6 +96,14 @@ export function CellOutput({
             )}
           </TabsList>
           <div className="flex items-center gap-6">
+            <button
+              className="hover:text-secondary-hover disabled:pointer-events-none disabled:opacity-50"
+              onClick={() => {
+                setFullscreen(!fullscreen);
+              }}
+            >
+              {fullscreen ? <Minimize size={16} /> : <Maximize size={16} />}
+            </button>
             <button
               className="hover:text-secondary-hover disabled:pointer-events-none disabled:opacity-50"
               disabled={activeTab === 'problems'}

--- a/packages/web/src/components/cells/code.tsx
+++ b/packages/web/src/components/cells/code.tsx
@@ -241,7 +241,8 @@ export default function CodeCell(props: {
                   cell={cell}
                   show={showStdio}
                   setShow={setShowStdio}
-                  fullscreen
+                  fullscreen={fullscreen}
+                  setFullscreen={setFullscreen}
                   fixDiagnostics={aiFixDiagnostics}
                   cellMode={cellMode}
                 />
@@ -302,6 +303,8 @@ export default function CodeCell(props: {
                 setShow={setShowStdio}
                 fixDiagnostics={aiFixDiagnostics}
                 cellMode={cellMode}
+                fullscreen={fullscreen}
+                setFullscreen={setFullscreen}
               />
             </>
           )}


### PR DESCRIPTION
Sometimes, you are focusing on the output, and there isn't enough room and you want to maximize the view. If the code cell is high, in this instance you have to scroll up, find the maximize button, and then focus your attention back at the bottom panel.

This adds a second button to maximize / minimize, in the output bar, to resolve this UX issue.