### PR TITLE
Add proper dev step for packages/shared

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "prebuild": "rm -rf ./dist",
     "build": "tsc",
+    "dev": "tsc --watch --project .",
     "check-types": "tsc",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
removes the need to run `pnpm build` before triggering `pnpm dev` for any changes to `@srcbook/shared`