### PR TITLE
Add ability to select session specific secrets

### DIFF
--- a/.changeset/moody-dragons-compare.md
+++ b/.changeset/moody-dragons-compare.md
@@ -2,4 +2,4 @@
 '@srcbook/web': patch
 ---
 
-added project specific secrets
+Secrets must now be enabled per Srcbook

--- a/.changeset/moody-dragons-compare.md
+++ b/.changeset/moody-dragons-compare.md
@@ -1,0 +1,5 @@
+---
+'@srcbook/web': patch
+---
+
+added project specific secrets

--- a/packages/api/config.mts
+++ b/packages/api/config.mts
@@ -66,6 +66,15 @@ export async function getSecrets(): Promise<Array<SecretWithAssociatedSessions>>
   }));
 }
 
+export async function getSecretsAssociatedWithSession(sessionId: string): Promise<Record<string, string>> {
+  const secretsResults = await getSecrets();
+  return Object.fromEntries(
+    secretsResults
+      .filter(secret => secret.associatedWithSessionIds.includes(sessionId))
+      .map(secret => [secret.name, secret.value])
+  );
+}
+
 export async function addSecret(name: string, value: string): Promise<Secret> {
   const result = await db
     .insert(secrets)

--- a/packages/api/config.mts
+++ b/packages/api/config.mts
@@ -118,7 +118,7 @@ export async function disassociateSecretWithSession(secretName: string, sessionI
   const secretId = result[0]!.id;
 
   await db.delete(secretsToSession).where(and(
-    eq(secretsToSession.id, secretId),
+    eq(secretsToSession.secret_id, secretId),
     eq(secretsToSession.session_id, sessionId),
   )).returning();
 }

--- a/packages/api/db/schema.mts
+++ b/packages/api/db/schema.mts
@@ -28,12 +28,18 @@ export const secrets = sqliteTable('secrets', {
 
 export type Secret = typeof secrets.$inferSelect;
 
-export const secretsToSession = sqliteTable('secrets_to_sessions', {
-  id: integer('id').primaryKey(),
-  session_id: text('session_id').notNull(),
-  secret_id: integer('secret_id').notNull().references(() => secrets.id),
-}, t => ({
-  unique_session_secret: unique().on(t.session_id, t.secret_id),
-}));
+export const secretsToSession = sqliteTable(
+  'secrets_to_sessions',
+  {
+    id: integer('id').primaryKey(),
+    session_id: text('session_id').notNull(),
+    secret_id: integer('secret_id')
+      .notNull()
+      .references(() => secrets.id),
+  },
+  (t) => ({
+    unique_session_secret: unique().on(t.session_id, t.secret_id),
+  }),
+);
 
 export type SecretsToSession = typeof secretsToSession.$inferSelect;

--- a/packages/api/db/schema.mts
+++ b/packages/api/db/schema.mts
@@ -27,3 +27,11 @@ export const secrets = sqliteTable('secrets', {
 });
 
 export type Secret = typeof secrets.$inferSelect;
+
+export const secretsToSession = sqliteTable('secrets_to_session', {
+  id: integer('id').primaryKey(),
+  session_id: text('session_id').notNull(),
+  secret_id: integer('secret_id').notNull().references(() => secrets.id),
+});
+
+export type SecretsToSession = typeof secretsToSession.$inferSelect;

--- a/packages/api/db/schema.mts
+++ b/packages/api/db/schema.mts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer, unique } from 'drizzle-orm/sqlite-core';
 import { randomid } from '@srcbook/shared';
 
 export const configs = sqliteTable('config', {
@@ -32,6 +32,8 @@ export const secretsToSession = sqliteTable('secrets_to_session', {
   id: integer('id').primaryKey(),
   session_id: text('session_id').notNull(),
   secret_id: integer('secret_id').notNull().references(() => secrets.id),
-});
+}, t => ({
+  unique_session_secret: unique().on(t.session_id, t.secret_id),
+}));
 
 export type SecretsToSession = typeof secretsToSession.$inferSelect;

--- a/packages/api/db/schema.mts
+++ b/packages/api/db/schema.mts
@@ -28,7 +28,7 @@ export const secrets = sqliteTable('secrets', {
 
 export type Secret = typeof secrets.$inferSelect;
 
-export const secretsToSession = sqliteTable('secrets_to_session', {
+export const secretsToSession = sqliteTable('secrets_to_sessions', {
   id: integer('id').primaryKey(),
   session_id: text('session_id').notNull(),
   secret_id: integer('secret_id').notNull().references(() => secrets.id),

--- a/packages/api/drizzle/0008_add_secrets.sql
+++ b/packages/api/drizzle/0008_add_secrets.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `secrets_to_session` (
+	`id` integer PRIMARY KEY NOT NULL,
+	`session_id` text NOT NULL,
+	`secret_id` integer NOT NULL,
+	FOREIGN KEY (`secret_id`) REFERENCES `secrets`(`id`) ON UPDATE no action ON DELETE no action
+);

--- a/packages/api/drizzle/0008_add_secrets.sql
+++ b/packages/api/drizzle/0008_add_secrets.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `secrets_to_session` (
+CREATE TABLE `secrets_to_sessions` (
 	`id` integer PRIMARY KEY NOT NULL,
 	`session_id` text NOT NULL,
 	`secret_id` integer NOT NULL,

--- a/packages/api/drizzle/0008_add_secrets.sql
+++ b/packages/api/drizzle/0008_add_secrets.sql
@@ -2,5 +2,5 @@ CREATE TABLE `secrets_to_sessions` (
 	`id` integer PRIMARY KEY NOT NULL,
 	`session_id` text NOT NULL,
 	`secret_id` integer NOT NULL,
-	FOREIGN KEY (`secret_id`) REFERENCES `secrets`(`id`) ON UPDATE no action ON DELETE no action
+	FOREIGN KEY (`secret_id`) REFERENCES `secrets`(`id`) ON UPDATE no action ON DELETE CASCADE
 );

--- a/packages/api/drizzle/0009_secret_session_unique.sql
+++ b/packages/api/drizzle/0009_secret_session_unique.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX `secrets_to_session_session_id_secret_id_unique` ON `secrets_to_session` (`session_id`,`secret_id`);

--- a/packages/api/drizzle/0009_secret_session_unique.sql
+++ b/packages/api/drizzle/0009_secret_session_unique.sql
@@ -1,1 +1,1 @@
-CREATE UNIQUE INDEX `secrets_to_sessions_session_id_secret_id_unique` ON `secrets_to_session` (`session_id`,`secret_id`);
+CREATE UNIQUE INDEX `secrets_to_sessions_session_id_secret_id_unique` ON `secrets_to_sessions` (`session_id`,`secret_id`);

--- a/packages/api/drizzle/0009_secret_session_unique.sql
+++ b/packages/api/drizzle/0009_secret_session_unique.sql
@@ -1,1 +1,1 @@
-CREATE UNIQUE INDEX `secrets_to_session_session_id_secret_id_unique` ON `secrets_to_session` (`session_id`,`secret_id`);
+CREATE UNIQUE INDEX `secrets_to_sessions_session_id_secret_id_unique` ON `secrets_to_session` (`session_id`,`secret_id`);

--- a/packages/api/drizzle/meta/0008_snapshot.json
+++ b/packages/api/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,183 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4564124c-e1d6-432f-ba1e-f4c85f4a3599",
+  "prevId": "a8c6d627-368f-4e6d-bdd9-42ffb1d8a8b2",
+  "tables": {
+    "config": {
+      "name": "config",
+      "columns": {
+        "base_dir": {
+          "name": "base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_language": {
+          "name": "default_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'typescript'"
+        },
+        "openai_api_key": {
+          "name": "openai_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anthropic_api_key": {
+          "name": "anthropic_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled_analytics": {
+          "name": "enabled_analytics",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "srcbook_installation_id": {
+          "name": "srcbook_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'bdruq89pvcu7hef3shbis3c09k'"
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openai'"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'gpt-4o'"
+        },
+        "ai_base_url": {
+          "name": "ai_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subscription_email": {
+          "name": "subscription_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "secrets": {
+      "name": "secrets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "secrets_name_unique": {
+          "name": "secrets_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "secrets_to_session": {
+      "name": "secrets_to_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "secrets_to_session_secret_id_secrets_id_fk": {
+          "name": "secrets_to_session_secret_id_secrets_id_fk",
+          "tableFrom": "secrets_to_session",
+          "tableTo": "secrets",
+          "columnsFrom": [
+            "secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/drizzle/meta/0008_snapshot.json
+++ b/packages/api/drizzle/meta/0008_snapshot.json
@@ -126,8 +126,8 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {}
     },
-    "secrets_to_session": {
-      "name": "secrets_to_session",
+    "secrets_to_sessions": {
+      "name": "secrets_to_sessions",
       "columns": {
         "id": {
           "name": "id",
@@ -153,9 +153,9 @@
       },
       "indexes": {},
       "foreignKeys": {
-        "secrets_to_session_secret_id_secrets_id_fk": {
-          "name": "secrets_to_session_secret_id_secrets_id_fk",
-          "tableFrom": "secrets_to_session",
+        "secrets_to_sessions_secret_id_secrets_id_fk": {
+          "name": "secrets_to_sessions_secret_id_secrets_id_fk",
+          "tableFrom": "secrets_to_sessions",
           "tableTo": "secrets",
           "columnsFrom": [
             "secret_id"

--- a/packages/api/drizzle/meta/0009_snapshot.json
+++ b/packages/api/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,192 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "fd7a01ac-c2a9-4369-a2e6-f47a691ba1a2",
+  "prevId": "4564124c-e1d6-432f-ba1e-f4c85f4a3599",
+  "tables": {
+    "config": {
+      "name": "config",
+      "columns": {
+        "base_dir": {
+          "name": "base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_language": {
+          "name": "default_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'typescript'"
+        },
+        "openai_api_key": {
+          "name": "openai_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anthropic_api_key": {
+          "name": "anthropic_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled_analytics": {
+          "name": "enabled_analytics",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "srcbook_installation_id": {
+          "name": "srcbook_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1uod9drl5flc07s7qglv3kgtuk'"
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openai'"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'gpt-4o'"
+        },
+        "ai_base_url": {
+          "name": "ai_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subscription_email": {
+          "name": "subscription_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "secrets": {
+      "name": "secrets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "secrets_name_unique": {
+          "name": "secrets_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "secrets_to_session": {
+      "name": "secrets_to_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "secrets_to_session_session_id_secret_id_unique": {
+          "name": "secrets_to_session_session_id_secret_id_unique",
+          "columns": [
+            "session_id",
+            "secret_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "secrets_to_session_secret_id_secrets_id_fk": {
+          "name": "secrets_to_session_secret_id_secrets_id_fk",
+          "tableFrom": "secrets_to_session",
+          "tableTo": "secrets",
+          "columnsFrom": [
+            "secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/drizzle/meta/0009_snapshot.json
+++ b/packages/api/drizzle/meta/0009_snapshot.json
@@ -126,8 +126,8 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {}
     },
-    "secrets_to_session": {
-      "name": "secrets_to_session",
+    "secrets_to_sessions": {
+      "name": "secrets_to_sessions",
       "columns": {
         "id": {
           "name": "id",
@@ -152,8 +152,8 @@
         }
       },
       "indexes": {
-        "secrets_to_session_session_id_secret_id_unique": {
-          "name": "secrets_to_session_session_id_secret_id_unique",
+        "secrets_to_sessions_session_id_secret_id_unique": {
+          "name": "secrets_to_sessions_session_id_secret_id_unique",
           "columns": [
             "session_id",
             "secret_id"
@@ -162,9 +162,9 @@
         }
       },
       "foreignKeys": {
-        "secrets_to_session_secret_id_secrets_id_fk": {
-          "name": "secrets_to_session_secret_id_secrets_id_fk",
-          "tableFrom": "secrets_to_session",
+        "secrets_to_sessions_secret_id_secrets_id_fk": {
+          "name": "secrets_to_sessions_secret_id_secrets_id_fk",
+          "tableFrom": "secrets_to_sessions",
           "tableTo": "secrets",
           "columnsFrom": [
             "secret_id"

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1725736805777,
       "tag": "0007_add_subscription_email",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1726084159070,
+      "tag": "0008_add_secrets",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1726084159070,
       "tag": "0008_add_secrets",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1726250539939,
+      "tag": "0009_secret_session_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/server/http.mts
+++ b/packages/api/server/http.mts
@@ -15,7 +15,15 @@ import {
 } from '../session.mjs';
 import { generateCells, generateSrcbook, healthcheck } from '../ai/generate.mjs';
 import { disk } from '../utils.mjs';
-import { getConfig, updateConfig, getSecrets, addSecret, removeSecret } from '../config.mjs';
+import {
+  getConfig,
+  updateConfig,
+  getSecrets,
+  addSecret,
+  removeSecret,
+  associateSecretWithSession,
+  disassociateSecretWithSession,
+} from '../config.mjs';
 import {
   createSrcbook,
   removeSrcbook,
@@ -237,6 +245,26 @@ router.post('/sessions/:id/export', cors(), async (req, res) => {
     console.error(error);
     return res.json({ error: true, result: error.stack });
   }
+});
+
+router.options('/sessions/:id/secrets', cors());
+router.get('/sessions/:id/secrets', cors(), async (req, res) => {
+  const { id } = req.params;
+  const secrets = await getSecretsAssociatedWithSession(id);
+  return res.json({ result: secrets });
+});
+
+router.options('/sessions/:id/secrets/:name', cors());
+router.put('/sessions/:id/secrets/:name', cors(), async (req, res) => {
+  const { id, name } = req.params;
+  await associateSecretWithSession(name, id);
+  return res.status(204).end();
+});
+
+router.delete('/sessions/:id/secrets/:name', cors(), async (req, res) => {
+  const { id, name } = req.params;
+  await disassociateSecretWithSession(name, id);
+  return res.status(204).end();
 });
 
 router.options('/settings', cors());

--- a/packages/api/server/http.mts
+++ b/packages/api/server/http.mts
@@ -247,13 +247,6 @@ router.post('/sessions/:id/export', cors(), async (req, res) => {
   }
 });
 
-router.options('/sessions/:id/secrets', cors());
-router.get('/sessions/:id/secrets', cors(), async (req, res) => {
-  const { id } = req.params;
-  const secrets = await getSecretsAssociatedWithSession(id);
-  return res.json({ result: secrets });
-});
-
 router.options('/sessions/:id/secrets/:name', cors());
 router.put('/sessions/:id/secrets/:name', cors(), async (req, res) => {
   const { id, name } = req.params;

--- a/packages/api/server/ws.mts
+++ b/packages/api/server/ws.mts
@@ -13,7 +13,7 @@ import {
   addCell,
   formatAndUpdateCodeCell,
 } from '../session.mjs';
-import { getSecrets } from '../config.mjs';
+import { getSecretsAssociatedWithSession } from '../config.mjs';
 import type { SessionType } from '../types.mjs';
 import { node, npmInstall, tsx } from '../exec.mjs';
 import { shouldNpmInstall, missingUndeclaredDeps } from '../deps.mjs';
@@ -137,7 +137,7 @@ async function cellExec(payload: CellExecPayloadType) {
 
   nudgeMissingDeps(wss, session);
 
-  const secrets = await getSecrets();
+  const secrets = await getSecretsAssociatedWithSession(session.id);
 
   cell.status = 'running';
   wss.broadcast(`session:${session.id}`, 'cell:updated', { cell });

--- a/packages/shared/index.mts
+++ b/packages/shared/index.mts
@@ -4,5 +4,6 @@ export * from './src/schemas/websockets.mjs';
 export * from './src/types/cells.mjs';
 export * from './src/types/tsserver.mjs';
 export * from './src/types/websockets.mjs';
+export * from './src/types/secrets.mjs';
 export * from './src/utils.mjs';
 export * from './src/ai.mjs';

--- a/packages/shared/src/types/secrets.mts
+++ b/packages/shared/src/types/secrets.mts
@@ -1,0 +1,5 @@
+export type SecretWithAssociatedSessions = {
+  name: string;
+  value: string;
+  associatedWithSessionIds: Array<string>;
+};

--- a/packages/web/src/components/session-menu/index.tsx
+++ b/packages/web/src/components/session-menu/index.tsx
@@ -57,7 +57,7 @@ export const SESSION_MENU_PANELS = [
     name: 'secrets' as const,
     icon: KeySquareIcon,
     openWidthInPx: 480,
-    contents: () => <SessionMenuPanelSecrets />,
+    contents: (props: SessionMenuPanelContentsProps) => <SessionMenuPanelSecrets session={props.session} />,
   },
 ];
 export type Panel = (typeof SESSION_MENU_PANELS)[0];

--- a/packages/web/src/components/session-menu/index.tsx
+++ b/packages/web/src/components/session-menu/index.tsx
@@ -9,6 +9,7 @@ import {
   MessageCircleIcon,
   PackageIcon,
   SettingsIcon,
+  KeySquareIcon,
   XIcon,
 } from 'lucide-react';
 import type { SessionType } from '@/types';
@@ -16,10 +17,11 @@ import KeyboardShortcutsDialog from '@/components/keyboard-shortcuts-dialog';
 import FeedbackDialog from '@/components/feedback-dialog';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent } from '@/components/ui/sheet';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import SessionMenuPanelTableOfContents from './table-of-contents-panel';
 import SessionMenuPanelPackages from './packages-panel';
 import SessionMenuPanelSettings from './settings-panel';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import SessionMenuPanelSecrets from './secrets-panel';
 
 export type SessionMenuPanelContentsProps = {
   session: SessionType;
@@ -51,13 +53,12 @@ export const SESSION_MENU_PANELS = [
     contents: (props: SessionMenuPanelContentsProps) => <SessionMenuPanelSettings {...props} />,
     tooltipContent: 'Settings and configuration',
   },
-  // NOTE: re-enable this in the follow up change!
-  // {
-  //   name: 'secrets' as const,
-  //   icon: KeySquareIcon,
-  //   openWidthInPx: 480,
-  //   contents: () => <SessionMenuPanelSecrets />,
-  // },
+  {
+    name: 'secrets' as const,
+    icon: KeySquareIcon,
+    openWidthInPx: 480,
+    contents: () => <SessionMenuPanelSecrets />,
+  },
 ];
 export type Panel = (typeof SESSION_MENU_PANELS)[0];
 

--- a/packages/web/src/components/session-menu/index.tsx
+++ b/packages/web/src/components/session-menu/index.tsx
@@ -57,7 +57,9 @@ export const SESSION_MENU_PANELS = [
     name: 'secrets' as const,
     icon: KeySquareIcon,
     openWidthInPx: 480,
-    contents: (props: SessionMenuPanelContentsProps) => <SessionMenuPanelSecrets session={props.session} />,
+    contents: (props: SessionMenuPanelContentsProps) => (
+      <SessionMenuPanelSecrets session={props.session} />
+    ),
   },
 ];
 export type Panel = (typeof SESSION_MENU_PANELS)[0];

--- a/packages/web/src/components/session-menu/secrets-panel.tsx
+++ b/packages/web/src/components/session-menu/secrets-panel.tsx
@@ -1,23 +1,26 @@
 // import { SessionMenuPanelContentsProps } from '.';
 
-import { useEffect, useState } from "react";
-import { getSecrets } from "@/lib/server";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from 'sonner';
+import { type SecretWithAssociatedSessions } from '@srcbook/shared';
 
-type PropsType = Record<string, never>; // Pick<SessionMenuPanelContentsProps, 'session' | 'openDepsInstallModal'>;
+import { getSecrets, associateSecretWithSession, disassociateSecretWithSession } from "@/lib/server";
+import { Switch } from "@/components/ui/switch";
+import { SessionMenuPanelContentsProps } from ".";
 
-type SecretsList = Record<string, string>;
+type PropsType = Pick<SessionMenuPanelContentsProps, 'session'>;
 
-export default function SessionMenuPanelSecrets(_props: PropsType) {
+export default function SessionMenuPanelSecrets(props: PropsType) {
   const [secretsList, setSecretsList] = useState<
     | { status: 'idle' } 
     | { status: 'loading' }
-    | { status: 'complete', data: SecretsList }
+    | { status: 'complete', data: Array<SecretWithAssociatedSessions> }
     | { status: 'error' }
   >({ status: 'idle' });
   useEffect(() => {
     const run = async () => {
       setSecretsList({ status: 'loading' });
-      let result: SecretsList;
+      let result: Array<SecretWithAssociatedSessions>;
       try {
         result = (await getSecrets()).result;
       } catch (err) {

--- a/packages/web/src/components/session-menu/secrets-panel.tsx
+++ b/packages/web/src/components/session-menu/secrets-panel.tsx
@@ -98,7 +98,7 @@ export default function SessionMenuPanelSecrets(props: PropsType) {
     setTimeout(() => {
       onDeregisterLoadingSecretName(secretName);
     }, 50);
-  }, [props.session.id]);
+  }, [props.session.id, onRegisterLoadingSecretName, onDeregisterLoadingSecretName]);
 
   return (
     <>
@@ -120,9 +120,10 @@ export default function SessionMenuPanelSecrets(props: PropsType) {
                 className="flex items-center justify-between h-8 cursor-pointer"
                 key={secret.name}
                 onClick={() => onChangeSecretEnabled(secret.name, !checked)}
+                aria-hidden={true}
               >
                 <span className="font-mono">{secret.name}</span>
-                <div onClick={e => e.stopPropagation()}>
+                <div onClick={e => e.stopPropagation()} aria-hidden={true}>
                   <Switch
                     disabled={loadingSecretNames.has(secret.name)}
                     checked={checked}

--- a/packages/web/src/components/session-menu/secrets-panel.tsx
+++ b/packages/web/src/components/session-menu/secrets-panel.tsx
@@ -1,20 +1,24 @@
 // import { SessionMenuPanelContentsProps } from '.';
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { type SecretWithAssociatedSessions } from '@srcbook/shared';
 
-import { getSecrets, associateSecretWithSession, disassociateSecretWithSession } from "@/lib/server";
-import { Switch } from "@/components/ui/switch";
-import { SessionMenuPanelContentsProps } from ".";
+import {
+  getSecrets,
+  associateSecretWithSession,
+  disassociateSecretWithSession,
+} from '@/lib/server';
+import { Switch } from '@/components/ui/switch';
+import { SessionMenuPanelContentsProps } from '.';
 
 type PropsType = Pick<SessionMenuPanelContentsProps, 'session'>;
 
 export default function SessionMenuPanelSecrets(props: PropsType) {
   const [secretsList, setSecretsList] = useState<
-    | { status: 'idle' } 
+    | { status: 'idle' }
     | { status: 'loading' }
-    | { status: 'complete', data: Array<SecretWithAssociatedSessions> }
+    | { status: 'complete'; data: Array<SecretWithAssociatedSessions> }
     | { status: 'error' }
   >({ status: 'idle' });
   useEffect(() => {
@@ -39,81 +43,88 @@ export default function SessionMenuPanelSecrets(props: PropsType) {
   // Store a list of all secret name association changes that are in progress so that a user cannot
   // change an already in flight association
   const [loadingSecretNames, setLoadingSecretName] = useState<Set<string>>(new Set());
-  const onRegisterLoadingSecretName = useCallback((secretName: string) => {
-    setLoadingSecretName(old => {
-      const newSet = new Set(old)
-      newSet.add(secretName);
-      return newSet;
-    });
-  }, [setLoadingSecretName]);
-  const onDeregisterLoadingSecretName = useCallback((secretName: string) => {
-    setLoadingSecretName(old => {
-      const newSet = new Set(old)
-      newSet.delete(secretName);
-      return newSet;
-    });
-  }, [setLoadingSecretName]);
+  const onRegisterLoadingSecretName = useCallback(
+    (secretName: string) => {
+      setLoadingSecretName((old) => {
+        const newSet = new Set(old);
+        newSet.add(secretName);
+        return newSet;
+      });
+    },
+    [setLoadingSecretName],
+  );
+  const onDeregisterLoadingSecretName = useCallback(
+    (secretName: string) => {
+      setLoadingSecretName((old) => {
+        const newSet = new Set(old);
+        newSet.delete(secretName);
+        return newSet;
+      });
+    },
+    [setLoadingSecretName],
+  );
 
-  const onChangeSecretEnabled = useCallback(async (secretName: string, enabled: boolean) => {
-    onRegisterLoadingSecretName(secretName);
+  const onChangeSecretEnabled = useCallback(
+    async (secretName: string, enabled: boolean) => {
+      onRegisterLoadingSecretName(secretName);
 
-    try {
-      if (enabled) {
-        await associateSecretWithSession(props.session.id, secretName);
-      } else {
-        await disassociateSecretWithSession(props.session.id, secretName);
+      try {
+        if (enabled) {
+          await associateSecretWithSession(props.session.id, secretName);
+        } else {
+          await disassociateSecretWithSession(props.session.id, secretName);
+        }
+      } catch (err) {
+        onDeregisterLoadingSecretName(secretName);
+        console.error(`Error changing secret ${secretName} enabled:`, err);
+        toast.error('Error enabling/disabling secret!');
+        return;
       }
-    } catch (err) {
-      onDeregisterLoadingSecretName(secretName);
-      console.error(`Error changing secret ${secretName} enabled:`, err);
-      toast.error("Error enabling/disabling secret!");
-      return;
-    }
 
-    // After changing the secret value, optimisitcally update the secrets list
-    // FIXME: maybe it would be better to just refetch?
-    setSecretsList(old => {
-      if (old.status !== 'complete') {
-        return old;
-      }
+      // After changing the secret value, optimisitcally update the secrets list
+      // FIXME: maybe it would be better to just refetch?
+      setSecretsList((old) => {
+        if (old.status !== 'complete') {
+          return old;
+        }
 
-      return {
-        ...old,
-        data: old.data.map(item => {
-          if (item.name === secretName) {
-            return {
-              ...item,
-              associatedWithSessionIds: enabled ? (
-                [...item.associatedWithSessionIds, props.session.id ]
-              ) : item.associatedWithSessionIds.filter(id => id !== props.session.id),
-            };
-          } else {
-            return item;
-          }
-        }),
-      };
-    });
+        return {
+          ...old,
+          data: old.data.map((item) => {
+            if (item.name === secretName) {
+              return {
+                ...item,
+                associatedWithSessionIds: enabled
+                  ? [...item.associatedWithSessionIds, props.session.id]
+                  : item.associatedWithSessionIds.filter((id) => id !== props.session.id),
+              };
+            } else {
+              return item;
+            }
+          }),
+        };
+      });
 
-    // NOTE: add a slight delay before removing the loading state to minimize ui flicker
-    setTimeout(() => {
-      onDeregisterLoadingSecretName(secretName);
-    }, 50);
-  }, [props.session.id, onRegisterLoadingSecretName, onDeregisterLoadingSecretName]);
+      // NOTE: add a slight delay before removing the loading state to minimize ui flicker
+      setTimeout(() => {
+        onDeregisterLoadingSecretName(secretName);
+      }, 50);
+    },
+    [props.session.id, onRegisterLoadingSecretName, onDeregisterLoadingSecretName],
+  );
 
   return (
     <>
       <h4 className="text-lg font-semibold leading-tight mb-2">Secrets</h4>
       <h6 className="mb-4 text-tertiary-foreground">Available in this srcbook</h6>
 
-      {secretsList.status === "idle" || secretsList.status === "loading" ? (
+      {secretsList.status === 'idle' || secretsList.status === 'loading' ? (
         <span>Loading</span>
       ) : null}
-      {secretsList.status === "error" ? (
-        <span>Error loading secrets!</span>
-      ) : null}
-      {secretsList.status === "complete" ? (
+      {secretsList.status === 'error' ? <span>Error loading secrets!</span> : null}
+      {secretsList.status === 'complete' ? (
         <div>
-          {secretsList.data.map(secret => {
+          {secretsList.data.map((secret) => {
             const checked = secret.associatedWithSessionIds.includes(props.session.id);
             return (
               <div
@@ -123,11 +134,11 @@ export default function SessionMenuPanelSecrets(props: PropsType) {
                 aria-hidden={true}
               >
                 <span className="font-mono">{secret.name}</span>
-                <div onClick={e => e.stopPropagation()} aria-hidden={true}>
+                <div onClick={(e) => e.stopPropagation()} aria-hidden={true}>
                   <Switch
                     disabled={loadingSecretNames.has(secret.name)}
                     checked={checked}
-                    onCheckedChange={checked => onChangeSecretEnabled(secret.name, checked)}
+                    onCheckedChange={(checked) => onChangeSecretEnabled(secret.name, checked)}
                   />
                 </div>
               </div>

--- a/packages/web/src/components/session-menu/secrets-panel.tsx
+++ b/packages/web/src/components/session-menu/secrets-panel.tsx
@@ -1,0 +1,56 @@
+// import { SessionMenuPanelContentsProps } from '.';
+
+import { useEffect, useState } from "react";
+import { getSecrets } from "@/lib/server";
+
+type PropsType = Record<string, never>; // Pick<SessionMenuPanelContentsProps, 'session' | 'openDepsInstallModal'>;
+
+type SecretsList = Record<string, string>;
+
+export default function SessionMenuPanelSecrets(_props: PropsType) {
+  const [secretsList, setSecretsList] = useState<
+    | { status: 'idle' } 
+    | { status: 'loading' }
+    | { status: 'complete', data: SecretsList }
+    | { status: 'error' }
+  >({ status: 'idle' });
+  useEffect(() => {
+    const run = async () => {
+      setSecretsList({ status: 'loading' });
+      let result: SecretsList;
+      try {
+        result = (await getSecrets()).result;
+      } catch (err) {
+        console.error('Error loading secrets!', err);
+        setSecretsList({ status: 'error' });
+        return;
+      }
+
+      setSecretsList({ status: 'complete', data: result });
+    };
+
+    // FIXME: it is possible for this to run twice in parallel?
+    run();
+  }, []);
+
+  return (
+    <>
+      <div>Secrets</div>
+      TODO
+
+      {secretsList.status === "idle" || secretsList.status === "loading" ? (
+        <span>Loading</span>
+      ) : null}
+      {secretsList.status === "error" ? (
+        <span>Error loading secrets!</span>
+      ) : null}
+      {secretsList.status === "complete" ? (
+        <div>
+          {Object.entries(secretsList.data).map(([secretKey, secretValue]) => (
+            <div key={secretKey}>{secretKey}: {secretValue}</div>
+          ))}
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/packages/web/src/lib/server.ts
+++ b/packages/web/src/lib/server.ts
@@ -332,6 +332,28 @@ export async function deleteSecret(request: DeleteSecretRequestType) {
   return response.json();
 }
 
+export async function associateSecretWithSession(sessionId: string, secretName: string) {
+  const response = await fetch(`${API_BASE_URL}/sessions/${sessionId}/secrets/${secretName}`, {
+    method: 'PUT',
+  });
+
+  if (!response.ok) {
+    console.error(response);
+    throw new Error('Request failed');
+  }
+}
+
+export async function disassociateSecretWithSession(sessionId: string, secretName: string) {
+  const response = await fetch(`${API_BASE_URL}/sessions/${sessionId}/secrets/${secretName}`, {
+    method: 'DELETE',
+  });
+
+  if (!response.ok) {
+    console.error(response);
+    throw new Error('Request failed');
+  }
+}
+
 // NPM package search, has to happen on the server given CORS restrictions
 export async function searchNpmPackages(query: string, size: number) {
   if (query === '') {

--- a/packages/web/src/routes/secrets.tsx
+++ b/packages/web/src/routes/secrets.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { cn } from '@/lib/utils.ts';
 import { getSecrets } from '@/lib/server';
+import { type SecretWithAssociatedSessions } from '@srcbook/shared';
 import { Info, Trash2, Eye, EyeOff } from 'lucide-react';
 import { Form, useLoaderData, useRevalidator } from 'react-router-dom';
 import { Input } from '@/components/ui/input';
@@ -25,7 +26,7 @@ function isValidSecretName(name: string) {
 }
 
 function Secrets() {
-  const { secrets } = useLoaderData() as { secrets: Record<string, string> };
+  const { secrets } = useLoaderData() as { secrets: Array<SecretWithAssociatedSessions> };
 
   const [error, _setError] = useState<string | null>(null);
 
@@ -81,7 +82,7 @@ function ErrorMessage(props: { message: string }) {
 }
 
 function SecretsTable(props: {
-  secrets: Record<string, string>;
+  secrets: Array<SecretWithAssociatedSessions>;
   setError: (message: string | null, clearAfter?: number | null) => void;
 }) {
   const revalidator = useRevalidator();
@@ -102,12 +103,12 @@ function SecretsTable(props: {
     revalidator.revalidate();
   }
 
-  const sortedSecrets = Object.entries(props.secrets).sort(([nameA], [nameB]) =>
+  const sortedSecrets = props.secrets.sort(({ name: nameA }, { name: nameB }) =>
     nameA.localeCompare(nameB),
   );
 
   return (
-    Object.keys(sortedSecrets).length > 0 && (
+    sortedSecrets.length > 0 && (
       <div className="relative w-full overflow-auto">
         <table className="w-full space-y-2">
           <thead>
@@ -118,11 +119,11 @@ function SecretsTable(props: {
             </tr>
           </thead>
           <tbody>
-            {sortedSecrets.map(([name, value]) => (
+            {sortedSecrets.map((secret) => (
               <SecretRow
-                key={name}
-                name={name}
-                value={value}
+                key={secret.name}
+                name={secret.name}
+                value={secret.value}
                 onUpdate={onUpdate}
                 onDelete={onDelete}
                 setError={props.setError}


### PR DESCRIPTION
Adds a new "secrets" panel to the left side of the app where one can select which secrets apply to a given srcbook. By default, a srcbook has access to none of a user's defined secrets, and a user must manually enable each.

I've kept the implementation relatively straightforward for now - there's a new `secrets_to_sessions` table in sqlite that is used as a many-to-many bridge table between secrets and all sessions in a user's local `~/.srcbook/srcbooks` directory. I'm calling this out because in the future, some logic similar to [livebook stamping](https://news.livebook.dev/hubs-and-secret-management---launch-week-1---day-3-3tMaJ2xthttps://news.livebook.dev/hubs-and-secret-management---launch-week-1---day-3-3tMaJ2) might be a good idea to harden the security here, but for the time being this was deemed to be out of scope.

<img width="906" alt="Screenshot 2024-09-13 at 2 29 30 PM" src="https://github.com/user-attachments/assets/6649b41d-3c8f-4724-a239-e88e8d947414">
