### PR TITLE
Capture a few more events in posthog

### DIFF
--- a/packages/api/server/http.mts
+++ b/packages/api/server/http.mts
@@ -68,6 +68,11 @@ router.post('/srcbooks', cors(), async (req, res) => {
     });
   }
 
+  posthog.capture({
+    event: 'user created srcbook',
+    properties: { language },
+  });
+
   try {
     const srcbookDir = await createSrcbook(name, language);
     return res.json({ error: false, result: { name, path: srcbookDir } });
@@ -99,9 +104,11 @@ router.post('/import', cors(), async (req, res) => {
 
   try {
     if (typeof path === 'string') {
+      posthog.capture({ event: 'user imported srcbook from file' });
       const srcbookDir = await importSrcbookFromSrcmdFile(path);
       return res.json({ error: false, result: { dir: srcbookDir } });
     } else {
+      posthog.capture({ event: 'user imported srcbook from text' });
       const srcbookDir = await importSrcbookFromSrcmdText(text);
       return res.json({ error: false, result: { dir: srcbookDir } });
     }


### PR DESCRIPTION
Given that we have lots of real usage, I want to capture more events from the users.

I was careful (but check me in the review) to never capture any sensitive information. I just want to understand better how users are getting value out of Srcbook. Events captured:
- user created srcbook
- user imported from file
- user imported from text (I don't think this is possible in the UI right now)
- user ran a cell
- user stopped a cell which was executing
- user installed an npm dep
- user deleted a cell
- user updated tsconfig