### PR TITLE
Add error states and output when npm installing

### DIFF
--- a/packages/api/server/ws.mts
+++ b/packages/api/server/ws.mts
@@ -259,12 +259,13 @@ async function depsInstall(payload: DepsInstallPayloadType) {
           output: { type: 'stderr', data: data.toString('utf8') },
         });
       },
-      async onExit() {
+      async onExit(exitCode) {
         const updatedJsonSource = await readPackageJsonContentsFromDisk(session);
+
         const updatedCell: PackageJsonCellType = {
           ...cell,
           source: updatedJsonSource,
-          status: 'idle',
+          status: exitCode === 0 ? 'idle' : 'failed',
         };
 
         const updatedSession = await updateSession(

--- a/packages/shared/src/schemas/cells.ts
+++ b/packages/shared/src/schemas/cells.ts
@@ -17,7 +17,7 @@ export const PackageJsonCellSchema = z.object({
   type: z.literal('package.json'),
   source: z.string(),
   filename: z.literal('package.json'),
-  status: z.enum(['idle', 'running']),
+  status: z.enum(['idle', 'running', 'failed']),
 });
 
 export const CodeCellSchema = z.object({

--- a/packages/web/src/components/session-menu.tsx
+++ b/packages/web/src/components/session-menu.tsx
@@ -74,7 +74,7 @@ export default function SessionMenu({
   const [showDelete, setShowDelete] = useState(false);
   const [showSave, setShowSave] = useState(false);
 
-  const { installing: installingDependencies } = usePackageJson();
+  const { installing: installingDependencies, failed: dependencyInstallFailed } = usePackageJson();
 
   const { cells: allCells } = useCells();
 
@@ -127,6 +127,7 @@ export default function SessionMenu({
               <Settings size={16} />
             )}
             Settings
+            {dependencyInstallFailed && <span className="text-error">(1)</span>}
           </button>
           <button
             onClick={() => setShowSave(true)}

--- a/packages/web/src/routes/session.tsx
+++ b/packages/web/src/routes/session.tsx
@@ -87,7 +87,12 @@ function Session(props: { session: SessionType; channel: SessionChannel; config:
     setTsServerSuggestions,
   } = useCells();
 
-  const { installing: installingDependencies } = usePackageJson();
+  const {
+    npmInstall,
+    failed: dependencyInstallFailed,
+    outdated: dependenciesOutdated,
+    installing: installingDependencies,
+  } = usePackageJson();
 
   const [depsInstallModalOpen, setDepsInstallModalOpen] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
@@ -203,13 +208,46 @@ function Session(props: { session: SessionType; channel: SessionChannel; config:
   const cells = remainingCells as (MarkdownCellType | CodeCellType | GenerateAICellType)[];
 
   useEffect(() => {
-    if (installingDependencies && !depsInstallModalOpen) {
-      const toastId = toast.loading('Installing dependencies...');
-      return () => toast.dismiss(toastId);
-    } else {
-      return () => {};
+    let result: () => void = () => {};
+
+    if (depsInstallModalOpen || showSettings) {
+      return result;
     }
-  }, [installingDependencies, depsInstallModalOpen]);
+
+    if (installingDependencies) {
+      const toastId = toast.loading('Installing dependencies...');
+      result = () => toast.dismiss(toastId);
+    } else if (dependencyInstallFailed) {
+      const toastId = toast.error('Failed to install dependencies', {
+        duration: 10000,
+        action: {
+          label: 'Try again',
+          onClick: () => {
+            setShowSettings(true);
+            setTimeout(npmInstall, 100);
+          },
+        },
+      });
+      result = () => toast.dismiss(toastId);
+    } else if (dependenciesOutdated) {
+      toast.warning('Packages need to be installed', {
+        duration: 10000,
+        action: {
+          label: 'Install',
+          onClick: () => npmInstall(),
+        },
+      });
+    }
+
+    return result;
+  }, [
+    dependenciesOutdated,
+    installingDependencies,
+    dependencyInstallFailed,
+    showSettings,
+    depsInstallModalOpen,
+    npmInstall,
+  ]);
 
   return (
     <>


### PR DESCRIPTION
This PR adds support for:

* Informing users when dependencies have failed to install
* Displays NPM output logs so user can debug
* Prompts user that installing dependencies failed (and brings them to settings install when they "try again")

#### Follow ups

- [ ] Style toast appropriately

### Successful install

<img width="1418" alt="Screenshot 2024-08-30 at 4 41 49 PM" src="https://github.com/user-attachments/assets/37578303-a376-445f-8af7-d596c5df4f32">

### Failed install

<img width="1418" alt="Screenshot 2024-08-30 at 4 41 29 PM" src="https://github.com/user-attachments/assets/600183a7-ffce-4ccf-ad60-895cf2ed18d3">

### Failed install when page is loaded or settings panel is closed

<img width="1418" alt="Screenshot 2024-08-30 at 4 41 24 PM" src="https://github.com/user-attachments/assets/149ede00-65b8-4c5c-bd0a-143a0672f0e3">