### PR TITLE
Add ability to create secrets within a Srcbook

### DIFF
--- a/packages/web/src/components/session-menu/secrets-panel.tsx
+++ b/packages/web/src/components/session-menu/secrets-panel.tsx
@@ -1,8 +1,5 @@
-// import { SessionMenuPanelContentsProps } from '.';
-
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
-import { type SecretWithAssociatedSessions } from '@srcbook/shared';
 
 import {
   getSecrets,
@@ -14,138 +11,73 @@ import { SessionMenuPanelContentsProps } from '.';
 
 type PropsType = Pick<SessionMenuPanelContentsProps, 'session'>;
 
-export default function SessionMenuPanelSecrets(props: PropsType) {
-  const [secretsList, setSecretsList] = useState<
-    | { status: 'idle' }
-    | { status: 'loading' }
-    | { status: 'complete'; data: Array<SecretWithAssociatedSessions> }
-    | { status: 'error' }
-  >({ status: 'idle' });
+export default function SessionMenuPanelSecrets({ session }: PropsType) {
+  const [secrets, setSecrets] = useState<{ name: string; checked: boolean }[]>([]);
+
   useEffect(() => {
     const run = async () => {
-      setSecretsList({ status: 'loading' });
-      let result: Array<SecretWithAssociatedSessions>;
       try {
-        result = (await getSecrets()).result;
+        const { result: secretsWithAssociations } = await getSecrets();
+
+        const secrets = secretsWithAssociations.map((s) => ({
+          name: s.name,
+          checked: s.associatedWithSessionIds.includes(session.id),
+        }));
+
+        setSecrets(secrets);
       } catch (err) {
-        console.error('Error loading secrets!', err);
-        setSecretsList({ status: 'error' });
+        console.error('Error loading secrets', err);
         return;
       }
-
-      setSecretsList({ status: 'complete', data: result });
     };
 
-    // FIXME: it is possible for this to run twice in parallel?
     run();
   }, []);
 
-  // Store a list of all secret name association changes that are in progress so that a user cannot
-  // change an already in flight association
-  const [loadingSecretNames, setLoadingSecretName] = useState<Set<string>>(new Set());
-  const onRegisterLoadingSecretName = useCallback(
-    (secretName: string) => {
-      setLoadingSecretName((old) => {
-        const newSet = new Set(old);
-        newSet.add(secretName);
-        return newSet;
-      });
-    },
-    [setLoadingSecretName],
-  );
-  const onDeregisterLoadingSecretName = useCallback(
-    (secretName: string) => {
-      setLoadingSecretName((old) => {
-        const newSet = new Set(old);
-        newSet.delete(secretName);
-        return newSet;
-      });
-    },
-    [setLoadingSecretName],
-  );
+  function toggleSecret(secretName: string) {
+    setSecrets((secrets) =>
+      secrets.map((s) => {
+        return s.name === secretName ? { ...s, checked: !s.checked } : s;
+      }),
+    );
+  }
 
-  const onChangeSecretEnabled = useCallback(
-    async (secretName: string, enabled: boolean) => {
-      onRegisterLoadingSecretName(secretName);
+  async function onChangeSecretEnabled(secretName: string, enabled: boolean) {
+    toggleSecret(secretName);
 
-      try {
-        if (enabled) {
-          await associateSecretWithSession(props.session.id, secretName);
-        } else {
-          await disassociateSecretWithSession(props.session.id, secretName);
-        }
-      } catch (err) {
-        onDeregisterLoadingSecretName(secretName);
-        console.error(`Error changing secret ${secretName} enabled:`, err);
-        toast.error('Error enabling/disabling secret!');
-        return;
-      }
-
-      // After changing the secret value, optimisitcally update the secrets list
-      // FIXME: maybe it would be better to just refetch?
-      setSecretsList((old) => {
-        if (old.status !== 'complete') {
-          return old;
-        }
-
-        return {
-          ...old,
-          data: old.data.map((item) => {
-            if (item.name === secretName) {
-              return {
-                ...item,
-                associatedWithSessionIds: enabled
-                  ? [...item.associatedWithSessionIds, props.session.id]
-                  : item.associatedWithSessionIds.filter((id) => id !== props.session.id),
-              };
-            } else {
-              return item;
-            }
-          }),
-        };
-      });
-
-      // NOTE: add a slight delay before removing the loading state to minimize ui flicker
-      setTimeout(() => {
-        onDeregisterLoadingSecretName(secretName);
-      }, 50);
-    },
-    [props.session.id, onRegisterLoadingSecretName, onDeregisterLoadingSecretName],
-  );
+    try {
+      const operation = enabled ? associateSecretWithSession : disassociateSecretWithSession;
+      await operation(session.id, secretName);
+    } catch (err) {
+      toggleSecret(secretName);
+      console.error(`Error toggling secret ${secretName}`, err);
+      toast.error('Error enabling/disabling secret!');
+      return;
+    }
+  }
 
   return (
     <>
       <h4 className="text-lg font-semibold leading-tight mb-2">Secrets</h4>
       <h6 className="mb-4 text-tertiary-foreground">Available in this srcbook</h6>
 
-      {secretsList.status === 'idle' || secretsList.status === 'loading' ? (
-        <span>Loading</span>
-      ) : null}
-      {secretsList.status === 'error' ? <span>Error loading secrets!</span> : null}
-      {secretsList.status === 'complete' ? (
-        <div>
-          {secretsList.data.map((secret) => {
-            const checked = secret.associatedWithSessionIds.includes(props.session.id);
-            return (
-              <div
-                className="flex items-center justify-between h-8 cursor-pointer"
-                key={secret.name}
-                onClick={() => onChangeSecretEnabled(secret.name, !checked)}
-                aria-hidden={true}
-              >
-                <span className="font-mono">{secret.name}</span>
-                <div onClick={(e) => e.stopPropagation()} aria-hidden={true}>
-                  <Switch
-                    disabled={loadingSecretNames.has(secret.name)}
-                    checked={checked}
-                    onCheckedChange={(checked) => onChangeSecretEnabled(secret.name, checked)}
-                  />
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      ) : null}
+      <div>
+        {secrets.map((secret) => (
+          <label
+            key={secret.name}
+            htmlFor={`secret-${secret.name}`}
+            className="flex items-center justify-between h-8 font-mono cursor-pointer"
+          >
+            {secret.name}
+
+            <Switch
+              id={`secret-${secret.name}`}
+              checked={secret.checked}
+              onCheckedChange={(checked) => onChangeSecretEnabled(secret.name, checked)}
+            />
+          </label>
+        ))}
+      </div>
     </>
   );
 }

--- a/packages/web/src/components/session-menu/secrets-panel.tsx
+++ b/packages/web/src/components/session-menu/secrets-panel.tsx
@@ -3,35 +3,40 @@ import { toast } from 'sonner';
 
 import {
   getSecrets,
+  createSecret,
   associateSecretWithSession,
   disassociateSecretWithSession,
 } from '@/lib/server';
 import { Switch } from '@/components/ui/switch';
 import { SessionMenuPanelContentsProps } from '.';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { isValidSecretName } from '@/lib/utils';
 
 type PropsType = Pick<SessionMenuPanelContentsProps, 'session'>;
 
 export default function SessionMenuPanelSecrets({ session }: PropsType) {
   const [secrets, setSecrets] = useState<{ name: string; checked: boolean }[]>([]);
+  const [showForm, setShowForm] = useState(false);
+
+  async function loadSecrets() {
+    try {
+      const { result: secretsWithAssociations } = await getSecrets();
+
+      const secrets = secretsWithAssociations.map((s) => ({
+        name: s.name,
+        checked: s.associatedWithSessionIds.includes(session.id),
+      }));
+
+      setSecrets(secrets.reverse());
+    } catch (err) {
+      console.error('Error loading secrets', err);
+      return;
+    }
+  }
 
   useEffect(() => {
-    const run = async () => {
-      try {
-        const { result: secretsWithAssociations } = await getSecrets();
-
-        const secrets = secretsWithAssociations.map((s) => ({
-          name: s.name,
-          checked: s.associatedWithSessionIds.includes(session.id),
-        }));
-
-        setSecrets(secrets);
-      } catch (err) {
-        console.error('Error loading secrets', err);
-        return;
-      }
-    };
-
-    run();
+    loadSecrets();
   }, []);
 
   function toggleSecret(secretName: string) {
@@ -43,25 +48,44 @@ export default function SessionMenuPanelSecrets({ session }: PropsType) {
   }
 
   async function onChangeSecretEnabled(secretName: string, enabled: boolean) {
-    toggleSecret(secretName);
+    toggleSecret(secretName); // optimistic update
 
     try {
       const operation = enabled ? associateSecretWithSession : disassociateSecretWithSession;
       await operation(session.id, secretName);
     } catch (err) {
-      toggleSecret(secretName);
+      toggleSecret(secretName); // undo optimistic update
       console.error(`Error toggling secret ${secretName}`, err);
       toast.error('Error enabling/disabling secret!');
       return;
     }
   }
 
+  async function onSecretAdded(secretName: string) {
+    setShowForm(false);
+    await loadSecrets();
+    toggleSecret(secretName);
+    await associateSecretWithSession(session.id, secretName);
+  }
+
   return (
     <>
       <h4 className="text-lg font-semibold leading-tight mb-2">Secrets</h4>
-      <h6 className="mb-4 text-tertiary-foreground">Available in this srcbook</h6>
 
-      <div>
+      <div className="flex items-center justify-between">
+        {showForm ? (
+          <InlineForm onSecretAdded={onSecretAdded} />
+        ) : (
+          <>
+            <p className="text-tertiary-foreground">Enable secrets below</p>
+            <Button variant="secondary" onClick={() => setShowForm(true)}>
+              Add secret
+            </Button>
+          </>
+        )}
+      </div>
+
+      <div className="mt-8">
         {secrets.map((secret) => (
           <label
             key={secret.name}
@@ -79,5 +103,69 @@ export default function SessionMenuPanelSecrets({ session }: PropsType) {
         ))}
       </div>
     </>
+  );
+}
+
+function InlineForm(props: { onSecretAdded: (name: string) => void }) {
+  const [name, setName] = useState('');
+  const [value, setValue] = useState('');
+  const [error, _setError] = useState<string | null>(null);
+
+  function setError(error: string | null) {
+    if (error === null) {
+      _setError(null);
+      return;
+    }
+
+    _setError(error);
+    setTimeout(() => _setError(null), 5000);
+  }
+
+  function isValidSecret() {
+    return isValidSecretName(name) && value.length > 0;
+  }
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    _setError(null);
+
+    try {
+      await createSecret({ name, value });
+    } catch (err) {
+      console.error('Error creating secret', err);
+      setError('Error creating secret');
+      return;
+    }
+
+    props.onSecretAdded(name);
+
+    setName('');
+    setValue('');
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <form name="inline-secret-form" className="flex items-center space-x-4" onSubmit={onSubmit}>
+        <Input
+          required
+          autoComplete="off"
+          placeholder="SECRET_NAME"
+          value={name}
+          onChange={(e) => setName(e.currentTarget.value.toUpperCase())}
+        />
+        <Input
+          required
+          autoComplete="off"
+          value={value}
+          onChange={(e) => setValue(e.currentTarget.value)}
+          placeholder="secret-value"
+        />
+        <Button type="submit" variant="secondary" disabled={!isValidSecret()}>
+          Add
+        </Button>
+      </form>
+      {error && <p className="text-error text-[13px]">{error}</p>}
+    </div>
   );
 }

--- a/packages/web/src/lib/server.ts
+++ b/packages/web/src/lib/server.ts
@@ -3,6 +3,7 @@ import type {
   CodeLanguageType,
   MarkdownCellType,
   CodeCellType,
+  SecretWithAssociatedSessions,
 } from '@srcbook/shared';
 import { SessionType, ExampleSrcbookType } from '@/types';
 import SRCBOOK_CONFIG from '@/config';
@@ -269,7 +270,7 @@ export async function updateConfig(request: EditConfigRequestType): Promise<void
 }
 
 // Secret management
-export async function getSecrets() {
+export async function getSecrets(): Promise<{ result: SecretWithAssociatedSessions[] }> {
   const response = await fetch(API_BASE_URL + '/secrets', {
     method: 'GET',
     headers: { 'content-type': 'application/json' },

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -27,3 +27,7 @@ export function getTitleForSession(session: SessionType) {
   const titleCell = session.cells.find((cell: CellType) => cell.type === 'title') as TitleCellType;
   return titleCell?.text;
 }
+
+export function isValidSecretName(name: string) {
+  return /^[A-Z0-9_]+$/.test(name);
+}

--- a/packages/web/src/routes/secrets.tsx
+++ b/packages/web/src/routes/secrets.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
-import { cn } from '@/lib/utils.ts';
+import { cn, isValidSecretName } from '@/lib/utils.ts';
 import { getSecrets } from '@/lib/server';
 import { type SecretWithAssociatedSessions } from '@srcbook/shared';
 import { Info, Trash2, Eye, EyeOff } from 'lucide-react';
@@ -19,10 +19,6 @@ import {
 async function loader() {
   const { result } = await getSecrets();
   return { secrets: result };
-}
-
-function isValidSecretName(name: string) {
-  return /^[A-Z0-9_]+$/.test(name);
 }
 
 function Secrets() {


### PR DESCRIPTION
We want to make it quick and easy to add a new secret on the Srcbook page.

### Notes

* Since this is all running locally right now and thus response times are < 10ms, I simplified the existing code to ignore the loading states which made it easier to add the other logic (see first commit in this PR).
* This isn't perfect, the form is minimal. There's no link to the secrets page, which has more functionality. The UI is probably not great. We can work with our designer to improve this.

![CleanShot 2024-09-19 at 00 04 26](https://github.com/user-attachments/assets/73f97841-9dd2-49d9-a7ec-ca0f1935ff5b)
