### PR TITLE
fixed squiggly line ahead by 1 character

### DIFF
--- a/packages/web/src/components/cells/code.tsx
+++ b/packages/web/src/components/cells/code.tsx
@@ -581,23 +581,18 @@ function tsDiagnosticMessage(diagnostic: TsServerDiagnosticType): string {
 
 function convertTSDiagnosticToCM(diagnostic: TsServerDiagnosticType, code: string): Diagnostic {
   const message = tsDiagnosticMessage(diagnostic);
-
-  // parse conversion TS server is {line, offset} to CodeMirror {from, to} in absolute chars
+  const lines = code.split('\n');
+  const startOffset =
+    lines.slice(0, diagnostic.start.line - 1).reduce((sum, line) => sum + line.length + 1, 0) +
+    diagnostic.start.offset -
+    1;
+  const endOffset =
+    lines.slice(0, diagnostic.end.line - 1).reduce((sum, line) => sum + line.length + 1, 0) +
+    diagnostic.end.offset -
+    1;
   return {
-    from: Math.min(
-      code.length - 1,
-      code
-        .split('\n')
-        .slice(0, diagnostic.start.line - 1)
-        .join('\n').length + diagnostic.start.offset,
-    ),
-    to: Math.min(
-      code.length - 1,
-      code
-        .split('\n')
-        .slice(0, diagnostic.end.line - 1)
-        .join('\n').length + diagnostic.end.offset,
-    ),
+    from: Math.min(code.length - 1, startOffset),
+    to: Math.min(code.length - 1, endOffset),
     message: message,
     severity: tsCategoryToSeverity(diagnostic),
   };


### PR DESCRIPTION
fixed #225 

used reduce here and moved  offsets to a new variable 
because if I do -1 at `diagnostic.start.offset `, it will  incorrectly shift the offset, causing misalignment in error markers,

in this picture, in 2nd line x should have a red underline, but it is behind one character and one line
![image](https://github.com/user-attachments/assets/95340094-e518-41ed-836f-73ec28f4dca3)
