### PR TITLE
Syntax highlighting in hover tooltips

### DIFF
--- a/packages/shared/src/schemas/tsserver.ts
+++ b/packages/shared/src/schemas/tsserver.ts
@@ -37,6 +37,13 @@ export const TsServerJSDocSchema = z
   ])
   .optional();
 
+export const TsServerJsDocTagsSchema = z.array(
+  z.object({
+    name: z.string(),
+    text: TsServerJSDocSchema,
+  }),
+);
+
 export const TsServerQuickInfoResponseSchema = z.object({
   kind: z.string(),
   kindModifiers: z.string(),
@@ -44,10 +51,5 @@ export const TsServerQuickInfoResponseSchema = z.object({
   end: TsServerLocationSchema,
   displayString: z.string(),
   documentation: TsServerJSDocSchema,
-  tags: z.array(
-    z.object({
-      name: z.string(),
-      text: TsServerJSDocSchema,
-    }),
-  ),
+  tags: TsServerJsDocTagsSchema,
 });

--- a/packages/shared/src/types/tsserver.ts
+++ b/packages/shared/src/types/tsserver.ts
@@ -5,6 +5,8 @@ import {
   TsServerDiagnosticSchema,
   TsServerSuggestionSchema,
   TsServerQuickInfoRequestSchema,
+  TsServerJSDocSchema,
+  TsServerJsDocTagsSchema,
   TsServerQuickInfoResponseSchema,
 } from '../schemas/tsserver.js';
 
@@ -12,4 +14,6 @@ export type TsServerLocationType = z.infer<typeof TsServerLocationSchema>;
 export type TsServerDiagnosticType = z.infer<typeof TsServerDiagnosticSchema>;
 export type TsServerSuggestionType = z.infer<typeof TsServerSuggestionSchema>;
 export type TsServerQuickInfoRequestType = z.infer<typeof TsServerQuickInfoRequestSchema>;
+export type TsServerJSDocType = z.infer<typeof TsServerJSDocSchema>;
+export type TsServerJsDocTagsType = z.infer<typeof TsServerJsDocTagsSchema>;
 export type TsServerQuickInfoResponseType = z.infer<typeof TsServerQuickInfoResponseSchema>;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -20,6 +20,7 @@
     "@codemirror/merge": "^6.6.5",
     "@codemirror/state": "^6.4.1",
     "@lezer/highlight": "^1.2.0",
+    "@lezer/javascript": "^1.4.17",
     "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-icons": "^1.3.0",

--- a/packages/web/src/components/cells/code.tsx
+++ b/packages/web/src/components/cells/code.tsx
@@ -638,7 +638,8 @@ function CodeEditor({
   updateCellOnServer: (cell: CodeCellType, attrs: CodeCellUpdateAttrsType) => void;
   readOnly: boolean;
 }) {
-  const { codeTheme } = useTheme();
+  const { theme, codeTheme } = useTheme();
+
   const {
     updateCell: updateCellOnClient,
     getTsServerDiagnostics,
@@ -652,14 +653,16 @@ function CodeEditor({
     return true;
   }
 
-  let extensions = [
+  const extensions = [
     javascript({ typescript: true }),
-    tsHover(session.id, cell, channel, codeTheme),
+    tsHover(session.id, cell, channel, theme),
     tsLinter(cell, getTsServerDiagnostics, getTsServerSuggestions),
     Prec.highest(keymap.of([{ key: 'Mod-Enter', run: evaluateModEnter }])),
   ];
+
   if (readOnly) {
-    extensions = extensions.concat([EditorView.editable.of(false), EditorState.readOnly.of(true)]);
+    extensions.push(EditorView.editable.of(false));
+    extensions.push(EditorState.readOnly.of(true));
   }
 
   return (

--- a/packages/web/src/components/cells/code.tsx
+++ b/packages/web/src/components/cells/code.tsx
@@ -654,7 +654,7 @@ function CodeEditor({
 
   let extensions = [
     javascript({ typescript: true }),
-    tsHover(session.id, cell, channel),
+    tsHover(session.id, cell, channel, codeTheme),
     tsLinter(cell, getTsServerDiagnostics, getTsServerSuggestions),
     Prec.highest(keymap.of([{ key: 'Mod-Enter', run: evaluateModEnter }])),
   ];

--- a/packages/web/src/components/cells/hover.tsx
+++ b/packages/web/src/components/cells/hover.tsx
@@ -1,24 +1,22 @@
-import {
+import type {
   CodeCellType,
-  TsServerQuickInfoRequestPayloadType,
+  TsServerJsDocTagsType,
+  TsServerJSDocType,
   TsServerQuickInfoResponsePayloadType,
-  TsServerQuickInfoResponseType,
 } from '@srcbook/shared';
-import { Extension, hoverTooltip, EditorView, EditorState } from '@uiw/react-codemirror';
+import { Extension, hoverTooltip } from '@uiw/react-codemirror';
 import { mapCMLocationToTsServer } from './util';
 import { SessionChannel } from '@/clients/websocket';
-import { createRoot } from 'react-dom/client';
-import { useEffect, useState } from 'react';
-import { javascript } from '@codemirror/lang-javascript';
 import { parse } from 'marked';
-import { type ThemeExtensionType } from '@/components/use-theme';
+import { formatCode } from '@/lib/code-theme';
+import { type ThemeType } from '@/components/use-theme';
 
 /** Hover extension for TS server information */
 export function tsHover(
   sessionId: string,
   cell: CodeCellType,
   channel: SessionChannel,
-  codeTheme: ThemeExtensionType,
+  theme: ThemeType,
 ): Extension {
   return hoverTooltip(async (view, pos) => {
     if (cell.language !== 'typescript') {
@@ -36,148 +34,101 @@ export function tsHover(
       pos: start,
       end: end,
       create: () => {
-        let innerView: EditorView | null = null;
+        const tooltipContainer = document.createElement('div');
+        tooltipContainer.className = 'p-2 space-y-2 max-w-3xl max-h-96 overflow-scroll';
 
-        function callback(payload: TsServerQuickInfoResponsePayloadType) {
-          innerView = new EditorView({
-            doc: payload.response.displayString,
-            extensions: [
-              javascript({ typescript: true }),
-              EditorState.readOnly.of(true),
-              codeTheme,
-            ],
-          });
+        function callback({ response }: TsServerQuickInfoResponsePayloadType) {
+          console.log(response);
 
-          tooltipView.dom.appendChild(innerView.dom);
+          const signatureNode = formatCode(response.displayString, theme);
+          tooltipContainer.appendChild(signatureNode);
 
-          const documentation = payload.response.documentation;
-          if (typeof documentation === 'string') {
-            const div = document.createElement('div');
-            div.className = 'p-2 sb-prose text-tertiary-foreground';
-            div.innerHTML = parse(documentation) as string;
-            tooltipView.dom.appendChild(div);
+          const documentationNode = formatDocumentation(response.documentation);
+          if (documentationNode !== null) {
+            tooltipContainer.appendChild(documentationNode);
+          }
+
+          const tagsNode = formatTags(response.tags);
+          if (tagsNode !== null) {
+            tooltipContainer.appendChild(tagsNode);
           }
         }
 
-        const tooltipView = {
-          dom: document.createElement('div'),
+        return {
+          dom: tooltipContainer,
           mount() {
-            const request: TsServerQuickInfoRequestPayloadType = {
+            channel.on('tsserver:cell:quickinfo:response', callback);
+            channel.push('tsserver:cell:quickinfo:request', {
               sessionId: sessionId,
               cellId: cell.id,
               request: { location: mapCMLocationToTsServer(cell.source, pos) },
-            };
-            channel.on('tsserver:cell:quickinfo:response', callback);
-            channel.push('tsserver:cell:quickinfo:request', request);
+            });
           },
           destroy() {
             channel.off('tsserver:cell:quickinfo:response', callback);
-            innerView?.destroy();
           },
         };
-
-        return tooltipView;
       },
     };
   });
 }
 
-function Tooltip({
-  sessionId,
-  cell,
-  channel,
-  pos,
-}: {
-  sessionId: string;
-  cell: CodeCellType;
-  channel: SessionChannel;
-  pos: number;
-}) {
-  const [hoverInfo, setHoverInfo] = useState<TsServerQuickInfoResponseType | null>(null);
+function formatDocumentation(documentation: TsServerJSDocType): HTMLElement | null {
+  if (!documentation) {
+    return null;
+  }
 
-  useEffect(() => {
-    if (cell.language !== 'typescript') {
-      setHoverInfo(null);
-      return;
-    }
+  const text =
+    typeof documentation === 'string'
+      ? documentation.trim()
+      : documentation
+          .map((part) => (typeof part === 'string' ? part : `${part.text} kind ${part.kind}`))
+          .join('\n\n')
+          .trim();
 
-    const tsServerPosition = mapCMLocationToTsServer(cell.source, pos);
+  if (text.length === 0) {
+    return null;
+  }
 
-    const request: TsServerQuickInfoRequestPayloadType = {
-      sessionId: sessionId,
-      cellId: cell.id,
-      request: { location: tsServerPosition },
-    };
+  const div = document.createElement('div');
+  div.className = 'sb-prose text-tertiary-foreground';
+  div.innerHTML = parse(text) as string;
 
-    channel.push('tsserver:cell:quickinfo:request', request);
-
-    function callback(payload: TsServerQuickInfoResponsePayloadType) {
-      setHoverInfo(payload.response);
-      channel.off('tsserver:cell:quickinfo:response', callback);
-    }
-
-    channel.on('tsserver:cell:quickinfo:response', callback);
-  }, [cell, channel, pos, sessionId]);
-
-  if (!hoverInfo) return null;
-
-  return (
-    <div className="p-2 space-y-3 max-w-lg max-h-64 text-xs overflow-auto relative">
-      {hoverInfo.displayString && <span>{hoverInfo.displayString}</span>}
-      {hoverInfo.documentation && (
-        <div>
-          {typeof hoverInfo.documentation === 'string' ? (
-            <span className="text-tertiary-foreground pt-2 whitespace-pre-wrap">
-              {hoverInfo.documentation}
-            </span>
-          ) : (
-            hoverInfo.documentation.map((part, index) => (
-              <span key={index} className="text-tertiary-foreground pt-2 whitespace-pre-wrap">
-                {typeof part === 'string' ? part : `${part.text} kind ${part.kind}`}
-              </span>
-            ))
-          )}
-        </div>
-      )}
-      {hoverInfo.tags.length > 0 && (
-        <div>
-          {hoverInfo.tags.map((part, index) => (
-            <span key={part.name + index.toString()}>
-              <span className="italic">
-                {part.name === 'example' ? '@example' : `@${part.name} - `}
-              </span>
-              {part.name === 'example' && <br />}
-              <span className="text-tertiary-foreground whitespace-pre-wrap">
-                {typeof part === 'string'
-                  ? part
-                  : typeof part.text === 'string'
-                    ? part.text
-                    : part.text?.map((text) => text.text).join('\n')}
-              </span>
-              <br />
-            </span>
-          ))}
-        </div>
-      )}
-    </div>
-  );
+  return div;
 }
 
-export const hoverRenderer = ({
-  sessionId,
-  cell,
-  channel,
-  pos,
-}: {
-  sessionId: string;
-  cell: CodeCellType;
-  channel: SessionChannel;
-  pos: number;
-}) => {
-  const dom = document.createElement('div');
+function formatTags(tags: TsServerJsDocTagsType): HTMLElement | null {
+  if (tags.length === 0) {
+    return null;
+  }
 
-  const root = createRoot(dom);
-  root.render(<Tooltip sessionId={sessionId} cell={cell} channel={channel} pos={pos} />);
+  const div = document.createElement('div');
+  div.className = 'sb-prose text-tertiary-foreground space-y-2';
 
-  return { dom };
-};
+  for (const tag of tags) {
+    const tagDiv = document.createElement('div');
+
+    const span = document.createElement('span');
+    span.className = 'italic';
+
+    if (tag.name === 'example') {
+      span.innerText = '@example';
+      tagDiv.appendChild(span);
+      tagDiv.appendChild(document.createElement('br'));
+    } else {
+      span.innerText = `@${tag.name}`;
+      tagDiv.appendChild(span);
+    }
+
+    if (typeof tag.text === 'string') {
+      const span = document.createElement('span');
+      span.appendChild(document.createTextNode('\u00A0'));
+      span.appendChild(document.createTextNode(tag.text));
+      tagDiv.append(span);
+    }
+
+    div.appendChild(tagDiv);
+  }
+
+  return div;
+}

--- a/packages/web/src/components/cells/hover.tsx
+++ b/packages/web/src/components/cells/hover.tsx
@@ -38,8 +38,6 @@ export function tsHover(
         tooltipContainer.className = 'p-2 space-y-2 max-w-3xl max-h-96 overflow-scroll';
 
         function callback({ response }: TsServerQuickInfoResponsePayloadType) {
-          console.log(response);
-
           const signatureNode = formatCode(response.displayString, theme);
           tooltipContainer.appendChild(signatureNode);
 

--- a/packages/web/src/components/use-theme.tsx
+++ b/packages/web/src/components/use-theme.tsx
@@ -28,8 +28,6 @@ function updateClass(theme: ThemeType) {
   }
 }
 
-export type ThemeExtensionType = typeof srcbookDark;
-
 export default function useTheme() {
   const [theme, _setTheme] = useState<ThemeType>(getTheme());
 

--- a/packages/web/src/components/use-theme.tsx
+++ b/packages/web/src/components/use-theme.tsx
@@ -28,6 +28,8 @@ function updateClass(theme: ThemeType) {
   }
 }
 
+export type ThemeExtensionType = typeof srcbookDark;
+
 export default function useTheme() {
   const [theme, _setTheme] = useState<ThemeType>(getTheme());
 

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -394,19 +394,19 @@
 }
 
 .cm-tooltip {
-  background-color: hsl(var(--background)) !important;
-  border-color: hsl(var(--border)) !important;
-  border-width: 1px;
-  border-radius: 0.1875rem;
-  overflow: hidden;
-  box-shadow:
-    0 4px 6px -1px rgb(0 0 0 / 0.1),
-    0 2px 4px -2px rgb(0 0 0 / 0.1);
+  @apply overflow-hidden;
+  @apply !bg-background;
+  @apply border;
+  @apply rounded-sm;
+  @apply shadow-md;
+  @apply !border-border;
 }
+
 .cm-diagnostic {
-  margin-left: 0;
-  padding: 0 !important;
+  @apply ml-0;
+  @apply !p-0;
 }
+
 .cm-tooltip-section:not(:first-child) {
-  border-top: 0 !important;
+  @apply !border-t-0;
 }

--- a/packages/web/src/lib/code-theme.ts
+++ b/packages/web/src/lib/code-theme.ts
@@ -1,11 +1,9 @@
-/**
- * @name srcbook
- */
-import { tags as t } from '@lezer/highlight';
+import { highlightCode, tags as t, tagHighlighter } from '@lezer/highlight';
+import { parser as lezerParser } from '@lezer/javascript';
 import { createTheme, CreateThemeOptions } from '@uiw/codemirror-themes';
 
-export const defaultSettingsSrcbookLight: CreateThemeOptions['settings'] = {
-  background: 'var(--backround)',
+const DEFAULT_LIGHT_SETTINGS: CreateThemeOptions['settings'] = {
+  background: 'var(--background)',
   foreground: 'var(--foreground)',
   caret: 'var(--foreground)',
   selection: '#BBDFFF',
@@ -17,38 +15,7 @@ export const defaultSettingsSrcbookLight: CreateThemeOptions['settings'] = {
   lineHighlight: 'transparent',
 };
 
-export const srcbookLightInit = (options?: Partial<CreateThemeOptions>) => {
-  const { theme = 'light', settings = {}, styles = [] } = options || {};
-  return createTheme({
-    theme: theme,
-    settings: {
-      ...defaultSettingsSrcbookLight,
-      ...settings,
-    },
-    styles: [
-      { tag: [t.standard(t.tagName), t.tagName], color: '#116329' },
-      { tag: [t.comment, t.bracket], color: '#6a737d' },
-      { tag: [t.className, t.propertyName], color: '#6f42c1' },
-      { tag: [t.variableName, t.attributeName, t.number, t.operator], color: '#005cc5' },
-      { tag: [t.keyword, t.typeName, t.typeOperator, t.typeName], color: '#d73a49' },
-      { tag: [t.string, t.meta, t.regexp], color: '#032f62' },
-      { tag: [t.name, t.quote], color: '#22863a' },
-      { tag: [t.heading, t.strong], color: '#24292e', fontWeight: 'bold' },
-      { tag: [t.emphasis], color: '#24292e', fontStyle: 'italic' },
-      { tag: [t.deleted], color: '#b31d28', backgroundColor: 'ffeef0' },
-      { tag: [t.atom, t.bool, t.special(t.variableName)], color: '#e36209' },
-      { tag: [t.url, t.escape, t.regexp, t.link], color: '#032f62' },
-      { tag: t.link, textDecoration: 'underline' },
-      { tag: t.strikethrough, textDecoration: 'line-through' },
-      { tag: t.invalid, color: '#cb2431' },
-      ...styles,
-    ],
-  });
-};
-
-export const srcbookLight = srcbookLightInit();
-
-export const defaultSettingsSrcbookDark: CreateThemeOptions['settings'] = {
+export const DEFAULT_DARK_SETTINGS: CreateThemeOptions['settings'] = {
   background: 'var(--background)',
   foreground: 'var(--foreground)',
   caret: 'var(--foreground)',
@@ -60,32 +27,89 @@ export const defaultSettingsSrcbookDark: CreateThemeOptions['settings'] = {
   gutterBorder: 'transparent',
 };
 
-export const srcbookDarkInit = (options?: Partial<CreateThemeOptions>) => {
-  const { theme = 'dark', settings = {}, styles = [] } = options || {};
-  return createTheme({
-    theme: theme,
-    settings: {
-      ...defaultSettingsSrcbookDark,
-      ...settings,
-    },
-    styles: [
-      { tag: [t.standard(t.tagName), t.tagName], color: '#7ee787' },
-      { tag: [t.comment, t.bracket], color: '#8b949e' },
-      { tag: [t.className, t.propertyName], color: '#d2a8ff' },
-      { tag: [t.variableName, t.attributeName, t.number, t.operator], color: '#79c0ff' },
-      { tag: [t.keyword, t.typeName, t.typeOperator, t.typeName], color: '#ff7b72' },
-      { tag: [t.string, t.meta, t.regexp], color: '#a5d6ff' },
-      { tag: [t.name, t.quote], color: '#7ee787' },
-      { tag: [t.heading, t.strong], color: '#d2a8ff', fontWeight: 'bold' },
-      { tag: [t.emphasis], color: '#d2a8ff', fontStyle: 'italic' },
-      { tag: [t.deleted], color: '#ffdcd7', backgroundColor: 'ffeef0' },
-      { tag: [t.atom, t.bool, t.special(t.variableName)], color: '#ffab70' },
-      { tag: t.link, textDecoration: 'underline' },
-      { tag: t.strikethrough, textDecoration: 'line-through' },
-      { tag: t.invalid, color: '#f97583' },
-      ...styles,
-    ],
-  });
-};
+export const LIGHT_TAGS = [
+  { tag: [t.standard(t.tagName), t.tagName], class: 'text-[#116329]' },
+  { tag: [t.comment, t.bracket], class: 'text-[#6a737d]' },
+  { tag: [t.className, t.propertyName], class: 'text-[#6f42c1]' },
+  { tag: [t.variableName, t.attributeName, t.number, t.operator], class: 'text-[#005cc5]' },
+  { tag: [t.keyword, t.typeName, t.typeOperator, t.typeName], class: 'text-[#d73a49]' },
+  { tag: [t.string, t.meta, t.regexp], class: 'text-[#032f62]' },
+  { tag: [t.name, t.quote], class: 'text-[#22863a]' },
+  { tag: [t.heading, t.strong], class: 'text-[#24292e] font-bold' },
+  { tag: [t.emphasis], class: 'text-[#24292e] italic' },
+  { tag: [t.deleted], class: 'text-[#b31d28] bg-[#ffeef0]' },
+  { tag: [t.atom, t.bool, t.special(t.variableName)], class: 'text-[#e36209]' },
+  { tag: [t.url, t.escape, t.regexp, t.link], class: 'text-[#032f62]' },
+  { tag: t.link, class: 'underline' },
+  { tag: t.strikethrough, class: 'line-through' },
+  { tag: t.invalid, class: 'text-[#cb2431]' },
+];
+export const DARK_TAGS = [
+  { tag: [t.standard(t.tagName), t.tagName], class: 'text-[#7ee787]' },
+  { tag: [t.comment, t.bracket], class: 'text-[#8b949e]' },
+  { tag: [t.className, t.propertyName], class: 'text-[#d2a8ff]' },
+  { tag: [t.variableName, t.attributeName, t.number, t.operator], class: 'text-[#79c0ff]' },
+  { tag: [t.keyword, t.typeName, t.typeOperator, t.typeName], class: 'text-[#ff7b72]' },
+  { tag: [t.string, t.meta, t.regexp], class: 'text-[#a5d6ff]' },
+  { tag: [t.name, t.quote], class: 'text-[#7ee787]' },
+  { tag: [t.heading, t.strong], class: 'text-[#d2a8ff] font-bold' },
+  { tag: [t.emphasis], class: 'text-[#d2a8ff] italic' },
+  { tag: [t.deleted], class: 'text-[#ffdcd7] bg-[#ffeef0]' },
+  { tag: [t.atom, t.bool, t.special(t.variableName)], class: 'text-[#ffab70]' },
+  { tag: t.link, class: 'underline' },
+  { tag: t.strikethrough, class: 'line-through' },
+  { tag: t.invalid, class: 'text-[#f97583]' },
+];
 
-export const srcbookDark = srcbookDarkInit();
+export const srcbookLight = createTheme({
+  theme: 'light',
+  settings: DEFAULT_LIGHT_SETTINGS,
+  styles: LIGHT_TAGS,
+});
+
+export const srcbookDark = createTheme({
+  theme: 'dark',
+  settings: DEFAULT_DARK_SETTINGS,
+  styles: DARK_TAGS,
+});
+
+function getTagHighlighter(theme: 'light' | 'dark') {
+  return tagHighlighter(theme === 'light' ? LIGHT_TAGS : DARK_TAGS);
+}
+
+/**
+ * Formats source code by applying syntax highlighting.
+ * The result is a DOM element containing the styled tokens.
+ */
+export function formatCode(
+  source: string,
+  theme: 'light' | 'dark',
+  classes: string = 'whitespace-pre-wrap',
+): HTMLElement {
+  const parser = lezerParser.configure({ dialect: 'ts' });
+  const tree = parser.parse(source);
+  const highlighter = getTagHighlighter(theme);
+
+  const root = document.createElement('div');
+
+  root.className = classes;
+
+  function putText(code: string, classes: string) {
+    if (classes.length === 0) {
+      root.append(document.createTextNode(code));
+    } else {
+      const element = document.createElement('span');
+      element.innerText = code;
+      element.className = classes;
+      root.append(element);
+    }
+  }
+
+  function putBreak() {
+    root.append(document.createElement('br'));
+  }
+
+  highlightCode(source, tree, highlighter, putText, putBreak);
+
+  return root;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       '@lezer/highlight':
         specifier: ^1.2.0
         version: 1.2.0
+      '@lezer/javascript':
+        specifier: ^1.4.17
+        version: 1.4.17
       '@radix-ui/react-collapsible':
         specifier: ^1.0.3
         version: 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1132,8 +1135,8 @@ packages:
   '@lezer/html@1.3.10':
     resolution: {integrity: sha512-dqpT8nISx/p9Do3AchvYGV3qYc4/rKr3IBZxlHmpIKam56P47RSHkSF5f13Vu9hebS1jM0HmtJIwLbWz1VIY6w==}
 
-  '@lezer/javascript@1.4.16':
-    resolution: {integrity: sha512-84UXR3N7s11MPQHWgMnjb9571fr19MmXnr5zTv2XX0gHXXUvW3uPJ8GCjKrfTXmSdfktjRK0ayKklw+A13rk4g==}
+  '@lezer/javascript@1.4.17':
+    resolution: {integrity: sha512-bYW4ctpyGK+JMumDApeUzuIezX01H76R1foD6LcRX224FWfyYit/HYxiPGDjXXe/wQWASjCvVGoukTH68+0HIA==}
 
   '@lezer/json@1.0.2':
     resolution: {integrity: sha512-xHT2P4S5eeCYECyKNPhr4cbEL9tc8w83SPwRC373o9uEdrvGKTZoJVAGxpOsZckMlEh9W23Pc72ew918RWQOBQ==}
@@ -4661,7 +4664,7 @@ snapshots:
       '@codemirror/state': 6.4.1
       '@codemirror/view': 6.27.0
       '@lezer/common': 1.2.1
-      '@lezer/javascript': 1.4.16
+      '@lezer/javascript': 1.4.17
 
   '@codemirror/lang-json@6.0.1':
     dependencies:
@@ -5038,7 +5041,7 @@ snapshots:
       '@lezer/highlight': 1.2.0
       '@lezer/lr': 1.4.1
 
-  '@lezer/javascript@1.4.16':
+  '@lezer/javascript@1.4.17':
     dependencies:
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.2.0


### PR DESCRIPTION
This adds syntax highlighting and formatting for the type signature + JS docs when hovering over a term in our code editor.

### Dark mode

<img width="1010" alt="Screenshot 2024-09-04 at 4 46 21 PM" src="https://github.com/user-attachments/assets/17fdd562-3acb-49e9-9fec-627187d5dbd1">

### Light mode

<img width="965" alt="Screenshot 2024-09-04 at 4 46 10 PM" src="https://github.com/user-attachments/assets/da78fa74-e4c4-4193-87e3-7db93ffd832b">

### Notes

* This is far from perfect but it's an improvement on what's already there. The type signature is in a good place but the JS docs are styled using our existing markdown styles (`sb-prose` class) which is intended for blog-post like prose, not condensed tooltips. We will have to address this later.
* I removed react for now but only because this felt simple enough. That may be a bad decision though and may want to reintroduce, we'll see.