### PR TITLE
Use HOME_DIR constant to figure out database path

### DIFF
--- a/packages/api/db/index.mts
+++ b/packages/api/db/index.mts
@@ -3,14 +3,14 @@ import { drizzle } from 'drizzle-orm/better-sqlite3';
 import Database from 'better-sqlite3';
 import * as schema from './schema.mjs';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
-import { DIST_DIR, SRCBOOKS_DIR } from '../constants.mjs';
+import { HOME_DIR, DIST_DIR, SRCBOOKS_DIR } from '../constants.mjs';
 import fs from 'node:fs';
 
 // We can't use a relative directory for drizzle since this application
 // can get run from anywhere, so use DIST_DIR as ground truth.
 const drizzleFolder = path.join(DIST_DIR, 'drizzle');
 
-const DB_PATH = `${process.env.HOME}/.srcbook/srcbook.db`;
+const DB_PATH = `${HOME_DIR}/.srcbook/srcbook.db`;
 
 // Creates the HOME/.srcbook/srcbooks dir
 fs.mkdirSync(SRCBOOKS_DIR, { recursive: true });


### PR DESCRIPTION
### Issue
The `process.env.HOME` variable was undefined when running `npm install -g srcbook && srcbook start` on Windows. 
This was preventing the database from being created on Windows which also prevented the user from being able to launch srcbook.

### Solution
Use the `HOME_DIR` constant

Fixes #245  

Manually tested on mac and windows and the `HOME_DIR` constant seems to work on both.