### PR TITLE
Polish import/export form

### DIFF
--- a/packages/web/src/components/srcmd-upload-drop-zone.tsx
+++ b/packages/web/src/components/srcmd-upload-drop-zone.tsx
@@ -7,9 +7,10 @@ import { cn } from '@/lib/utils';
 
 type SrcMdUploadDropZoneProps = {
   onDrop: (uploadedFile: File) => void;
+  className?: string;
 };
 
-export default function SrcMdUploadDropZone({ onDrop }: SrcMdUploadDropZoneProps) {
+export default function SrcMdUploadDropZone({ onDrop, className }: SrcMdUploadDropZoneProps) {
   const onDropInternal = useCallback(
     (acceptedFiles: Array<File>) => {
       if (acceptedFiles.length > 1) {
@@ -35,11 +36,12 @@ export default function SrcMdUploadDropZone({ onDrop }: SrcMdUploadDropZoneProps
     <button
       {...rootProps}
       className={cn(
-        'flex flex-col gap-4 w-full items-center justify-center h-[160px] border border-dashed rounded-md',
+        'flex flex-col gap-4 w-full items-center justify-center p-6 border border-dashed rounded-md',
         'hover:bg-muted cursor-pointer',
         {
           'bg-muted': isDragActive,
         },
+        className,
         rootProps.className,
       )}
     >


### PR DESCRIPTION
Some polish from QA:

- [x] Remove upload file validation on file name, which is not the same as the srcbook title and broke an otherwise valid Srcbook I have
- [x] Reset error/form state when navigating between tabs (especially for errors which don't apply on other tab)
- [x] Disable tabs switching while importing is in progress
- [x] Use placeholder in import url input to indicate the Hub is where this behavior mostly applies
- [x] Use toasts consistently