### PR TITLE
Add a mailing list subscription upsell on front-page and settings

### DIFF
--- a/.changeset/honest-stingrays-push.md
+++ b/.changeset/honest-stingrays-push.md
@@ -1,0 +1,7 @@
+---
+'@srcbook/api': patch
+'@srcbook/web': patch
+'srcbook': patch
+---
+
+Added an upsell to subscribe to our mailing list + ability to update in settings

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ srcbook/lib/**/*
 
 # turbo
 **/.turbo
+
+# Aide
+*.code-workspace

--- a/packages/api/db/schema.mts
+++ b/packages/api/db/schema.mts
@@ -14,6 +14,8 @@ export const configs = sqliteTable('config', {
   aiProvider: text('ai_provider').notNull().default('openai'),
   aiModel: text('ai_model').default('gpt-4o'),
   aiBaseUrl: text('ai_base_url'),
+  // Null: unset. Email: subscribed. "dismissed": dismissed the dialog.
+  subscriptionEmail: text('subscription_email'),
 });
 
 export type Config = typeof configs.$inferSelect;

--- a/packages/api/drizzle/0007_add_subscription_email.sql
+++ b/packages/api/drizzle/0007_add_subscription_email.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `config` ADD `subscription_email` text;

--- a/packages/api/drizzle/meta/0007_snapshot.json
+++ b/packages/api/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,139 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a8c6d627-368f-4e6d-bdd9-42ffb1d8a8b2",
+  "prevId": "e99407eb-2c92-4d3c-8864-bd760846d61b",
+  "tables": {
+    "config": {
+      "name": "config",
+      "columns": {
+        "base_dir": {
+          "name": "base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_language": {
+          "name": "default_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'typescript'"
+        },
+        "openai_api_key": {
+          "name": "openai_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anthropic_api_key": {
+          "name": "anthropic_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled_analytics": {
+          "name": "enabled_analytics",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "srcbook_installation_id": {
+          "name": "srcbook_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'kkoge7ntqjmhgn1l5ljmkdsfpg'"
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openai'"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'gpt-4o'"
+        },
+        "ai_base_url": {
+          "name": "ai_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subscription_email": {
+          "name": "subscription_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "secrets": {
+      "name": "secrets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "secrets_name_unique": {
+          "name": "secrets_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1723745583289,
       "tag": "0006_deprecate_ai_config",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1725736805777,
+      "tag": "0007_add_subscription_email",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/server/http.mts
+++ b/packages/api/server/http.mts
@@ -338,6 +338,24 @@ router.get('/npm/search', cors(), async (req, res) => {
   return res.json({ result: results });
 });
 
+router.options('/subscribe', cors());
+router.post('/subscribe', cors(), async (req, res) => {
+  const { email } = req.body;
+  const hubResponse = await fetch('https://hub.srcbook.com/api/subscribe', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email }),
+  });
+
+  if (hubResponse.ok) {
+    return res.json({ success: true });
+  } else {
+    return res.status(hubResponse.status).json({ success: false });
+  }
+});
+
 app.use('/api', router);
 
 export default app;

--- a/packages/web/src/components/mailing-list-card.tsx
+++ b/packages/web/src/components/mailing-list-card.tsx
@@ -43,9 +43,6 @@ export default function MailingListCard() {
       const response = await subscribeToMailingList(email);
       if (response.success) {
         handleSubscribe();
-      } else if (response.status === 409) {
-        toast.info('You are already subscribed to our mailing list.');
-        handleSubscribe();
       } else {
         toast.error('There was an error subscribing to the mailing list. Please try again later.');
       }

--- a/packages/web/src/components/mailing-list-card.tsx
+++ b/packages/web/src/components/mailing-list-card.tsx
@@ -1,0 +1,104 @@
+import { useState, useEffect } from 'react';
+import { X, Mailbox } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+import { subscribeToMailingList } from '@/lib/server';
+import { getSubscribedEmailStatus, setSubscribedEmailStatus } from '@/lib/utils';
+
+export default function MailingListCard() {
+  const [isVisible, setIsVisible] = useState(() => {
+    const { email, dismissed } = getSubscribedEmailStatus();
+    return !email && !dismissed;
+  });
+
+  const [email, setEmail] = useState('');
+  const [subscribed, setSubscribed] = useState(false);
+
+  useEffect(() => {
+    const { email } = getSubscribedEmailStatus();
+    if (email) {
+      setEmail(email);
+      setSubscribed(true);
+    }
+  }, []);
+
+  const handleSubscribe = async () => {
+    setSubscribed(true);
+    setSubscribedEmailStatus(email);
+    setTimeout(() => {
+      setIsVisible(false);
+    }, 3000);
+  };
+
+  const handleClose = () => {
+    setSubscribedEmailStatus(null, true);
+    setIsVisible(false);
+  };
+
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (e) => {
+    e.preventDefault();
+    try {
+      const response = await subscribeToMailingList(email);
+      if (response.success) {
+        handleSubscribe();
+      } else if (response.status === 409) {
+        toast.info('You are already subscribed to our mailing list.');
+        handleSubscribe();
+      } else {
+        toast.error('There was an error subscribing to the mailing list. Please try again later.');
+      }
+    } catch (error) {
+      toast.error('There was an error subscribing to the mailing list. Please try again later.');
+      console.error('Subscription error:', error);
+    }
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <Card className="fixed bottom-6 left-6 w-[460px] shadow-lg z-30">
+      <div className="relative">
+        <button
+          className="absolute top-2 right-2 hover:bg-muted p-1 rounded-sm"
+          onClick={handleClose}
+        >
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </button>
+        <CardContent className="p-6">
+          <div className="flex flex-col gap-2">
+            <Mailbox size={24} />
+            {subscribed ? (
+              <>
+                <h1 className="mt-2 text-lg font-medium">Subscribed successfully!</h1>
+                <p>Looking forward to keeping you updated.</p>
+              </>
+            ) : (
+              <>
+                <h1 className="mt-2 text-lg font-medium">Join our mailing list!</h1>
+                <p className="">
+                  Get the latest updates, early access features, and expert tips delivered to your
+                  inbox.
+                </p>
+              </>
+            )}
+            {!subscribed && (
+              <form onSubmit={handleSubmit} className="flex gap-1 py-3">
+                <Input
+                  type="email"
+                  placeholder="Email"
+                  className=""
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                />
+                <Button type="submit">Subscribe</Button>
+              </form>
+            )}
+          </div>
+        </CardContent>
+      </div>
+    </Card>
+  );
+}

--- a/packages/web/src/components/ui/card.tsx
+++ b/packages/web/src/components/ui/card.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border bg-card text-card-foreground shadow",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/packages/web/src/components/ui/card.tsx
+++ b/packages/web/src/components/ui/card.tsx
@@ -1,76 +1,56 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const Card = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "rounded-xl border bg-card text-card-foreground shadow",
-      className
-    )}
-    {...props}
-  />
-))
-Card.displayName = "Card"
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-xl border bg-card text-card-foreground shadow', className)}
+      {...props}
+    />
+  ),
+);
+Card.displayName = 'Card';
 
-const CardHeader = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
-    {...props}
-  />
-))
-CardHeader.displayName = "CardHeader"
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  ),
+);
+CardHeader.displayName = 'CardHeader';
 
-const CardTitle = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLHeadingElement>
->(({ className, ...props }, ref) => (
-  <h3
-    ref={ref}
-    className={cn("font-semibold leading-none tracking-tight", className)}
-    {...props}
-  />
-))
-CardTitle.displayName = "CardTitle"
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3
+      ref={ref}
+      className={cn('font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
+  ),
+);
+CardTitle.displayName = 'CardTitle';
 
 const CardDescription = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, ...props }, ref) => (
-  <p
-    ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
-CardDescription.displayName = "CardDescription"
+  <p ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+));
+CardDescription.displayName = 'CardDescription';
 
-const CardContent = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
-))
-CardContent.displayName = "CardContent"
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  ),
+);
+CardContent.displayName = 'CardContent';
 
-const CardFooter = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
-    {...props}
-  />
-))
-CardFooter.displayName = "CardFooter"
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+  ),
+);
+CardFooter.displayName = 'CardFooter';
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/packages/web/src/components/ui/card.tsx
+++ b/packages/web/src/components/ui/card.tsx
@@ -22,6 +22,7 @@ CardHeader.displayName = 'CardHeader';
 
 const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
+    // eslint-disable-next-line jsx-a11y/heading-has-content
     <h3
       ref={ref}
       className={cn('font-semibold leading-none tracking-tight', className)}

--- a/packages/web/src/lib/server.ts
+++ b/packages/web/src/lib/server.ts
@@ -238,6 +238,7 @@ interface EditConfigRequestType {
   aiBaseUrl?: string;
   aiModel?: string;
   aiProvider?: AiProviderType;
+  subscriptionEmail?: string | null;
 }
 
 export async function getConfig() {
@@ -253,7 +254,7 @@ export async function getConfig() {
   return response.json();
 }
 
-export async function updateConfig(request: EditConfigRequestType) {
+export async function updateConfig(request: EditConfigRequestType): Promise<void> {
   const response = await fetch(API_BASE_URL + '/settings', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
@@ -404,10 +405,6 @@ export async function subscribeToMailingList(email: string) {
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ email }),
   });
-
-  if (response.status === 409) {
-    return { success: false, status: 409 };
-  }
 
   if (!response.ok) {
     console.error(response);

--- a/packages/web/src/lib/server.ts
+++ b/packages/web/src/lib/server.ts
@@ -397,3 +397,22 @@ export async function aiHealthcheck() {
   }
   return response.json();
 }
+
+export async function subscribeToMailingList(email: string) {
+  const response = await fetch(API_BASE_URL + '/subscribe', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email }),
+  });
+
+  if (response.status === 409) {
+    return { success: false, status: 409 };
+  }
+
+  if (!response.ok) {
+    console.error(response);
+    throw new Error('Subscription request failed');
+  }
+
+  return response.json();
+}

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -3,7 +3,6 @@ import type { SessionType } from '../types';
 import type { CellType, TitleCellType } from '@srcbook/shared';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
-import { getConfig, updateConfig } from './server';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -27,3 +27,33 @@ export function getTitleForSession(session: SessionType) {
   const titleCell = session.cells.find((cell: CellType) => cell.type === 'title') as TitleCellType;
   return titleCell?.text;
 }
+
+/**
+ * Retrieves the subscribed email status from localStorage.
+ * @returns An object with the email and a dismissed flag.
+ */
+export function getSubscribedEmailStatus(): { email: string | null; dismissed: boolean } {
+  const storedValue = localStorage.getItem('sb:mailing-list-email');
+  if (storedValue === null) {
+    return { email: null, dismissed: false };
+  }
+  if (storedValue === 'dismissed') {
+    return { email: null, dismissed: true };
+  }
+  return { email: storedValue, dismissed: false };
+}
+
+/**
+ * Sets the subscribed email status in localStorage.
+ * @param email The email to store. Pass null to remove the stored email.
+ * @param dismissed Whether the user has dismissed the subscription popup.
+ */
+export function setSubscribedEmailStatus(email: string | null, dismissed: boolean = false): void {
+  if (email === null && dismissed) {
+    localStorage.setItem('sb:mailing-list-email', 'dismissed');
+  } else if (email === null) {
+    localStorage.removeItem('sb:mailing-list-email');
+  } else {
+    localStorage.setItem('sb:mailing-list-email', email);
+  }
+}

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -3,6 +3,7 @@ import type { SessionType } from '../types';
 import type { CellType, TitleCellType } from '@srcbook/shared';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import { getConfig, updateConfig } from './server';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -26,34 +27,4 @@ export function mergeRefs<T>(
 export function getTitleForSession(session: SessionType) {
   const titleCell = session.cells.find((cell: CellType) => cell.type === 'title') as TitleCellType;
   return titleCell?.text;
-}
-
-/**
- * Retrieves the subscribed email status from localStorage.
- * @returns An object with the email and a dismissed flag.
- */
-export function getSubscribedEmailStatus(): { email: string | null; dismissed: boolean } {
-  const storedValue = localStorage.getItem('sb:mailing-list-email');
-  if (storedValue === null) {
-    return { email: null, dismissed: false };
-  }
-  if (storedValue === 'dismissed') {
-    return { email: null, dismissed: true };
-  }
-  return { email: storedValue, dismissed: false };
-}
-
-/**
- * Sets the subscribed email status in localStorage.
- * @param email The email to store. Pass null to remove the stored email.
- * @param dismissed Whether the user has dismissed the subscription popup.
- */
-export function setSubscribedEmailStatus(email: string | null, dismissed: boolean = false): void {
-  if (email === null && dismissed) {
-    localStorage.setItem('sb:mailing-list-email', 'dismissed');
-  } else if (email === null) {
-    localStorage.removeItem('sb:mailing-list-email');
-  } else {
-    localStorage.setItem('sb:mailing-list-email', email);
-  }
 }

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -22,6 +22,7 @@ import {
 import DeleteSrcbookModal from '@/components/delete-srcbook-dialog';
 import { ExternalLink } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import MailingListCard from '@/components/mailing-list-card';
 
 export async function loader() {
   const [{ result: config }, { result: srcbooks }, { result: examples }] = await Promise.all([
@@ -142,6 +143,7 @@ export default function Home() {
           </div>
         </div>
       )}
+      <MailingListCard />
     </div>
   );
 }

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { CircleCheck, Loader2, CircleX } from 'lucide-react';
-import { disk, updateConfig, aiHealthcheck } from '@/lib/server';
+import { disk, updateConfig, aiHealthcheck, subscribeToMailingList } from '@/lib/server';
 import { useSettings } from '@/components/use-settings';
 import { AiProviderType, getDefaultModel, type CodeLanguageType } from '@srcbook/shared';
 import type { SettingsType, FsObjectResultType } from '@/types';
@@ -17,6 +17,8 @@ import { Input } from '@/components/ui/input';
 import useTheme from '@/components/use-theme';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+import { getSubscribedEmailStatus, setSubscribedEmailStatus } from '@/lib/utils';
 
 async function loader() {
   const { result: diskResult } = await disk({});
@@ -49,6 +51,17 @@ function Settings() {
   const [anthropicKey, setAnthropicKey] = useState<string>(configAnthropicKey ?? '');
   const [model, setModel] = useState<string>(aiModel);
   const [baseUrl, setBaseUrl] = useState<string>(aiBaseUrl || '');
+  const [email, setEmail] = useState<string>('');
+  const [emailStatus, setEmailStatus] = useState<{ email: string | null; dismissed: boolean }>({
+    email: null,
+    dismissed: false,
+  });
+
+  useEffect(() => {
+    const status = getSubscribedEmailStatus();
+    setEmailStatus(status);
+    setEmail(status.email || '');
+  }, []);
 
   const updateDefaultLanguage = (value: CodeLanguageType) => {
     updateConfigContext({ defaultLanguage: value });
@@ -210,6 +223,53 @@ function Settings() {
             The default directory to look for Srcbooks when importing.
           </label>
           <DirPicker id="base-dir-picker" dirname={baseDir} entries={entries} cta="Change" />
+        </div>
+        <div>
+          <h2 className="text-xl pb-2">Get product updates</h2>
+          <div>
+            <label className="opacity-70 text-sm" htmlFor="mailing-list-email">
+              Subscribe to our mailing list to get the latest updates, early access features, and
+              expert tips delivered to your inbox.
+            </label>
+            <div className="flex gap-2 mt-4">
+              <Input
+                id="mailing-list-email"
+                type="text"
+                placeholder="Your email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+              <Button
+                className="px-5"
+                onClick={async () => {
+                  try {
+                    const response = await subscribeToMailingList(email);
+                    if (response.success) {
+                      setSubscribedEmailStatus(email);
+                      setEmailStatus({ email, dismissed: false });
+                      toast.success('Subscribed successfully!');
+                    } else if (response.status === 409) {
+                      toast.info('You are already subscribed to our mailing list.');
+                      setSubscribedEmailStatus(email);
+                      setEmailStatus({ email, dismissed: false });
+                    } else {
+                      toast.error(
+                        'There was an error subscribing to the mailing list. Please try again later.',
+                      );
+                    }
+                  } catch (error) {
+                    toast.error(
+                      'There was an error subscribing to the mailing list. Please try again later.',
+                    );
+                    console.error('Subscription error:', error);
+                  }
+                }}
+                disabled={email === emailStatus.email}
+              >
+                {email === emailStatus.email ? 'Subscribed' : 'Subscribe'}
+              </Button>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -93,6 +93,22 @@ function Settings() {
     ((aiBaseUrl === null || aiBaseUrl === undefined) && baseUrl.length > 0) ||
     model !== aiModel;
 
+  const handleSubscribe = async () => {
+    try {
+      const response = await subscribeToMailingList(email);
+      if (response.success) {
+        setSubscribedEmailStatus(email);
+        setEmailStatus({ email, dismissed: false });
+        toast.success('Subscribed successfully!');
+      } else {
+        toast.error('There was an error subscribing to the mailing list. Please try again later.');
+      }
+    } catch (error) {
+      toast.error('There was an error subscribing to the mailing list. Please try again later.');
+      console.error('Subscription error:', error);
+    }
+  };
+
   return (
     <div>
       <h4 className="h4 mx-auto mb-6">Settings</h4>
@@ -241,29 +257,7 @@ function Settings() {
               />
               <Button
                 className="px-5"
-                onClick={async () => {
-                  try {
-                    const response = await subscribeToMailingList(email);
-                    if (response.success) {
-                      setSubscribedEmailStatus(email);
-                      setEmailStatus({ email, dismissed: false });
-                      toast.success('Subscribed successfully!');
-                    } else if (response.status === 409) {
-                      toast.info('You are already subscribed to our mailing list.');
-                      setSubscribedEmailStatus(email);
-                      setEmailStatus({ email, dismissed: false });
-                    } else {
-                      toast.error(
-                        'There was an error subscribing to the mailing list. Please try again later.',
-                      );
-                    }
-                  } catch (error) {
-                    toast.error(
-                      'There was an error subscribing to the mailing list. Please try again later.',
-                    );
-                    console.error('Subscription error:', error);
-                  }
-                }}
+                onClick={handleSubscribe}
                 disabled={email === emailStatus.email}
               >
                 {email === emailStatus.email ? 'Subscribed' : 'Subscribe'}

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -20,6 +20,7 @@ export type SettingsType = {
   aiProvider: AiProviderType;
   aiModel: string;
   aiBaseUrl?: string | null;
+  subscriptionEmail?: string | null;
 };
 
 export type StdoutOutputType = { type: 'stdout'; data: string };


### PR DESCRIPTION
We want to collect users emails if they're interested so that we can send them updates, questionnaires, and tips. We want to talk to our users!

This adds a modal that pops up on the homepage. When the user either dismisses it or enters their email, it won't appear again.
The user can still go in the settings to add or modify their email subscription settings.

The feature is powered by sqlite.

The API supports unsubscribe, but I'd rather have that flow happen through the email newsletter than in the UI, so left it out.

Experience videos:

https://github.com/user-attachments/assets/f025f880-bd70-47ca-bddf-9f371c4ccc34


https://github.com/user-attachments/assets/f035f66a-8326-4c44-9c74-15b45b926c34

