### PR TITLE
Tweak theme to match ours for mermaid diagrams

### DIFF
--- a/.changeset/tough-hounds-destroy.md
+++ b/.changeset/tough-hounds-destroy.md
@@ -1,0 +1,5 @@
+---
+'@srcbook/web': patch
+---
+
+Theme improvements for mermaid diagrams

--- a/packages/web/src/components/cells/markdown.tsx
+++ b/packages/web/src/components/cells/markdown.tsx
@@ -14,11 +14,25 @@ import { useCells } from '../use-cell';
 
 marked.use({ gfm: true });
 
+const MERMAID_LIGHT_OVERRIDES = {
+  background: '#FFFFFF', // bg-background // Other colors (eg line color) are derived from this
+  primaryColor: '#FBFCFD', // bg-muted
+  primaryBorderColor: '#D8DBDD', // bg-border
+  primaryTextColor: '#38464F', // text-foreground
+};
+
+const MERMAID_DARK_OVERRIDES = {
+  background: '#20282D', // bg-background // Other colors (eg line color) are derived from this
+  primaryColor: '#293239', // bg-muted
+  primaryBorderColor: '#38464F', // bg-border
+  primaryTextColor: '#FFFFFF', // text-foreground
+};
+
 const markdownRenderer = {
   code(snippet: React.ReactNode, lang: string) {
     if (lang === 'mermaid') {
       return (
-        <pre className="mermaid" key="mermaid">
+        <pre className="mermaid !bg-background" key="mermaid">
           {snippet}
         </pre>
       );
@@ -65,7 +79,13 @@ export default function MarkdownCell(props: {
 
   // Initializes mermaid and updates it on theme change
   useEffect(() => {
-    mermaid.initialize({ startOnLoad: true, theme: theme === 'dark' ? 'dark' : 'base' });
+    mermaid.initialize({
+      startOnLoad: true,
+      theme: 'base',
+      fontFamily: 'IBM Plex Sans',
+      darkMode: theme === 'dark',
+      themeVariables: theme === 'dark' ? MERMAID_DARK_OVERRIDES : MERMAID_LIGHT_OVERRIDES,
+    });
   }, [theme]);
 
   // Rerenders mermaid diagrams when the cell is in view mode


### PR DESCRIPTION
I only tested on two diagram types. There are a number of other settings and colors for different things, so I'm sure this is far from perfect. But it's mostly there with minimal effort for now.

<img width="1508" alt="Screenshot 2024-09-13 at 1 01 50 PM" src="https://github.com/user-attachments/assets/a7b1ed1b-4df2-4593-bec1-e4fc1e8b47f5">

<img width="1508" alt="Screenshot 2024-09-13 at 1 01 56 PM" src="https://github.com/user-attachments/assets/cc968fc6-5ae0-49c6-9f25-81b31d5611f6">
