### PR TITLE
Improve mermaid rendering

### DIFF
--- a/.changeset/brown-peas-hope.md
+++ b/.changeset/brown-peas-hope.md
@@ -1,0 +1,5 @@
+---
+'@srcbook/web': patch
+---
+
+Improve mermaid rendering

--- a/packages/web/src/components/cells/markdown.tsx
+++ b/packages/web/src/components/cells/markdown.tsx
@@ -32,14 +32,14 @@ const markdownRenderer = {
   code(snippet: React.ReactNode, lang: string) {
     if (lang === 'mermaid') {
       return (
-        <pre className="mermaid !bg-background" key="mermaid">
+        <pre className="mermaid !bg-background" key={String(snippet)}>
           {snippet}
         </pre>
       );
     }
 
     return (
-      <pre key="code">
+      <pre key={String(snippet)}>
         <code>{snippet}</code>
       </pre>
     );
@@ -80,7 +80,7 @@ export default function MarkdownCell(props: {
   // Initializes mermaid and updates it on theme change
   useEffect(() => {
     mermaid.initialize({
-      startOnLoad: true,
+      startOnLoad: false,
       theme: 'base',
       fontFamily: 'IBM Plex Sans',
       darkMode: theme === 'dark',


### PR DESCRIPTION
I was noticing some wonky behavior with Mermaid rendering. I would occasionally see one or both of the following:

* With multiple diagrams, sometimes the renderer would render all of them in the same location, even if they were supposed to be rendered at different points in the markdown
* Sometimes (with multiple diagrams especially) I would see one or two diagrams render but not the others

Then I noticed the keys were fixed even though there could be multiple rendering in the same markdown block. We were getting unique key warnings in the console.