### PR TITLE
feat: add go to definiton keyboard shortcuts entry

### DIFF
--- a/packages/web/src/components/keyboard-shortcuts-dialog.tsx
+++ b/packages/web/src/components/keyboard-shortcuts-dialog.tsx
@@ -45,6 +45,7 @@ export default function KeyboardShortcutsDialog({
               <ShortcutRow keys={['alt', '↑']} description="move lines up" />
               <ShortcutRow keys={['alt', '↓']} description="move lines down" />
               <ShortcutRow keys={['shift', 'alt', 'f']} description="format code using Prettier" />
+              <ShortcutRow keys={['alt', 'click']} description="Go to definition" />
             </div>
           </DialogDescription>
         </DialogHeader>

--- a/packages/web/src/components/keyboard-shortcuts-dialog.tsx
+++ b/packages/web/src/components/keyboard-shortcuts-dialog.tsx
@@ -45,7 +45,7 @@ export default function KeyboardShortcutsDialog({
               <ShortcutRow keys={['alt', '↑']} description="move lines up" />
               <ShortcutRow keys={['alt', '↓']} description="move lines down" />
               <ShortcutRow keys={['shift', 'alt', 'f']} description="format code using Prettier" />
-              <ShortcutRow keys={['alt', 'click']} description="Go to definition" />
+              <ShortcutRow keys={['alt', 'click']} description="go to definition" />
             </div>
           </DialogDescription>
         </DialogHeader>


### PR DESCRIPTION
Note that according to vscode's documentation, it is "Go to definition" and not "Goto Definition", so I went with that: https://code.visualstudio.com/Docs/editor/editingevolved#_go-to-definition

<img width="572" alt="Screenshot 2024-09-20 at 4 01 47 PM" src="https://github.com/user-attachments/assets/68b7d562-48f6-4f54-9545-f7648782858d">
