### PR TITLE
fix: typos #322

### DIFF
--- a/packages/web/src/components/ai-generate-tips-dialog.tsx
+++ b/packages/web/src/components/ai-generate-tips-dialog.tsx
@@ -17,10 +17,11 @@ export default function AiGenerateTipsDialog({ children }: { children: React.Rea
           <DialogTitle>Prompt tips</DialogTitle>
           <div className="text-sm">
             <p>Here are a few tips to get the AI to work well for you.</p>
+
             <ul className="list-disc list-inside py-4 leading-5">
-              <li>The AI knows already knows about all of the contents of this srcbook.</li>
+              <li>The AI already knows about all of the contents of this srcbook.</li>
               <li>It also knows what cell you're updating.</li>
-              <li>You can ask the code to add or improve comments or jsdoc.</li>
+              <li>You can ask the AI to add or improve comments or JSDoc.</li>
               <li>You can ask the AI to refactor or rewrite the whole thing.</li>
               <li>
                 Try asking the AI to refactor, improve or modularize your code, simply by asking for


### PR DESCRIPTION

Here I fixed the typos that was there in prompt tips dialog box, but since I have not bought any api key I was not able to put snapshot.

You can check it out using your own api key.
![Screenshot from 2024-09-29 08-10-11](https://github.com/user-attachments/assets/708a7e88-dd8e-462b-8c7d-a96aa877444c)

