### PR TITLE
Tweaks to packages panel and keyboard shortcut

### DIFF
--- a/packages/web/src/components/keyboard-shortcuts-dialog.tsx
+++ b/packages/web/src/components/keyboard-shortcuts-dialog.tsx
@@ -34,8 +34,8 @@ export default function KeyboardShortcutsDialog({
             <div>
               <h5 className="font-semibold pt-4 pb-2">Global</h5>
               <ShortcutRow keys={['?']} description="show this dialog" />
-              <ShortcutRow keys={['mod', ';']} description="open Srcbook settings" />
-              <ShortcutRow keys={['mod', 'i']} description="open NPM package install modal" />
+              <ShortcutRow keys={['mod', ';']} description="open package.json" />
+              <ShortcutRow keys={['mod', 'i']} description="open npm package install modal" />
               <h5 className="font-semibold pt-6 pb-2">Markdown edit</h5>
               <ShortcutRow keys={['esc']} description="switch back to preview mode" />
               <ShortcutRow keys={['mod', '↵']} description="switch back to preview mode" />

--- a/packages/web/src/components/session-menu/index.tsx
+++ b/packages/web/src/components/session-menu/index.tsx
@@ -39,8 +39,8 @@ export const SESSION_MENU_PANELS = [
     name: 'packages' as const,
     icon: PackageIcon,
     openWidthInPx: 480,
-    contents: ({ session, openDepsInstallModal }: SessionMenuPanelContentsProps) => (
-      <SessionMenuPanelPackages session={session} openDepsInstallModal={openDepsInstallModal} />
+    contents: ({ openDepsInstallModal }: SessionMenuPanelContentsProps) => (
+      <SessionMenuPanelPackages openDepsInstallModal={openDepsInstallModal} />
     ),
     tooltipContent: 'package.json',
   },

--- a/packages/web/src/components/session-menu/packages-panel.tsx
+++ b/packages/web/src/components/session-menu/packages-panel.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { TitleCellType } from '@srcbook/shared';
 import { OutputType } from '@/types';
 import {
   Info,
@@ -19,27 +18,13 @@ import { Button } from '@/components/ui/button';
 import { usePackageJson } from '@/components/use-package-json';
 
 import { SessionMenuPanelContentsProps } from '.';
-import { useCells } from '@/components/use-cell';
 
-type PropsType = Pick<SessionMenuPanelContentsProps, 'session' | 'openDepsInstallModal'>;
+type PropsType = Pick<SessionMenuPanelContentsProps, 'openDepsInstallModal'>;
 
-export default function SessionMenuPanelPackages({ session, openDepsInstallModal }: PropsType) {
-  const { cells } = useCells();
-  const title = cells.find((cell) => cell.type === 'title') as TitleCellType;
-
+export default function SessionMenuPanelPackages({ openDepsInstallModal }: PropsType) {
   return (
     <>
-      <div className="text-lg font-semibold leading-tight mb-3">
-        <span>Dependencies</span>
-      </div>
-
-      <div className="flex items-center justify-between gap-8 text-sm mb-5">
-        <h5 className="font-medium max-w-72 truncate">{title.text}</h5>
-        <p className="text-tertiary-foreground">
-          {session.language === 'typescript' ? 'TypeScript' : 'JavaScript'}
-        </p>
-      </div>
-
+      <h4 className="text-lg font-semibold leading-tight mb-4">Dependencies</h4>
       <PackageJson openDepsInstallModal={openDepsInstallModal} />
     </>
   );

--- a/packages/web/src/components/session-menu/settings-panel.tsx
+++ b/packages/web/src/components/session-menu/settings-panel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { TsConfigUpdatedPayloadType } from '@srcbook/shared';
+import type { TitleCellType, TsConfigUpdatedPayloadType } from '@srcbook/shared';
 import { X, Info } from 'lucide-react';
 import CodeMirror from '@uiw/react-codemirror';
 import { json } from '@codemirror/lang-json';
@@ -11,20 +11,30 @@ import CollapsibleContainer from '@/components/collapsible-container';
 import useTheme from '@/components/use-theme';
 import { SessionChannel } from '@/clients/websocket';
 import { useTsconfigJson } from '@/components/use-tsconfig-json';
+import { useCells } from '@/components/use-cell';
 
-import { SessionMenuPanelContentsProps } from '.';
+import type { SessionMenuPanelContentsProps } from '.';
 
 type PropsType = Pick<SessionMenuPanelContentsProps, 'session' | 'channel'>;
 
 export default function SessionMenuPanelSettings({ session, channel }: PropsType) {
-  const { aiEnabled } = useSettings();
   const navigate = useNavigate();
+  const { aiEnabled } = useSettings();
+  const { cells } = useCells();
+
   const [showAiNudge, setShowAiNudge] = useState(!aiEnabled);
+
+  const title = cells.find((cell) => cell.type === 'title') as TitleCellType;
 
   return (
     <>
-      <div className="text-lg font-semibold leading-tight mb-4">
-        <span>Settings</span>
+      <h4 className="text-lg font-semibold leading-tight mb-4">Settings</h4>
+
+      <div className="flex items-center justify-between gap-8 text-sm mb-5">
+        <h5 className="font-medium max-w-72 truncate">{title.text}</h5>
+        <p className="text-tertiary-foreground">
+          {session.language === 'typescript' ? 'TypeScript' : 'JavaScript'}
+        </p>
       </div>
 
       {showAiNudge && (
@@ -49,9 +59,15 @@ export default function SessionMenuPanelSettings({ session, channel }: PropsType
           </p>
         </div>
       )}
-      <div className="text-foreground mt-2 space-y-6">
-        {session.language === 'typescript' && <TsconfigJson channel={channel} />}
-      </div>
+      {/* TOOD: Add more settings or handle this in a better way */}
+      {session.language === 'javascript' && (
+        <p className="text-tertiary-foreground text-lg mt-5">No additional settings</p>
+      )}
+      {session.language === 'typescript' && (
+        <div className="text-foreground mt-2 space-y-6">
+          <TsconfigJson channel={channel} />
+        </div>
+      )}
     </>
   );
 }

--- a/packages/web/src/components/session-menu/table-of-contents-panel.tsx
+++ b/packages/web/src/components/session-menu/table-of-contents-panel.tsx
@@ -14,9 +14,7 @@ export default function SessionMenuPanelTableOfContents(_props: PropsType) {
 
   return (
     <>
-      <div className="text-lg font-semibold leading-tight mb-4">
-        <span>Table of contents</span>
-      </div>
+      <h4 className="text-lg font-semibold leading-tight mb-4">Table of contents</h4>
 
       <div className="max-w-60 text-tertiary-foreground pr-10">
         {cells.map((cell) => {

--- a/packages/web/src/routes/session.tsx
+++ b/packages/web/src/routes/session.tsx
@@ -142,8 +142,8 @@ function Session(props: {
   );
 
   useHotkeys('mod+;', () => {
-    if (isPanelOpen('settings')) {
-      setSelectedPanelNameAndOpen(['settings', true]);
+    if (!isPanelOpen('packages')) {
+      setSelectedPanelNameAndOpen(['packages', true]);
     }
   });
 


### PR DESCRIPTION
- [x] Fix keyboard shortcut for opening settings
- [x] Change keyboard shortcut to open package.json instead of settings as I believe that's going to be more frequently used
- [x] Move title and language header into settings panel instead of package.json (seems more appropriate). I almost removed this entirely but then realized there's no where else we explicitly show the language used on a the srcbook page which IIRC is the reason we put it there in the first place
- [x] Basic empty state for settings panel when the language is JavaScript since the only settings we currently have is the tsconfig.json file which is TS only.

@1egoman I changed the panel headings to h4s. This is a preference but I can change back this if there's a reason why they were div+spans. Let me know!