### PR TITLE
Various small UI fixes and improvements

### DIFF
--- a/.changeset/early-weeks-taste.md
+++ b/.changeset/early-weeks-taste.md
@@ -1,0 +1,5 @@
+---
+'@srcbook/web': patch
+---
+
+Various small UI fixes and improvements

--- a/packages/web/src/components/cell-output.tsx
+++ b/packages/web/src/components/cell-output.tsx
@@ -147,7 +147,7 @@ export function CellOutput({
         {show && (
           <div
             className={cn(
-              'p-2 flex flex-col-reverse overflow-scroll whitespace-pre-wrap text-[13px]',
+              'p-2 flex flex-col-reverse overflow-auto whitespace-pre-wrap text-[13px]',
               !fullscreen && 'max-h-96',
             )}
           >

--- a/packages/web/src/components/generate-srcbook-modal.tsx
+++ b/packages/web/src/components/generate-srcbook-modal.tsx
@@ -84,7 +84,7 @@ export default function GenerateSrcbookModal({
             onChange={(e) => setQuery(e.target.value)}
           />
           <Button
-            className="w-fit self-end flex items-center gap-2"
+            className="self-end flex items-center gap-2"
             disabled={!query || status === 'loading'}
             onClick={generate}
           >
@@ -97,18 +97,19 @@ export default function GenerateSrcbookModal({
             )}
           </Button>
           {error !== null && <ErrorMessage type={error} onRetry={generate} />}
-          <div className="w-full border-t"></div>
-          <p className="font-bold">Examples</p>
-          {EXAMPLES.map((example) => (
-            <button
-              onClick={() => setQuery(example)}
-              className="flex w-full items-center justify-center gap-6 cursor-pointer hover:bg-muted rounded px-1.5 py-1"
-              key={JSON.stringify(example)}
-            >
-              <Sparkles size={16} className="shrink-0" />
-              <p className="grow text-sm">{example}</p>
-            </button>
-          ))}
+          <div className="border-t">
+            <p className="py-3 font-bold">Examples</p>
+            {EXAMPLES.map((example) => (
+              <button
+                onClick={() => setQuery(example)}
+                className="flex items-center justify-center gap-6 cursor-pointer hover:bg-muted rounded px-1.5 py-2"
+                key={JSON.stringify(example)}
+              >
+                <Sparkles size={16} className="shrink-0" />
+                <p className="text-sm text-left">{example}</p>
+              </button>
+            ))}
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/packages/web/src/components/navbar.tsx
+++ b/packages/web/src/components/navbar.tsx
@@ -22,10 +22,10 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { createSession, createSrcbook } from '@/lib/server';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 function LightDarkModeDebugChanger() {
   const { theme, toggleTheme } = useTheme();
@@ -100,7 +100,7 @@ export function SessionNavbar(props: SessionNavbarProps) {
             <NavLink to="/">
               <h1 className="font-mono font-bold flex items-center space-x-[10px] pr-1">
                 <SrcbookLogo size={20} />
-                <span>Srcbooks</span>
+                <span>Srcbook</span>
               </h1>
             </NavLink>
 
@@ -134,6 +134,7 @@ export function SessionNavbar(props: SessionNavbarProps) {
                       <DropdownMenuItem
                         key={srcbook.id}
                         onClick={() => navigate(`/srcbooks/${srcbook.id}`)}
+                        className="cursor-pointer"
                       >
                         {titleCell.text}
                       </DropdownMenuItem>
@@ -142,8 +143,8 @@ export function SessionNavbar(props: SessionNavbarProps) {
 
                 {/* FIXME: how should more than 6 entries be rendered? */}
                 {props.srcbooks.length > 6 ? (
-                  <DropdownMenuItem asChild>
-                    <Link to="/">More...</Link>
+                  <DropdownMenuItem asChild className="cursor-pointer border-t mt-2 pt-2">
+                    <Link to="/">See all</Link>
                   </DropdownMenuItem>
                 ) : null}
               </DropdownMenuContent>
@@ -158,10 +159,9 @@ export function SessionNavbar(props: SessionNavbarProps) {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start" className="w-56">
-                <DropdownMenuItem onClick={onCreateSrcbook}>
+                <DropdownMenuItem onClick={onCreateSrcbook} className="cursor-pointer">
                   <PlusIcon className="mr-2 h-4 w-4" />
                   <span>Create Srcbook</span>
-                  <DropdownMenuShortcut>⌘N</DropdownMenuShortcut>
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => {
@@ -174,6 +174,7 @@ export function SessionNavbar(props: SessionNavbarProps) {
                       setShowGenSrcbookModal(true);
                     }, 0);
                   }}
+                  className="cursor-pointer"
                 >
                   <SparklesIcon className="mr-2 h-4 w-4" />
                   <span>Generate Srcbook</span>
@@ -189,6 +190,7 @@ export function SessionNavbar(props: SessionNavbarProps) {
                       setShowImportSrcbookModal(true);
                     }, 0);
                   }}
+                  className="cursor-pointer"
                 >
                   <ImportIcon className="mr-2 h-4 w-4" />
                   <span>Open Srcbook</span>
@@ -200,14 +202,21 @@ export function SessionNavbar(props: SessionNavbarProps) {
           <LightDarkModeDebugChanger />
 
           <div className="flex items-center gap-2">
-            <Button
-              variant="icon"
-              size="icon"
-              onClick={() => setShowDelete(true)}
-              className="active:translate-y-0"
-            >
-              <TrashIcon size={18} />
-            </Button>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="icon"
+                    size="icon"
+                    onClick={() => setShowDelete(true)}
+                    className="active:translate-y-0"
+                  >
+                    <TrashIcon size={18} />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Delete this Srcbook</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
             <Button
               variant="secondary"
               onClick={() => setShowSave(true)}
@@ -255,7 +264,7 @@ export function Navbar() {
           <NavLink to="/">
             <h1 className="font-mono font-bold flex items-center space-x-[10px]">
               <SrcbookLogo size={20} />
-              <span>Srcbooks</span>
+              <span>Srcbook</span>
             </h1>
           </NavLink>
 

--- a/packages/web/src/components/session-menu/index.tsx
+++ b/packages/web/src/components/session-menu/index.tsx
@@ -19,7 +19,7 @@ import { Sheet, SheetContent } from '@/components/ui/sheet';
 import SessionMenuPanelTableOfContents from './table-of-contents-panel';
 import SessionMenuPanelPackages from './packages-panel';
 import SessionMenuPanelSettings from './settings-panel';
-// import SessionMenuPanelSecrets from './secrets-panel';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 export type SessionMenuPanelContentsProps = {
   session: SessionType;
@@ -33,6 +33,7 @@ export const SESSION_MENU_PANELS = [
     icon: ListIcon,
     openWidthInPx: 312,
     contents: () => <SessionMenuPanelTableOfContents />,
+    tooltipContent: 'Table of contents',
   },
   {
     name: 'packages' as const,
@@ -41,12 +42,14 @@ export const SESSION_MENU_PANELS = [
     contents: ({ session, openDepsInstallModal }: SessionMenuPanelContentsProps) => (
       <SessionMenuPanelPackages session={session} openDepsInstallModal={openDepsInstallModal} />
     ),
+    tooltipContent: 'package.json',
   },
   {
     name: 'settings' as const,
     icon: SettingsIcon,
     openWidthInPx: 480,
     contents: (props: SessionMenuPanelContentsProps) => <SessionMenuPanelSettings {...props} />,
+    tooltipContent: 'Settings and configuration',
   },
   // NOTE: re-enable this in the follow up change!
   // {
@@ -190,47 +193,70 @@ function Sidebar({
         {SESSION_MENU_PANELS.map((panel) => {
           const Icon = panel.icon;
           return (
-            <Button
-              key={panel.name}
-              variant="icon"
-              size="icon"
-              className="active:translate-y-0"
-              onClick={() =>
-                onChangeSelectedPanelNameAndOpen(([oldName, oldOpen]) => {
-                  return oldName === panel.name && oldOpen ? [oldName, false] : [panel.name, true];
-                })
-              }
-            >
-              <Icon
-                size={18}
-                className={cn({
-                  'stroke-secondary-foreground':
-                    selectedPanelOpen && selectedPanelName === panel.name,
-                  'stroke-tertiary-foreground':
-                    !selectedPanelOpen || selectedPanelName !== panel.name,
-                })}
-              />
-            </Button>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    key={panel.name}
+                    variant="icon"
+                    size="icon"
+                    className="active:translate-y-0"
+                    onClick={() =>
+                      onChangeSelectedPanelNameAndOpen(([oldName, oldOpen]) => {
+                        return oldName === panel.name && oldOpen
+                          ? [oldName, false]
+                          : [panel.name, true];
+                      })
+                    }
+                  >
+                    <Icon
+                      size={18}
+                      className={cn({
+                        'stroke-secondary-foreground':
+                          selectedPanelOpen && selectedPanelName === panel.name,
+                        'stroke-tertiary-foreground':
+                          !selectedPanelOpen || selectedPanelName !== panel.name,
+                      })}
+                    />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="right">{panel.tooltipContent}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           );
         })}
       </div>
       <div className="flex flex-col items-center w-full gap-2">
-        <Button
-          variant="icon"
-          size="icon"
-          className="active:translate-y-0"
-          onClick={onShowShortcutsModal}
-        >
-          <KeyboardIcon size={18} className="stroke-tertiary-foreground" />
-        </Button>
-        <Button
-          variant="icon"
-          size="icon"
-          className="active:translate-y-0"
-          onClick={onShowFeedbackModal}
-        >
-          <MessageCircleIcon size={18} className="stroke-tertiary-foreground" />
-        </Button>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="icon"
+                size="icon"
+                className="active:translate-y-0"
+                onClick={onShowShortcutsModal}
+              >
+                <KeyboardIcon size={18} className="stroke-tertiary-foreground" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right">Keyboard shortcuts</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="icon"
+                size="icon"
+                className="active:translate-y-0"
+                onClick={onShowFeedbackModal}
+              >
+                <MessageCircleIcon size={18} className="stroke-tertiary-foreground" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right">Leave feedback</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       </div>
     </div>
   );

--- a/packages/web/src/components/ui/heading.tsx
+++ b/packages/web/src/components/ui/heading.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils';
 import { TitleCellUpdateAttrsSchema } from '@srcbook/shared';
 
 const className =
-  'flex w-full break-all whitespace-normal rounded-md border border-transparent bg-transparent px-1 py-1 transition-colors hover:border-input hover:shadow-sm focus-visible:shadow-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50';
+  'flex w-full whitespace-normal rounded-md border border-transparent bg-transparent px-1 py-1 transition-colors hover:border-input hover:shadow-sm focus-visible:shadow-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50';
 
 function isCharacterKey(e: React.KeyboardEvent<HTMLHeadingElement>) {
   return (

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -123,12 +123,12 @@ function Settings() {
           <Select onValueChange={updateDefaultLanguage}>
             <SelectTrigger id="language-selector" className="w-[180px]">
               <SelectValue
-                placeholder={defaultLanguage.charAt(0).toUpperCase() + defaultLanguage.slice(1)}
+                placeholder={defaultLanguage === 'typescript' ? 'TypeScript' : 'JavaScript'}
               />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="typescript">Typescript</SelectItem>
-              <SelectItem value="javascript">Javascript</SelectItem>
+              <SelectItem value="typescript">TypeScript</SelectItem>
+              <SelectItem value="javascript">JavaScript</SelectItem>
             </SelectContent>
           </Select>
         </div>


### PR DESCRIPTION
- [x] Srcbook should be singular in navbar, not plural
- [x] Add tooltips for nav icons
- [x] Remove keyboard shortcut indicator in nav that isn't implemented
- [x] Cursor pointer applied to dropdown menu items in navbar
- [x] Clear separator between items in dropdown and the "view all" link
- [x] JavaScript/TypeScript casing in settings
- [x] Fix styles in generate with AI modal (text should be left aligned, and padding was off)
- [x] Title break word (srcbook titles were breaking at arbitrary characters)
- [x] Remove an overflow-scroll in cell output
