### PR TITLE
Do not crash when multi-byte unicode characters are present in tsserver messages

### DIFF
--- a/packages/api/test/tsserver.test.mts
+++ b/packages/api/test/tsserver.test.mts
@@ -1,0 +1,94 @@
+import { parse } from '../tsserver/messages.mjs';
+
+describe('parsing JSON RPC messages', () => {
+  it('complete message', () => {
+    const chunk = Buffer.from(
+      'Content-Length: 76\r\n\r\n{"seq":0,"type":"event","event":"typingsInstallerPid","body":{"pid":58118}}\n',
+    );
+
+    const { messages, buffered } = parse(chunk, Buffer.from(''));
+
+    expect(messages).toEqual([
+      {
+        seq: 0,
+        type: 'event',
+        event: 'typingsInstallerPid',
+        body: { pid: 58118 },
+      },
+    ]);
+
+    expect(buffered).toEqual(Buffer.from(''));
+  });
+
+  it('partial message', () => {
+    const firstChunk = Buffer.from(
+      'Content-Length: 76\r\n\r\n{"seq":0,"type":"event","event":"typingsInstallerPid","body":{"pid":58118}}\nContent-Length: 18\r\n\r\n{"js',
+    );
+
+    const secondChunk = Buffer.from('onrpc":"2.0"}\n');
+
+    let result = parse(firstChunk, Buffer.from(''));
+
+    expect(result.messages).toEqual([
+      {
+        seq: 0,
+        type: 'event',
+        event: 'typingsInstallerPid',
+        body: { pid: 58118 },
+      },
+    ]);
+
+    expect(result.buffered.toString('utf-8')).toEqual('Content-Length: 18\r\n\r\n{"js');
+
+    result = parse(secondChunk, result.buffered);
+
+    expect(result.messages).toEqual([{ jsonrpc: '2.0' }]);
+    expect(result.buffered.toString('utf-8')).toEqual('');
+  });
+
+  it('message with unicode characters', () => {
+    const chunk = Buffer.from(
+      `Content-Length: 396\r\n\r\n{"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/Users/ben/.srcbook/srcbooks/26c73ru4docv5bnve7e68ca6to/src/foo.ts","diagnostics":[{"start":{"line":1,"offset":1},"end":{"line":1,"offset":2},"text":"Cannot find name 'Ï'.","code":2304,"category":"error"},{"start":{"line":3,"offset":13},"end":{"line":3,"offset":14},"text":"Cannot find name 'x'.","code":2304,"category":"error"}]}}\nContent-Length: 152\r\n\r\n{"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/Users/ben/.srcbook/srcbooks/26c73ru4docv5bnve7e68ca6to/src/foo.ts","diagnostics":[]}}\n`,
+    );
+
+    const { messages, buffered } = parse(chunk, Buffer.from(''));
+
+    expect(messages).toEqual([
+      {
+        seq: 0,
+        type: 'event',
+        event: 'semanticDiag',
+        body: {
+          file: '/Users/ben/.srcbook/srcbooks/26c73ru4docv5bnve7e68ca6to/src/foo.ts',
+          diagnostics: [
+            {
+              start: { line: 1, offset: 1 },
+              end: { line: 1, offset: 2 },
+              text: "Cannot find name 'Ï'.",
+              code: 2304,
+              category: 'error',
+            },
+            {
+              start: { line: 3, offset: 13 },
+              end: { line: 3, offset: 14 },
+              text: "Cannot find name 'x'.",
+              code: 2304,
+              category: 'error',
+            },
+          ],
+        },
+      },
+      {
+        body: {
+          diagnostics: [],
+          file: '/Users/ben/.srcbook/srcbooks/26c73ru4docv5bnve7e68ca6to/src/foo.ts',
+        },
+        event: 'suggestionDiag',
+        seq: 0,
+        type: 'event',
+      },
+    ]);
+
+    expect(buffered).toEqual(Buffer.from(''));
+  });
+});

--- a/packages/api/tsserver/messages.mts
+++ b/packages/api/tsserver/messages.mts
@@ -1,0 +1,134 @@
+import type { server as tsserver } from 'typescript';
+
+const ENCODER = new TextEncoder();
+const DECODER = new TextDecoder();
+const CONTENT_LENGTH_HEADER = ENCODER.encode('Content-Length: ');
+const CARRIAGE_RETURN_CHAR_CODE = '\r'.charCodeAt(0);
+
+/**
+ * Parse messages from a chunk of data sent by tsserver.
+ *
+ * Notes:
+ *
+ * - A 'message' takes the form:  "Content-Length: <number>\r\n\r\n<json>".
+ * - A single chunk may contain multiple messages.
+ * - A single chunk of data may contain an incomplete message, or contain complete message(s) followed by an incomplete one.
+ * - The "content length" number is the number of bytes, not characters. Unicode characters may be multiple bytes but only one string character. Thus, we must parse bytes not strings.
+ */
+export function parse(chunk: Buffer, buffered: Buffer) {
+  let buffer = new Uint8Array(Buffer.concat([buffered, chunk]));
+
+  const messages: Array<tsserver.protocol.Event | tsserver.protocol.Response> = [];
+
+  while (true) {
+    const content = getContentByteLength(buffer);
+
+    if (content === null) {
+      return { messages: messages, buffered: Buffer.from(buffer) };
+    }
+
+    const { start, byteLength } = content;
+
+    const end = start + byteLength;
+
+    if (end > buffer.byteLength) {
+      return { messages: messages, buffered: Buffer.from(buffer) };
+    }
+
+    const message = DECODER.decode(buffer.slice(start, end));
+
+    messages.push(JSON.parse(message));
+
+    buffer = buffer.slice(end);
+
+    if (buffer.byteLength === 0) {
+      break;
+    }
+  }
+
+  return { messages, buffered: Buffer.from(buffer) };
+}
+
+/**
+ * Get the byte length and start index of the message content.
+ *
+ * If the buffer does not contain a complete Content-Length header, null is returned.
+ *
+ * If the buffer is an unexpected format (has data but not the Content-Length header),
+ * an error is thrown.
+ *
+ * Example:
+ *
+ *     getContentByteLength("Content-Length: 3\r\n\r\n{}\n") // => { start: 21, byteLength: 3 }
+ *
+ */
+function getContentByteLength(buffer: Uint8Array): { start: number; byteLength: number } | null {
+  if (buffer.byteLength < CONTENT_LENGTH_HEADER.byteLength) {
+    return null;
+  }
+
+  if (!startsWith(buffer, CONTENT_LENGTH_HEADER)) {
+    throw new Error(
+      `Expected buffer argument to start with '${DECODER.decode(CONTENT_LENGTH_HEADER)}'`,
+    );
+  }
+
+  const start = CONTENT_LENGTH_HEADER.byteLength;
+
+  let i = start;
+
+  while (true) {
+    if (i >= buffer.byteLength) {
+      return null;
+    }
+
+    if (buffer[i] === CARRIAGE_RETURN_CHAR_CODE) {
+      break;
+    }
+
+    // If the character is not a number (codes 48-57), the data in the buffer is invalid.
+    if (buffer[i] < 48 || buffer[i] > 57) {
+      throw new Error(
+        `Unexpected byte '${buffer[i]}' in Content-Length header. Expected a number between 0 and 9 (byte values 48-57).`,
+      );
+    }
+
+    i++;
+  }
+
+  const byteLength = Number(DECODER.decode(buffer.slice(start, i)));
+
+  // The message content starts after '\r\n\r\n'
+  const contentStart = i + 4;
+
+  if (buffer.byteLength < contentStart) {
+    return null;
+  }
+
+  return { start: contentStart, byteLength: byteLength };
+}
+
+/**
+ * Does one buffer start with another?
+ *
+ * Examples:
+ *
+ *     startsWith(Uint8Array(4) [1,2,3,4], Uint8Array (2) [1,2]) // => true
+ *     startsWith(Uint8Array(4) [1,2,3,4], Uint8Array (2) [5,2]) // => false
+ */
+function startsWith(buffer: Uint8Array, prefix: Uint8Array) {
+  const bufferLen = buffer.byteLength;
+  const prefixLen = prefix.byteLength;
+
+  if (prefixLen > bufferLen) {
+    return false;
+  }
+
+  for (let i = 0; i < prefixLen; i++) {
+    if (buffer[i] !== prefix[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/api/tsserver/tsserver.mts
+++ b/packages/api/tsserver/tsserver.mts
@@ -1,7 +1,7 @@
 import EventEmitter from 'node:events';
 import type { ChildProcess } from 'node:child_process';
 import type { server as tsserver } from 'typescript';
-import { parseTsServerMessages } from './utils.mjs';
+import { parse } from './messages.mjs';
 
 /**
  * This class provides a wrapper around a process running tsserver and is used to communicate
@@ -41,7 +41,7 @@ export class TsServer extends EventEmitter {
     super();
     this.process = process;
     this.process.stdout?.on('data', (chunk) => {
-      const { messages, buffered } = parseTsServerMessages(chunk, this.buffered);
+      const { messages, buffered } = parse(chunk, this.buffered);
       this.buffered = buffered;
       for (const message of messages) {
         if (message.type === 'response') {

--- a/packages/api/tsserver/utils.mts
+++ b/packages/api/tsserver/utils.mts
@@ -1,60 +1,6 @@
 import type { server as tsserver } from 'typescript';
 import type { TsServerDiagnosticType } from '@srcbook/shared';
 
-/**
- * Parse messages from a chunk of data sent by tsserver.
- *
- * Notes:
- *
- * - A 'message' takes the form:  "Content-Length: <number>\r\n\r\n<json>".
- * - A single chunk may contain multiple messages.
- * - A single chunk of data may contain an incomplete message, or contain complete message(s) followed by an incomplete one.
- *
- * Example that contains only one message:
- *
- *     "Content-Length: 238\r\n\r\n{\"seq\":0,\"type\":\"event\",\"event\":\"projectLoadingStart\",\"body\":{\"projectName\":\"/Users/ben/.srcbook/tsconfig.json\",\"reason\":\"Creating possible configured project for /Users/ben/.srcbook/srcbooks/4bs7n0hg8n0163du5ik9shjdmc/main.ts to open\"}}\n"
- *
- * Example with multiple messages:
- *
- *     "Content-Length: 609\r\n\r\n{\"seq\":0,\"type\":\"event\",\"event\":\"telemetry\",\"body\":{\"telemetryEventName\":\"projectInfo\",\"payload\":{\"projectId\":\"ebdc8edc2317622018a25bdb7fd3ef5e41538960354c166d5577561381bed531\",\"fileStats\":{\"js\":0,\"jsSize\":0,\"jsx\":0,\"jsxSize\":0,\"ts\":5,\"tsSize\":2084,\"tsx\":0,\"tsxSize\":0,\"dts\":7,\"dtsSize\":1567085,\"deferred\":0,\"deferredSize\":0},\"compilerOptions\":{},\"typeAcquisition\":{\"enable\":false,\"include\":false,\"exclude\":false},\"extends\":false,\"files\":false,\"include\":false,\"exclude\":false,\"compileOnSave\":false,\"configFileName\":\"tsconfig.json\",\"projectType\":\"configured\",\"languageServiceEnabled\":true,\"version\":\"5.5.3\"}}}\nContent-Length: 435\r\n\r\n{\"seq\":0,\"type\":\"event\",\"event\":\"configFileDiag\",\"body\":{\"triggerFile\":\"/Users/ben/.srcbook/srcbooks/4bs7n0hg8n0163du5ik9shjdmc/main.ts\",\"configFile\":\"/Users/ben/.srcbook/tsconfig.json\",\"diagnostics\":[{\"start\":{\"line\":2,\"offset\":3},\"end\":{\"line\":2,\"offset\":11},\"text\":\"'module' should be set inside the 'compilerOptions' object of the config json file\",\"code\":6258,\"category\":\"error\",\"fileName\":\"/Users/ben/.srcbook/tsconfig.json\"}]}}\nContent-Length: 76\r\n\r\n{\"seq\":0,\"type\":\"event\",\"event\":\"typingsInstallerPid\",\"body\":{\"pid\":44901}}\n"
- *
- */
-export function parseTsServerMessages(chunk: Buffer, buffered: Buffer) {
-  const data = Buffer.concat([buffered, chunk]).toString('utf8');
-  const dataLen = data.length;
-
-  const matches = data.matchAll(/Content-Length: (\d+)\r\n\r\n/g);
-
-  const messages: Array<tsserver.protocol.Event | tsserver.protocol.Response> = [];
-
-  for (const match of matches) {
-    // 'header' is everything that matched in the regexp, i.e.: "Content-Length: <number>\r\n\r\n"
-    const header = match[0];
-
-    // 'offset' is the index (in the string) of the first character of the match, i.e. 'C' in 'Content-Length: ...'
-    const offset = match.index;
-
-    // 'contentLength' is the <number> in "Content-Length: <number>\r\n\r\n"
-    const contentLength = Number(match[1]);
-
-    // 'start' is where the JSON message body starts
-    const start = offset + header.length;
-
-    // 'end' is where the JSON message body ends
-    const end = start + contentLength;
-
-    if (end > dataLen) {
-      // If the chunk does not contain the entire message,
-      // we buffer starting at the offset of the current match.
-      return { messages, buffered: Buffer.from(data.slice(offset)) };
-    }
-
-    messages.push(JSON.parse(data.slice(start, end)));
-  }
-
-  return { messages, buffered: Buffer.from('') };
-}
-
 export function normalizeDiagnostic(
   diagnostic: tsserver.protocol.Diagnostic | tsserver.protocol.DiagnosticWithLinePosition,
 ): TsServerDiagnosticType {


### PR DESCRIPTION
Addresses #192.

There was a bug in the code that parses messages sent from tsserver. If a message contained a unicode character represented by more than one byte, our parsing would fail. The content-length header specifies the length in bytes yet we were treating that as the length in string characters, which are not necessarily the same.