### PR TITLE
add @srcbook/web for build & changeset tracking

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,9 @@ importers:
       '@srcbook/shared':
         specifier: workspace:^
         version: link:../packages/shared
+      '@srcbook/web':
+        specifier: workspace:^
+        version: link:../packages/web
       ai:
         specifier: ^3.3.33
         version: 3.3.33(openai@4.52.3)(react@18.3.1)(sswr@2.1.0(svelte@4.2.18))(svelte@4.2.18)(vue@3.4.31(typescript@5.6.2))(zod@3.23.8)

--- a/srcbook/package.json
+++ b/srcbook/package.json
@@ -19,6 +19,7 @@
     "@ai-sdk/openai": "catalog:",
     "@srcbook/api": "workspace:^",
     "@srcbook/shared": "workspace:^",
+    "@srcbook/web": "workspace:^",
     "ai": "^3.3.33",
     "better-sqlite3": "^11.3.0",
     "chalk": "^5.3.0",


### PR DESCRIPTION
This just gets turbo & changeset properly resolving that CLI depends on web since it never directly imported it before, fixes a potential changeset issue if changes are only to web and fixes issue with turbo in rare instances