### PR TITLE
Update prompts, comes with a Srcbook of evals !

### DIFF
--- a/packages/api/prompts/srcbook-generator.txt
+++ b/packages/api/prompts/srcbook-generator.txt
@@ -13,7 +13,7 @@ Srcbooks are either in javascript, or typescript, and their markdown always star
 
 Structure of a srcbook:
 0. The language comment: <!-- srcbook:{"language":"javascript"} --> for example for javascript
-1. Title cell (always first)
+1. Title cell (always first, as short as possible, no more than 44 characters)
 2. Package.json cell (always second)
 3. Markdown cells (GitHub flavored Markdown)
 4. Code cells (either JavaScript or TypeScript), which have filenames and source contents.
@@ -21,7 +21,7 @@ Structure of a srcbook:
 Follow these steps to create your srcbook:
 
 1. Title Cell:
-Create a title cell as the first cell of your srcbook.
+Create a title cell as the first cell of your srcbook. Make it as short as possible, no more than 44 characters.
 <example>
 # Express server basics
 </example>
@@ -57,7 +57,7 @@ In this srcbook, we'll explore the fundamentals of **websockets** and the ws lib
 </example>
 
 4. Code Cells:
-Code cells are either JavaScript or TypeScript. They have a filename, like for example something.js or something.ts respectively for JS or TS. The filename is set as an H6 right before a code block with triple backticks. Use triple backticks to denote a code block and specify the language as javascript or typescript. Remember that these are ECMAScript modules, so you can export variables and import from other code cells. For example:
+Code cells are either JavaScript or TypeScript. They have a unique filename, for example something.js or something.ts respectively for JS or TS. The filename is set as an H6 right before a code block with triple backticks. Use triple backticks to denote a code block and specify the language as javascript or typescript. Remember that these are ECMAScript modules, so you can export variables and import from other code cells. Make sure to never reuse a filename twice. For example:
 <example>
 ###### file1.js
 ```javascript
@@ -76,7 +76,7 @@ console.log(demonstrateFeature("example"));
 
 ===== BEGING EXAMPLES =====
 
-Below are 3 examples of Srcbooks. 
+Below are 3 examples of Srcbooks.
 
 ### Example 1: Getting started
 <!-- srcbook:{"language":"javascript"} -->
@@ -521,7 +521,7 @@ One of the more tedious aspects of this is keeping track of the state about conn
 ===== END EXAMPLES =====
 
 ===== FINAL INSTRUCTIONS =====
-The user will describe the srcbook they want, your job is to create it following the above guidelines. Aim for a balance of explanatory markdown cells and demonstrative code cells. Be brief but thorough. A typical srcbook will have 4 to 10 cells, but if the request makes sense for that rule to be broken, that's fine.
+The user will describe the srcbook they want, your job is to create it following the above guidelines. Aim for a balance of explanatory markdown cells and demonstrative code cells. If they express intent that they want to learn, use more markdown. If they clearly want to prototype things, use more code. Be brief but thorough. A typical srcbook will have 4 to 10 cells, but if the request makes sense for that rule to be broken, that's fine.
 
-Response with _only_ the srcbook contents, no preambule, prefix, or suffix at the end. 
+Response with _only_ the srcbook contents, no preambule, prefix, or suffix at the end.
 ===== END FINAL INSTRUCTIONS ===


### PR DESCRIPTION
Fixes 2 issues with our previous AI generation prompt: 
- Adds the constraint that titles should be short (shorter than 44 chars)
- Adds the constraint that filenames should be unique

## Testing
I actually used Srcbook for this! I created a Srcbook which runs evals. I'll share it in the hub soon so others can use / extend it.

Results for the title:
```
{
  'Create a typescript srcbook teaching me about CRDTs and Y.js': {
    old: {
      openai: 'Conflict-Free Replicated Data Types (CRDTs) with Y.js',
      anthropic: 'Conflict-free Replicated Data Types (CRDTs) and Y.js'
    },
    new: { openai: 'CRDTs with Y.js', anthropic: 'CRDTs and Y.js' }
  },
  'I want to learn about websockets': {
    old: {
      openai: 'Introduction to WebSockets',
      anthropic: 'WebSockets Fundamentals'
    },
    new: {
      openai: 'WebSockets Overview',
      anthropic: 'WebSockets Fundamentals'
    }
  },
  'A srcbook which helps me check which ports have a service running on my machine and which are available': {
    old: {
      openai: 'Checking Ports on Your Machine',
      anthropic: 'Port Checker'
    },
    new: { openai: 'Port Availability Checker', anthropic: 'Port checker' }
  },
  'A srcbook to take screenshots of the front page of HN using puppeteer': {
    old: {
      openai: 'Taking Screenshots of Hacker News Front Page with Puppeteer',
      anthropic: 'Taking Screenshots with Puppeteer'
    },
    new: {
      openai: 'Screenshot HN Front Page',
      anthropic: 'HN Screenshot Puppeteer'
    }
  },
  'A srcbook showing best practices on how to factor code to do type checking using zod when building an express API server.': {
    old: {
      openai: 'Type Checking in Express with Zod',
      anthropic: 'Type Checking with Zod in Express APIs'
    },
    new: {
      openai: 'Express & Zod Best Practices',
      anthropic: 'Zod Type Checking for Express'
    }
  }
}
```