### PR TITLE
Windows Typescript Notebook Support

### DIFF
--- a/packages/api/constants.mts
+++ b/packages/api/constants.mts
@@ -1,16 +1,16 @@
 import os from 'node:os';
-import path from 'node:path';
+import Path from 'node:path';
 import { fileURLToPath } from 'url';
 
 // When running Srcbook as an npx executable, the cwd is not reliable.
 // Commands that should be run from the root of the package, like npm scripts
 // should therefore use DIST_DIR as the cwd.
 const _filename = fileURLToPath(import.meta.url);
-const _dirname = path.dirname(_filename);
+const _dirname = Path.dirname(_filename);
 
 export const HOME_DIR = os.homedir();
-export const SRCBOOK_DIR = path.join(HOME_DIR, '.srcbook');
-export const SRCBOOKS_DIR = path.join(SRCBOOK_DIR, 'srcbooks');
+export const SRCBOOK_DIR = Path.join(HOME_DIR, '.srcbook');
+export const SRCBOOKS_DIR = Path.join(SRCBOOK_DIR, 'srcbooks');
 export const DIST_DIR = _dirname;
-export const PROMPTS_DIR = path.join(DIST_DIR, 'prompts');
+export const PROMPTS_DIR = Path.join(DIST_DIR, 'prompts');
 export const IS_PRODUCTION = process.env.NODE_ENV === 'production';

--- a/packages/api/db/index.mts
+++ b/packages/api/db/index.mts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import Path from 'node:path';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import Database from 'better-sqlite3';
 import * as schema from './schema.mjs';
@@ -8,9 +8,9 @@ import fs from 'node:fs';
 
 // We can't use a relative directory for drizzle since this application
 // can get run from anywhere, so use DIST_DIR as ground truth.
-const drizzleFolder = path.join(DIST_DIR, 'drizzle');
+const drizzleFolder = Path.join(DIST_DIR, 'drizzle');
 
-const DB_PATH = `${HOME_DIR}/.srcbook/srcbook.db`;
+const DB_PATH = Path.join(HOME_DIR, '.srcbook', 'srcbook.db');
 
 // Creates the HOME/.srcbook/srcbooks dir
 fs.mkdirSync(SRCBOOKS_DIR, { recursive: true });

--- a/packages/api/server/http.mts
+++ b/packages/api/server/http.mts
@@ -50,7 +50,7 @@ router.post('/file', cors(), async (req, res) => {
 
   try {
     const content = await fs.readFile(file, 'utf8');
-    const cell = file.includes('.srcbook/srcbooks') && !file.includes('node_modules');
+    const cell = file.includes(Path.join('.srcbook', 'srcbooks')) && !file.includes('node_modules');
     const filename = cell ? file.split('/').pop() || file : file;
 
     return res.json({

--- a/packages/api/test/srcmd.test.mts
+++ b/packages/api/test/srcmd.test.mts
@@ -8,7 +8,7 @@ describe('encoding and decoding srcmd files', () => {
   const languagePrefix = '<!-- srcbook:{"language": "javascript"} -->\n\n';
 
   beforeAll(async () => {
-    srcmd = await getRelativeFileContents('srcmd_files/srcbook.src.md');
+    srcmd = await getRelativeFileContents(Path.join('srcmd_files', 'srcbook.src.md'));
   });
 
   it('is an error when there is no title', () => {

--- a/packages/api/test/utils.mts
+++ b/packages/api/test/utils.mts
@@ -1,9 +1,9 @@
 import fs from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-import path from 'node:path';
+import Path from 'node:path';
 
 export async function getRelativeFileContents(relativePath: string) {
   const __filename = fileURLToPath(import.meta.url);
-  const __dirname = path.dirname(__filename);
-  return fs.readFile(path.join(__dirname, relativePath), { encoding: 'utf8' });
+  const __dirname = Path.dirname(__filename);
+  return fs.readFile(Path.join(__dirname, relativePath), { encoding: 'utf8' });
 }

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import Path from 'path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 
@@ -7,7 +7,7 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': Path.resolve(__dirname, './src'),
     },
   },
 });

--- a/srcbook/src/utils.mts
+++ b/srcbook/src/utils.mts
@@ -1,15 +1,15 @@
 import fs from 'node:fs';
 import net from 'node:net';
-import path from 'node:path';
+import Path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = Path.dirname(__filename);
 
-const ROOT_PATH = path.join(__dirname, '../../');
+const ROOT_PATH = Path.join(__dirname, '../../');
 
 export function pathTo(...paths: string[]) {
-  return path.join(ROOT_PATH, ...paths);
+  return Path.join(ROOT_PATH, ...paths);
 }
 
 export function getPackageJson() {


### PR DESCRIPTION
Fixes #297 

Add support for tsserver, file parsing, srcmd parsing, and file route handling on windows.