### PR TITLE
Update CONTRIBUTING.md to require pnpm version 9.5+

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 ## Setup
 
 - Node 22+
-- pnpm 9+
+- pnpm 9.5+
 
 ## Development
 


### PR DESCRIPTION
This was required when I set things up locally - I was running an older version of `9`, but that didn't support the `catalog:` stuff in some of the package.json's which led to install issues.