### PR TITLE
fix CSS cm-editor * + dark:secondary-text + add new compact UI

### DIFF
--- a/.changeset/healthy-toys-marry.md
+++ b/.changeset/healthy-toys-marry.md
@@ -1,0 +1,5 @@
+---
+'@srcbook/web': patch
+---
+
+Improve styling of typescript hover box

--- a/packages/web/src/components/cells/code.tsx
+++ b/packages/web/src/components/cells/code.tsx
@@ -868,10 +868,10 @@ function CodeEditor({
   // simplified.
   const extensions = useMemo(() => {
     const extensions: Array<Extension> = [javascript({ typescript: true })];
+    extensions.push(tsLinter(cell, getTsServerDiagnostics, getTsServerSuggestions));
     if (typeof channel !== 'undefined') {
       extensions.push(tsHover(session.id, cell, channel, theme));
     }
-    extensions.push(tsLinter(cell, getTsServerDiagnostics, getTsServerSuggestions));
     if (typeof channel !== 'undefined') {
       extensions.push(
         autocompletion({

--- a/packages/web/src/components/cells/code.tsx
+++ b/packages/web/src/components/cells/code.tsx
@@ -864,8 +864,8 @@ function CodeEditor({
     DEBOUNCE_DELAY,
   );
 
-  // FIXME: are the order of these extensions important? If not, the below can probably be
-  // simplified.
+  // The order of these extensions is important.
+  // We want the errors to be first, so we call tsLinter before tsHover.
   const extensions = useMemo(() => {
     const extensions: Array<Extension> = [javascript({ typescript: true })];
     extensions.push(tsLinter(cell, getTsServerDiagnostics, getTsServerSuggestions));

--- a/packages/web/src/components/cells/hover.tsx
+++ b/packages/web/src/components/cells/hover.tsx
@@ -38,7 +38,7 @@ export function tsHover(
         tooltipContainer.className = 'hidden';
 
         function callback({ response }: TsServerQuickInfoResponsePayloadType) {
-          tooltipContainer.className = 'p-2 space-y-2 max-w-3xl max-h-96 overflow-scroll';
+          tooltipContainer.className = 'p-2 space-y-2 max-w-3xl max-h-96 overflow-scroll text-xs';
           const signatureNode = formatCode(response.displayString, theme);
           tooltipContainer.appendChild(signatureNode);
 
@@ -90,7 +90,7 @@ function formatDocumentation(documentation: TsServerJSDocType): HTMLElement | nu
   }
 
   const div = document.createElement('div');
-  div.className = 'sb-prose text-tertiary-foreground';
+  div.className = 'text-xs text-secondary-foreground';
   div.innerHTML = parse(text) as string;
 
   return div;
@@ -102,7 +102,7 @@ function formatTags(tags: TsServerJsDocTagsType): HTMLElement | null {
   }
 
   const div = document.createElement('div');
-  div.className = 'sb-prose text-tertiary-foreground space-y-2';
+  div.className = 'text-xs text-secondary-foreground space-y-2';
 
   for (const tag of tags) {
     const tagDiv = document.createElement('div');

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -29,7 +29,6 @@
     --sb-yellow-30: 33 97% 85%;
     --sb-yellow-40: 34 96% 81%;
     --sb-yellow-50: 35 95% 76%;
-    --sb-yellow-50-subtle: 35 95% 76% 0.1;
     --sb-yellow-60: 33 76% 69%;
     --sb-yellow-70: 35 31% 45%;
     --sb-yellow-80: 34 28% 32%;
@@ -38,7 +37,6 @@
     --sb-red-20: 0 100% 86%;
     --sb-red-30: 0 100% 76%;
     --sb-red-40: 0 100% 66%;
-    --sb-red-40-subtle: 0 100% 66% 0.1;
     --sb-red-50: 0 66% 53%;
     --sb-red-60: 0 66% 41%;
     --sb-red-70: 0 74% 30%;
@@ -79,10 +77,10 @@
     --inline-code-foreground: var(--foreground);
     --error: var(--sb-red-30);
     --error-foreground: var(--sb-red-80);
-    --error-background-subtle: var(--sb-red-40-subtle);
+    --error-background-subtle: hsl(var(--sb-red-40) / 0.1);
     --warning: var(--sb-yellow-20);
     --warning-foreground: var(--sb-yellow-80);
-    --warning-background-subtle: var(--sb-yellow-50-subtle);
+    --warning-background-subtle: hsl(var(--sb-yellow-50) / 0.1);
   }
 
   .dark {
@@ -100,10 +98,10 @@
     --inline-code-foreground: var(--foreground);
     --error: var(--sb-red-30);
     --error-foreground: var(--sb-red-80);
-    --error-background-subtle: var(--sb-red-40-subtle);
+    --error-background-subtle: hsl(var(--sb-red-40) / 0.1);
     --warning: var(--sb-yellow-20);
     --warning-foreground: var(--sb-yellow-80);
-    --warning-background-subtle: var(--sb-yellow-50-subtle);
+    --warning-background-subtle: hsl(var(--sb-yellow-50) / 0.1);
   }
 
   /* shadcn variables light */

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -406,10 +406,6 @@
   @apply border;
   @apply shadow-md;
   @apply !border-border;
-  font-size: 14px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 20px; /* 142.857% */
 }
 
 .cm-tooltip-autocomplete {

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -29,6 +29,7 @@
     --sb-yellow-30: 33 97% 85%;
     --sb-yellow-40: 34 96% 81%;
     --sb-yellow-50: 35 95% 76%;
+    --sb-yellow-50-subtle: 35 95% 76% 0.1;
     --sb-yellow-60: 33 76% 69%;
     --sb-yellow-70: 35 31% 45%;
     --sb-yellow-80: 34 28% 32%;
@@ -37,6 +38,7 @@
     --sb-red-20: 0 100% 86%;
     --sb-red-30: 0 100% 76%;
     --sb-red-40: 0 100% 66%;
+    --sb-red-40-subtle: 0 100% 66% 0.1;
     --sb-red-50: 0 66% 53%;
     --sb-red-60: 0 66% 41%;
     --sb-red-70: 0 74% 30%;
@@ -77,8 +79,10 @@
     --inline-code-foreground: var(--foreground);
     --error: var(--sb-red-30);
     --error-foreground: var(--sb-red-80);
+    --error-background-subtle: var(--sb-red-40-subtle);
     --warning: var(--sb-yellow-20);
     --warning-foreground: var(--sb-yellow-80);
+    --warning-background-subtle: var(--sb-yellow-50-subtle);
   }
 
   .dark {
@@ -96,8 +100,10 @@
     --inline-code-foreground: var(--foreground);
     --error: var(--sb-red-30);
     --error-foreground: var(--sb-red-80);
+    --error-background-subtle: var(--sb-red-40-subtle);
     --warning: var(--sb-yellow-20);
     --warning-foreground: var(--sb-yellow-80);
+    --warning-background-subtle: var(--sb-yellow-50-subtle);
   }
 
   /* shadcn variables light */
@@ -134,7 +140,7 @@
     --primary: var(--sb-core-0);
     --primary-foreground: var(--sb-core-100);
     --secondary: var(--sb-core-130);
-    --secondary-foreground: var(--sb-core-0);
+    --secondary-foreground: var(--sb-core-40);
     --muted: var(--sb-core-120);
     --muted-foreground: var(--sb-core-90);
     --accent: var(--sb-blue-60);
@@ -390,6 +396,9 @@
 .cm-editor * {
   font-family: 'IBM Plex Mono', ui-monospace, 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas',
     'Liberation Mono', 'Courier New', 'monospace';
+}
+
+.cm-editor {
   font-size: 14px;
 }
 
@@ -397,16 +406,18 @@
   @apply overflow-hidden;
   @apply !bg-background;
   @apply border;
-  @apply rounded-sm;
   @apply shadow-md;
   @apply !border-border;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 20px; /* 142.857% */
 }
 
 .cm-tooltip-autocomplete {
   @apply overflow-hidden;
   @apply !bg-background;
   @apply border;
-  @apply rounded-sm;
   @apply shadow-md;
   @apply !border-border;
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/798e57cf-fbe6-4db1-a41d-bafac5bc442d)

> Some extra CSS changes to add warning and error tooltip backgrounds in followup PR