### PR TITLE
fix: Limit title length to 50 characters in cellUpdate function

### DIFF
--- a/packages/api/server/ws.mts
+++ b/packages/api/server/ws.mts
@@ -416,6 +416,7 @@ async function cellUpdate(payload: CellUpdatePayloadType) {
 
 async function cellRename(payload: CellRenamePayloadType) {
   const session = await findSession(payload.sessionId);
+
   if (!session) {
     throw new Error(`No session exists for session '${payload.sessionId}'`);
   }

--- a/packages/api/server/ws.mts
+++ b/packages/api/server/ws.mts
@@ -390,6 +390,13 @@ async function cellUpdate(payload: CellUpdatePayloadType) {
       `No cell exists for session '${payload.sessionId}' and cell '${payload.cellId}'`,
     );
   }
+  if (
+    cellBeforeUpdate.type === 'title' &&
+    'text' in payload.updates &&
+    payload.updates?.text?.length > 50
+  ) {
+    throw new Error('Title cannot be more than 50 characters');
+  }
 
   const result = await updateCell(session, cellBeforeUpdate, payload.updates);
 
@@ -416,7 +423,6 @@ async function cellUpdate(payload: CellUpdatePayloadType) {
 
 async function cellRename(payload: CellRenamePayloadType) {
   const session = await findSession(payload.sessionId);
-
   if (!session) {
     throw new Error(`No session exists for session '${payload.sessionId}'`);
   }

--- a/packages/api/server/ws.mts
+++ b/packages/api/server/ws.mts
@@ -390,13 +390,6 @@ async function cellUpdate(payload: CellUpdatePayloadType) {
       `No cell exists for session '${payload.sessionId}' and cell '${payload.cellId}'`,
     );
   }
-  if (
-    cellBeforeUpdate.type === 'title' &&
-    'text' in payload.updates &&
-    payload.updates?.text?.length > 50
-  ) {
-    throw new Error('Title cannot be more than 50 characters');
-  }
 
   const result = await updateCell(session, cellBeforeUpdate, payload.updates);
 

--- a/packages/shared/src/schemas/cells.ts
+++ b/packages/shared/src/schemas/cells.ts
@@ -65,7 +65,7 @@ export const SrcbookMetadataSchema = z.object({
 ///////////////////////////////////////////
 
 export const TitleCellUpdateAttrsSchema = z.object({
-  text: z.string(),
+  text: z.string().max(44, 'Title must be 44 characters or fewer'),
 });
 
 export const MarkdownCellUpdateAttrsSchema = z.object({

--- a/packages/web/src/components/import-export-srcbook-modal.tsx
+++ b/packages/web/src/components/import-export-srcbook-modal.tsx
@@ -32,8 +32,8 @@ export function ImportSrcbookModal({
   async function onChange(entry: FsObjectType) {
     setError(null);
 
-    if (entry.basename.length > 50) {
-      setError('File name should be less than 50 characters');
+    if (entry.basename.length > 44) {
+      setError('Srcbook title should be less than 44 characters');
       return;
     }
 

--- a/packages/web/src/components/import-export-srcbook-modal.tsx
+++ b/packages/web/src/components/import-export-srcbook-modal.tsx
@@ -32,6 +32,11 @@ export function ImportSrcbookModal({
   async function onChange(entry: FsObjectType) {
     setError(null);
 
+    if (entry.basename.length > 50) {
+      setError('File name should be less than 50 characters');
+      return;
+    }
+
     const { error: importError, result: importResult } = await importSrcbook({ path: entry.path });
 
     if (importError) {

--- a/packages/web/src/components/ui/heading.tsx
+++ b/packages/web/src/components/ui/heading.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 import { Info } from 'lucide-react';
-import { z } from 'zod';
+import { TitleCellUpdateAttrsSchema } from '@srcbook/shared';
 
 const className =
   'flex w-full break-all whitespace-normal rounded-md border border-transparent bg-transparent px-1 py-1 transition-colors hover:border-input hover:shadow-sm focus-visible:shadow-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50';
@@ -17,12 +17,9 @@ export function EditableH1(props: {
     React.useState<boolean>(false);
 
   const maxHeadingLength = 44;
-  const headingSchema = z.string().max(maxHeadingLength, {
-    message: `Heading must be at most ${maxHeadingLength} characters long.`,
-  });
 
   const handleChange = (newValue: string) => {
-    const result = headingSchema.safeParse(newValue);
+    const result = TitleCellUpdateAttrsSchema.safeParse({ text: newValue });
     if (!result.success) {
       setIsMaxHeadingLengthExceeded(true);
       if (ref.current) {

--- a/packages/web/src/components/ui/heading.tsx
+++ b/packages/web/src/components/ui/heading.tsx
@@ -11,28 +11,30 @@ export function EditableH1(props: {
   className?: string;
   onUpdated: (text: string) => void;
 }) {
-  const ref = React.useRef<HTMLHeadingElement | null>(null);
-  const [heading, setHeading] = React.useState(props.text);
-  const [isMaxHeadingLengthExceeded, setisMaxHeadingLengthExceeded] = React.useState(false);
+  const ref = React.useRef<HTMLTextAreaElement | null>(null);
+  const [heading, setHeading] = React.useState<string>(props.text);
+  const [isMaxHeadingLengthExceeded, setIsMaxHeadingLengthExceeded] =
+    React.useState<boolean>(false);
   const maxHeadingLength = 50;
 
-  const handleChange = (e: HTMLTextAreaElement['value']) => {
-    if (e.length > maxHeadingLength) {
-      setisMaxHeadingLengthExceeded(true);
+  const handleChange = (newValue: string) => {
+    if (newValue.length > maxHeadingLength) {
+      setIsMaxHeadingLengthExceeded(true);
       setTimeout(() => {
-        setisMaxHeadingLengthExceeded(false);
+        setIsMaxHeadingLengthExceeded(false);
       }, 2000);
       return;
     }
-    setHeading(e);
+    setHeading(newValue);
   };
+
   return (
     <div>
       <textarea
         className={cn(className, props.className)}
         value={heading}
         onBlur={(e) => {
-          const text = e.currentTarget.innerHTML;
+          const text = e.currentTarget.value;
           if (text !== props.text) {
             props.onUpdated(text);
           }
@@ -42,7 +44,10 @@ export function EditableH1(props: {
             ref.current.blur();
           }
         }}
-        onChange={(e) => handleChange(e.target.value)}
+        onChange={(e) => {
+          handleChange(e.target.value);
+        }}
+        ref={ref}
         rows={1}
       />
       {isMaxHeadingLengthExceeded && (

--- a/packages/web/src/components/ui/heading.tsx
+++ b/packages/web/src/components/ui/heading.tsx
@@ -15,7 +15,7 @@ export function EditableH1(props: {
   const [heading, setHeading] = React.useState<string>(props.text);
   const [isMaxHeadingLengthExceeded, setIsMaxHeadingLengthExceeded] =
     React.useState<boolean>(false);
-  const maxHeadingLength = 50;
+  const maxHeadingLength = 44;
 
   const handleChange = (newValue: string) => {
     if (newValue.length > maxHeadingLength) {

--- a/packages/web/src/components/ui/heading.tsx
+++ b/packages/web/src/components/ui/heading.tsx
@@ -23,7 +23,7 @@ export function EditableH1(props: {
     if (!result.success) {
       setIsMaxHeadingLengthExceeded(true);
       if (ref.current) {
-        // Ensure text is saved when contenteditable becomes false  by triggering blur event
+        // Ensures text is saved when contenteditable becomes false  by triggering blur event
         ref.current.blur();
       }
       setTimeout(() => {

--- a/packages/web/src/components/ui/heading.tsx
+++ b/packages/web/src/components/ui/heading.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
+import { Info } from 'lucide-react';
 
 const className =
   'flex w-full rounded-md border border-transparent bg-transparent px-1 py-1 transition-colors hover:border-input hover:shadow-sm focus-visible:shadow-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50';
@@ -11,26 +12,45 @@ export function EditableH1(props: {
   onUpdated: (text: string) => void;
 }) {
   const ref = React.useRef<HTMLHeadingElement | null>(null);
+  const [heading, setHeading] = React.useState(props.text);
+  const [isMaxHeadingLengthExceeded, setisMaxHeadingLengthExceeded] = React.useState(false);
+  const maxHeadingLength = 50;
 
+  const handleChange = (e: HTMLTextAreaElement['value']) => {
+    if (e.length > maxHeadingLength) {
+      setisMaxHeadingLengthExceeded(true);
+      setTimeout(() => {
+        setisMaxHeadingLengthExceeded(false);
+      }, 2000);
+      return;
+    }
+    setHeading(e);
+  };
   return (
-    <h1
-      className={cn(className, props.className)}
-      ref={ref}
-      contentEditable
-      suppressContentEditableWarning={true}
-      onBlur={(e) => {
-        const text = e.currentTarget.innerHTML;
-        if (text !== props.text) {
-          props.onUpdated(text);
-        }
-      }}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' && ref.current) {
-          ref.current.blur();
-        }
-      }}
-    >
-      {props.text}
-    </h1>
+    <div>
+      <textarea
+        className={cn(className, props.className)}
+        value={heading}
+        onBlur={(e) => {
+          const text = e.currentTarget.innerHTML;
+          if (text !== props.text) {
+            props.onUpdated(text);
+          }
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && ref.current) {
+            ref.current.blur();
+          }
+        }}
+        onChange={(e) => handleChange(e.target.value)}
+        rows={1}
+      />
+      {isMaxHeadingLengthExceeded && (
+        <div className="bg-error text-error-foreground flex items-center rounded-sm border border-transparent px-[10px] py-2 text-sm leading-none font-medium">
+          <Info size={14} className="mr-1.5" />
+          Max heading length exceeded
+        </div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
Fixed https://github.com/srcbookdev/srcbook/issues/207 

I have replaced  `<h1>` to `<textarea>` because the `contentEditable` approach in `<h1>`  did not handle text wrapping efficiently, which leads to an overflow of text  like below 

![CleanShot 2024-08-25 at 01 03 28@2x](https://github.com/user-attachments/assets/7fb7c76d-89e7-4884-ad15-589f8809a5bc)
