### PR TITLE
UI tweaks

### DIFF
--- a/.changeset/happy-scissors-share.md
+++ b/.changeset/happy-scissors-share.md
@@ -1,0 +1,5 @@
+---
+'@srcbook/web': patch
+---
+
+Visual tweaks when missing AI configuration, and Prettier logo size"

--- a/packages/web/src/components/cells/code.tsx
+++ b/packages/web/src/components/cells/code.tsx
@@ -447,7 +447,7 @@ function Header(props: {
                     onClick={formatCell}
                     tabIndex={1}
                   >
-                    <PrettierLogo size={16} />
+                    <PrettierLogo size={14} />
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>Format using Prettier</TooltipContent>
@@ -588,7 +588,7 @@ function Header(props: {
 
           {!aiEnabled && (
             <div className="flex items-center justify-between bg-warning text-warning-foreground rounded-sm text-sm px-3 py-1 m-3">
-              <p>API key required</p>
+              <p>AI provider not configured.</p>
               <button
                 className="font-medium underline cursor-pointer"
                 onClick={() => navigate('/settings')}

--- a/packages/web/src/components/cells/generate-ai.tsx
+++ b/packages/web/src/components/cells/generate-ai.tsx
@@ -110,10 +110,11 @@ export default function GenerateAiCell(props: {
         )}
 
         {!aiEnabled && (
-          <div className="flex items-center justify-between bg-sb-yellow-20 text-sb-yellow-80 rounded-sm text-sm p-1 m-3">
-            <p className="px-2">API key required</p>
+          <div className="flex items-center justify-between bg-sb-yellow-20 text-sb-yellow-80 rounded-sm text-sm px-3 py-1 m-3">
+            <p>AI provider not configured.</p>
+
             <button
-              className="border border-sb-yellow-70 rounded-sm px-2 py-1 hover:border-sb-yellow-80 animate-all"
+              className="font-medium underline cursor-pointer"
               onClick={() => navigate('/settings')}
             >
               Settings

--- a/packages/web/src/components/generate-srcbook-modal.tsx
+++ b/packages/web/src/components/generate-srcbook-modal.tsx
@@ -74,6 +74,7 @@ export default function GenerateSrcbookModal({
           <DialogTitle>Generate with AI</DialogTitle>
         </DialogHeader>
         <div className="flex flex-col gap-3">
+          {!aiEnabled && <APIKeyWarning />}
           <Textarea
             placeholder="Write a prompt to create a Srcbook..."
             className="focus-visible:ring-2"
@@ -82,7 +83,6 @@ export default function GenerateSrcbookModal({
             disabled={!aiEnabled || status === 'loading'}
             onChange={(e) => setQuery(e.target.value)}
           />
-          {!aiEnabled && <APIKeyWarning />}
           <Button
             className="self-end flex items-center gap-2"
             disabled={!query || status === 'loading'}

--- a/packages/web/src/components/generate-srcbook-modal.tsx
+++ b/packages/web/src/components/generate-srcbook-modal.tsx
@@ -74,7 +74,6 @@ export default function GenerateSrcbookModal({
           <DialogTitle>Generate with AI</DialogTitle>
         </DialogHeader>
         <div className="flex flex-col gap-3">
-          {!aiEnabled && <APIKeyWarning />}
           <Textarea
             placeholder="Write a prompt to create a Srcbook..."
             className="focus-visible:ring-2"
@@ -83,6 +82,7 @@ export default function GenerateSrcbookModal({
             disabled={!aiEnabled || status === 'loading'}
             onChange={(e) => setQuery(e.target.value)}
           />
+          {!aiEnabled && <APIKeyWarning />}
           <Button
             className="self-end flex items-center gap-2"
             disabled={!query || status === 'loading'}
@@ -119,7 +119,7 @@ export default function GenerateSrcbookModal({
 function APIKeyWarning() {
   return (
     <div className="flex items-center justify-between bg-sb-yellow-20 text-sb-yellow-80 rounded-sm text-sm font-medium px-3 py-2">
-      <p>Set up an AI provider to start using AI features.</p>
+      <p>AI provider not configured.</p>
       <Link to="/settings" className="underline">
         Settings
       </Link>


### PR DESCRIPTION
## Smaller prettier logo

See before after
![CleanShot 2024-09-12 at 16 33 38@2x](https://github.com/user-attachments/assets/dbed7001-4ac5-40e9-890f-02aec8c97c94)
![CleanShot 2024-09-12 at 16 33 30@2x](https://github.com/user-attachments/assets/992cd2fe-b235-407a-bc17-ab7942e6e44a)

## AI config warnings homogenization

## AI warning is now beneath textarea

![CleanShot 2024-09-12 at 16 44 11@2x](https://github.com/user-attachments/assets/9567355f-468e-4922-9e29-5a2a7cc7cb2d)
![CleanShot 2024-09-12 at 16 43 49@2x](https://github.com/user-attachments/assets/02fde425-13fd-49a5-8580-cd41db500be3)
