### PR TITLE
Update WS server client to pass in topic context and connection

### DIFF
--- a/.changeset/afraid-adults-chew.md
+++ b/.changeset/afraid-adults-chew.md
@@ -1,0 +1,8 @@
+---
+'@srcbook/components': patch
+'@srcbook/shared': patch
+'@srcbook/api': patch
+'@srcbook/web': patch
+---
+
+Update websocket client to pass context and connection

--- a/packages/api/server/ws.mts
+++ b/packages/api/server/ws.mts
@@ -40,41 +40,31 @@ import type {
   TsServerDefinitionLocationRequestPayloadType,
 } from '@srcbook/shared';
 import {
-  CellErrorPayloadSchema,
   CellUpdatePayloadSchema,
-  CellUpdatedPayloadSchema,
   CellRenamePayloadSchema,
   CellDeletePayloadSchema,
   CellFormatPayloadSchema,
   CellExecPayloadSchema,
   CellStopPayloadSchema,
   AiGenerateCellPayloadSchema,
-  AiGeneratedCellPayloadSchema,
   AiFixDiagnosticsPayloadSchema,
   DepsInstallPayloadSchema,
   DepsValidatePayloadSchema,
-  CellOutputPayloadSchema,
-  DepsValidateResponsePayloadSchema,
   TsServerStartPayloadSchema,
   TsServerStopPayloadSchema,
-  TsServerCellDiagnosticsPayloadSchema,
   CellCreatePayloadSchema,
   TsConfigUpdatePayloadSchema,
-  TsConfigUpdatedPayloadSchema,
-  TsServerCellSuggestionsPayloadSchema,
   TsServerQuickInfoRequestPayloadSchema,
-  TsServerQuickInfoResponsePayloadSchema,
-  CellFormattedPayloadSchema,
   TsServerDefinitionLocationRequestPayloadSchema,
-  TsServerDefinitionLocationResponsePayloadSchema,
-  TsServerCompletionEntriesPayloadSchema,
 } from '@srcbook/shared';
 import tsservers from '../tsservers.mjs';
 import { TsServer } from '../tsserver/tsserver.mjs';
-import WebSocketServer from './ws-client.mjs';
+import WebSocketServer, { MessageContextType } from './ws-client.mjs';
 import { filenameFromPath, pathToCodeFile } from '../srcbook/path.mjs';
 import { normalizeDiagnostic } from '../tsserver/utils.mjs';
 import { removeCodeCellFromDisk } from '../srcbook/index.mjs';
+
+type SessionsContextType = MessageContextType<'sessionId'>;
 
 const wss = new WebSocketServer();
 
@@ -120,8 +110,8 @@ async function nudgeMissingDeps(wss: WebSocketServer, session: SessionType) {
   }
 }
 
-async function cellExec(payload: CellExecPayloadType) {
-  const session = await findSession(payload.sessionId);
+async function cellExec(payload: CellExecPayloadType, context: SessionsContextType) {
+  const session = await findSession(context.params.sessionId);
   const cell = findCell(session, payload.cellId);
   if (!cell || cell.type !== 'code') {
     console.error(`Cannot execute cell with id ${payload.cellId}; cell not found.`);
@@ -229,8 +219,8 @@ async function tsxExec({ session, cell, secrets }: ExecRequestType) {
   );
 }
 
-async function depsInstall(payload: DepsInstallPayloadType) {
-  const session = await findSession(payload.sessionId);
+async function depsInstall(payload: DepsInstallPayloadType, context: SessionsContextType) {
+  const session = await findSession(context.params.sessionId);
   const cell = session.cells.find(
     (cell) => cell.type === 'package.json',
   ) as PackageJsonCellType | void;
@@ -306,13 +296,13 @@ async function depsInstall(payload: DepsInstallPayloadType) {
   );
 }
 
-async function depsValidate(payload: DepsValidatePayloadType) {
-  const session = await findSession(payload.sessionId);
+async function depsValidate(_payload: DepsValidatePayloadType, context: SessionsContextType) {
+  const session = await findSession(context.params.sessionId);
   nudgeMissingDeps(wss, session);
 }
 
-async function cellStop(payload: CellStopPayloadType) {
-  const session = await findSession(payload.sessionId);
+async function cellStop(payload: CellStopPayloadType, context: SessionsContextType) {
+  const session = await findSession(context.params.sessionId);
   const cell = findCell(session, payload.cellId);
 
   if (!cell || cell.type !== 'code') {
@@ -337,11 +327,11 @@ async function cellStop(payload: CellStopPayloadType) {
   }
 }
 
-async function cellCreate(payload: CellCreatePayloadType) {
-  const session = await findSession(payload.sessionId);
+async function cellCreate(payload: CellCreatePayloadType, context: SessionsContextType) {
+  const session = await findSession(context.params.sessionId);
 
   if (!session) {
-    throw new Error(`No session exists for session '${payload.sessionId}'`);
+    throw new Error(`No session exists for session '${context.params.sessionId}'`);
   }
 
   const { index, cell } = payload;
@@ -392,8 +382,8 @@ function reopenFileInTsServer(
   tsserver.open({ file: openFilePath, fileContent: file.source });
 }
 
-async function cellGenerate(payload: AiGenerateCellPayloadType) {
-  const session = await findSession(payload.sessionId);
+async function cellGenerate(payload: AiGenerateCellPayloadType, context: SessionsContextType) {
+  const session = await findSession(context.params.sessionId);
   const cell = session.cells.find((cell) => cell.id === payload.cellId) as CodeCellType;
 
   posthog.capture({
@@ -412,8 +402,11 @@ async function cellGenerate(payload: AiGenerateCellPayloadType) {
   });
 }
 
-async function cellFixDiagnostics(payload: AiFixDiagnosticsPayloadType) {
-  const session = await findSession(payload.sessionId);
+async function cellFixDiagnostics(
+  payload: AiFixDiagnosticsPayloadType,
+  context: SessionsContextType,
+) {
+  const session = await findSession(context.params.sessionId);
   const cell = findCell(session, payload.cellId) as CodeCellType;
 
   const result = await fixDiagnostics(session, cell, payload.diagnostics);
@@ -424,16 +417,16 @@ async function cellFixDiagnostics(payload: AiFixDiagnosticsPayloadType) {
   });
 }
 
-async function cellFormat(payload: CellFormatPayloadType) {
-  const session = await findSession(payload.sessionId);
+async function cellFormat(payload: CellFormatPayloadType, context: SessionsContextType) {
+  const session = await findSession(context.params.sessionId);
   if (!session) {
-    throw new Error(`No session exists for session '${payload.sessionId}'`);
+    throw new Error(`No session exists for session '${context.params.sessionId}'`);
   }
   const cellBeforeUpdate = findCell(session, payload.cellId);
 
   if (!cellBeforeUpdate || cellBeforeUpdate.type !== 'code') {
     throw new Error(
-      `No cell exists or not a code cell for session '${payload.sessionId}' and cell '${payload.cellId}'`,
+      `No cell exists or not a code cell for session '${context.params.sessionId}' and cell '${payload.cellId}'`,
     );
   }
   const result = await formatAndUpdateCodeCell(session, cellBeforeUpdate);
@@ -461,18 +454,18 @@ async function cellFormat(payload: CellFormatPayloadType) {
   }
 }
 
-async function cellUpdate(payload: CellUpdatePayloadType) {
-  const session = await findSession(payload.sessionId);
+async function cellUpdate(payload: CellUpdatePayloadType, context: SessionsContextType) {
+  const session = await findSession(context.params.sessionId);
 
   if (!session) {
-    throw new Error(`No session exists for session '${payload.sessionId}'`);
+    throw new Error(`No session exists for session '${context.params.sessionId}'`);
   }
 
   const cellBeforeUpdate = findCell(session, payload.cellId);
 
   if (!cellBeforeUpdate) {
     throw new Error(
-      `No cell exists for session '${payload.sessionId}' and cell '${payload.cellId}'`,
+      `No cell exists for session '${context.params.sessionId}' and cell '${payload.cellId}'`,
     );
   }
   const result = await updateCell(session, cellBeforeUpdate, payload.updates);
@@ -486,18 +479,18 @@ async function cellUpdate(payload: CellUpdatePayloadType) {
   refreshCodeCellDiagnostics(session, cell);
 }
 
-async function cellRename(payload: CellRenamePayloadType) {
-  const session = await findSession(payload.sessionId);
+async function cellRename(payload: CellRenamePayloadType, context: SessionsContextType) {
+  const session = await findSession(context.params.sessionId);
 
   if (!session) {
-    throw new Error(`No session exists for session '${payload.sessionId}'`);
+    throw new Error(`No session exists for session '${context.params.sessionId}'`);
   }
 
   const cellBeforeUpdate = findCell(session, payload.cellId);
 
   if (!cellBeforeUpdate) {
     throw new Error(
-      `No cell exists for session '${payload.sessionId}' and cell '${payload.cellId}'`,
+      `No cell exists for session '${context.params.sessionId}' and cell '${payload.cellId}'`,
     );
   }
 
@@ -559,18 +552,18 @@ async function cellRename(payload: CellRenamePayloadType) {
   }
 }
 
-async function cellDelete(payload: CellDeletePayloadType) {
-  const session = await findSession(payload.sessionId);
+async function cellDelete(payload: CellDeletePayloadType, context: SessionsContextType) {
+  const session = await findSession(context.params.sessionId);
 
   if (!session) {
-    throw new Error(`No session exists for session '${payload.sessionId}'`);
+    throw new Error(`No session exists for session '${context.params.sessionId}'`);
   }
 
   const cell = findCell(session, payload.cellId);
 
   if (!cell) {
     throw new Error(
-      `No cell exists for session '${payload.sessionId}' and cell '${payload.cellId}'`,
+      `No cell exists for session '${context.params.sessionId}' and cell '${payload.cellId}'`,
     );
   }
 
@@ -682,11 +675,11 @@ function createTsServer(session: SessionType) {
   return tsserver;
 }
 
-async function tsserverStart(payload: TsServerStartPayloadType) {
-  const session = await findSession(payload.sessionId);
+async function tsserverStart(_payload: TsServerStartPayloadType, context: SessionsContextType) {
+  const session = await findSession(context.params.sessionId);
 
   if (!session) {
-    throw new Error(`No session exists for session '${payload.sessionId}'`);
+    throw new Error(`No session exists for session '${context.params.sessionId}'`);
   }
 
   if (session.language !== 'typescript') {
@@ -699,15 +692,15 @@ async function tsserverStart(payload: TsServerStartPayloadType) {
   );
 }
 
-async function tsserverStop(payload: TsServerStopPayloadType) {
-  tsservers.shutdown(payload.sessionId);
+async function tsserverStop(_payload: TsServerStopPayloadType, context: SessionsContextType) {
+  tsservers.shutdown(context.params.sessionId);
 }
 
-async function tsconfigUpdate(payload: TsConfigUpdatePayloadType) {
-  const session = await findSession(payload.sessionId);
+async function tsconfigUpdate(payload: TsConfigUpdatePayloadType, context: SessionsContextType) {
+  const session = await findSession(context.params.sessionId);
 
   if (!session) {
-    throw new Error(`No session exists for session '${payload.sessionId}'`);
+    throw new Error(`No session exists for session '${context.params.sessionId}'`);
   }
 
   posthog.capture({ event: 'user updated tsconfig' });
@@ -725,11 +718,14 @@ async function tsconfigUpdate(payload: TsConfigUpdatePayloadType) {
   });
 }
 
-async function tsserverQuickInfo(payload: TsServerQuickInfoRequestPayloadType) {
-  const session = await findSession(payload.sessionId);
+async function tsserverQuickInfo(
+  payload: TsServerQuickInfoRequestPayloadType,
+  context: SessionsContextType,
+) {
+  const session = await findSession(context.params.sessionId);
 
   if (!session) {
-    throw new Error(`No session exists for session '${payload.sessionId}'`);
+    throw new Error(`No session exists for session '${context.params.sessionId}'`);
   }
 
   if (session.language !== 'typescript') {
@@ -764,11 +760,14 @@ async function tsserverQuickInfo(payload: TsServerQuickInfoRequestPayloadType) {
   });
 }
 
-async function getCompletions(payload: TsServerDefinitionLocationRequestPayloadType) {
-  const session = await findSession(payload.sessionId);
+async function getCompletions(
+  payload: TsServerDefinitionLocationRequestPayloadType,
+  context: SessionsContextType,
+) {
+  const session = await findSession(context.params.sessionId);
 
   if (!session) {
-    throw new Error(`No session exists for session '${payload.sessionId}'`);
+    throw new Error(`No session exists for session '${context.params.sessionId}'`);
   }
 
   if (session.language !== 'typescript') {
@@ -798,11 +797,14 @@ async function getCompletions(payload: TsServerDefinitionLocationRequestPayloadT
   });
 }
 
-async function getDefinitionLocation(payload: TsServerDefinitionLocationRequestPayloadType) {
-  const session = await findSession(payload.sessionId);
+async function getDefinitionLocation(
+  payload: TsServerDefinitionLocationRequestPayloadType,
+  context: SessionsContextType,
+) {
+  const session = await findSession(context.params.sessionId);
 
   if (!session) {
-    throw new Error(`No session exists for session '${payload.sessionId}'`);
+    throw new Error(`No session exists for session '${context.params.sessionId}'`);
   }
 
   if (session.language !== 'typescript') {
@@ -852,51 +854,33 @@ function refreshCodeCellDiagnostics(session: SessionType, cell: CodeCellType) {
     requestAllDiagnostics(tsserver, session);
   }
 }
+
 wss
-  .channel('session:*')
-  .incoming('cell:exec', CellExecPayloadSchema, cellExec)
-  .incoming('cell:stop', CellStopPayloadSchema, cellStop)
-  .incoming('cell:create', CellCreatePayloadSchema, cellCreate)
-  .incoming('cell:update', CellUpdatePayloadSchema, cellUpdate)
-  .incoming('cell:rename', CellRenamePayloadSchema, cellRename)
-  .incoming('cell:delete', CellDeletePayloadSchema, cellDelete)
-  .incoming('cell:format', CellFormatPayloadSchema, cellFormat)
-  .incoming('ai:generate', AiGenerateCellPayloadSchema, cellGenerate)
-  .incoming('ai:fix_diagnostics', AiFixDiagnosticsPayloadSchema, cellFixDiagnostics)
-  .incoming('deps:install', DepsInstallPayloadSchema, depsInstall)
-  .incoming('deps:validate', DepsValidatePayloadSchema, depsValidate)
-  .incoming('tsserver:start', TsServerStartPayloadSchema, tsserverStart)
-  .incoming('tsserver:stop', TsServerStopPayloadSchema, tsserverStop)
-  .incoming('tsconfig.json:update', TsConfigUpdatePayloadSchema, tsconfigUpdate)
-  .incoming(
-    'tsserver:cell:quickinfo:request',
-    TsServerQuickInfoRequestPayloadSchema,
-    tsserverQuickInfo,
-  )
-  .incoming(
+  .channel('session:<sessionId>')
+  .on('cell:exec', CellExecPayloadSchema, cellExec)
+  .on('cell:stop', CellStopPayloadSchema, cellStop)
+  .on('cell:create', CellCreatePayloadSchema, cellCreate)
+  .on('cell:update', CellUpdatePayloadSchema, cellUpdate)
+  .on('cell:rename', CellRenamePayloadSchema, cellRename)
+  .on('cell:delete', CellDeletePayloadSchema, cellDelete)
+  .on('cell:format', CellFormatPayloadSchema, cellFormat)
+  .on('ai:generate', AiGenerateCellPayloadSchema, cellGenerate)
+  .on('ai:fix_diagnostics', AiFixDiagnosticsPayloadSchema, cellFixDiagnostics)
+  .on('deps:install', DepsInstallPayloadSchema, depsInstall)
+  .on('deps:validate', DepsValidatePayloadSchema, depsValidate)
+  .on('tsserver:start', TsServerStartPayloadSchema, tsserverStart)
+  .on('tsserver:stop', TsServerStopPayloadSchema, tsserverStop)
+  .on('tsconfig.json:update', TsConfigUpdatePayloadSchema, tsconfigUpdate)
+  .on('tsserver:cell:quickinfo:request', TsServerQuickInfoRequestPayloadSchema, tsserverQuickInfo)
+  .on(
     'tsserver:cell:definition_location:request',
     TsServerDefinitionLocationRequestPayloadSchema,
     getDefinitionLocation,
   )
-  .incoming(
+  .on(
     'tsserver:cell:completions:request',
     TsServerDefinitionLocationRequestPayloadSchema,
     getCompletions,
-  )
-  .outgoing('tsserver:cell:completions:response', TsServerCompletionEntriesPayloadSchema)
-  .outgoing('tsserver:cell:quickinfo:response', TsServerQuickInfoResponsePayloadSchema)
-  .outgoing(
-    'tsserver:cell:definition_location:response',
-    TsServerDefinitionLocationResponsePayloadSchema,
-  )
-  .outgoing('cell:updated', CellUpdatedPayloadSchema)
-  .outgoing('cell:formatted', CellFormattedPayloadSchema)
-  .outgoing('cell:error', CellErrorPayloadSchema)
-  .outgoing('cell:output', CellOutputPayloadSchema)
-  .outgoing('ai:generated', AiGeneratedCellPayloadSchema)
-  .outgoing('deps:validate:response', DepsValidateResponsePayloadSchema)
-  .outgoing('tsserver:cell:diagnostics', TsServerCellDiagnosticsPayloadSchema)
-  .outgoing('tsserver:cell:suggestions', TsServerCellSuggestionsPayloadSchema)
-  .outgoing('tsconfig.json:updated', TsConfigUpdatedPayloadSchema);
+  );
 
 export default wss;

--- a/packages/shared/src/schemas/websockets.mts
+++ b/packages/shared/src/schemas/websockets.mts
@@ -16,57 +16,47 @@ export const WebSocketMessageSchema = z.tuple([
 ]);
 
 export const CellExecPayloadSchema = z.object({
-  sessionId: z.string(),
   cellId: z.string(),
 });
 
 export const CellStopPayloadSchema = z.object({
-  sessionId: z.string(),
   cellId: z.string(),
 });
 
 export const CellCreatePayloadSchema = z.object({
-  sessionId: z.string(),
   index: z.number(),
   cell: z.union([MarkdownCellSchema, CodeCellSchema]),
 });
 
 export const CellUpdatePayloadSchema = z.object({
-  sessionId: z.string(),
   cellId: z.string(),
   updates: CellUpdateAttrsSchema,
 });
 
 export const CellFormatPayloadSchema = z.object({
-  sessionId: z.string(),
   cellId: z.string(),
 });
 
 export const AiGenerateCellPayloadSchema = z.object({
-  sessionId: z.string(),
   cellId: z.string(),
   prompt: z.string(),
 });
 
 export const AiFixDiagnosticsPayloadSchema = z.object({
-  sessionId: z.string(),
   cellId: z.string(),
   diagnostics: z.string(),
 });
 
 export const CellRenamePayloadSchema = z.object({
-  sessionId: z.string(),
   cellId: z.string(),
   filename: z.string(),
 });
 
 export const CellDeletePayloadSchema = z.object({
-  sessionId: z.string(),
   cellId: z.string(),
 });
 
 export const CellErrorPayloadSchema = z.object({
-  sessionId: z.string(),
   cellId: z.string(),
   errors: z.array(
     z.object({
@@ -98,25 +88,18 @@ export const CellOutputPayloadSchema = z.object({
 });
 
 export const DepsInstallPayloadSchema = z.object({
-  sessionId: z.string(),
   packages: z.array(z.string()).optional(),
 });
 
-export const DepsValidatePayloadSchema = z.object({
-  sessionId: z.string(),
-});
+export const DepsValidatePayloadSchema = z.object({});
 
 export const DepsValidateResponsePayloadSchema = z.object({
   packages: z.array(z.string()).optional(),
 });
 
-export const TsServerStartPayloadSchema = z.object({
-  sessionId: z.string(),
-});
+export const TsServerStartPayloadSchema = z.object({});
 
-export const TsServerStopPayloadSchema = z.object({
-  sessionId: z.string(),
-});
+export const TsServerStopPayloadSchema = z.object({});
 
 export const TsServerCellDiagnosticsPayloadSchema = z.object({
   cellId: z.string(),
@@ -130,7 +113,6 @@ export const TsServerCellSuggestionsPayloadSchema = z.object({
 
 export const TsServerQuickInfoRequestPayloadSchema = z.object({
   cellId: z.string(),
-  sessionId: z.string(),
   request: TsServerQuickInfoRequestSchema,
 });
 
@@ -140,7 +122,6 @@ export const TsServerQuickInfoResponsePayloadSchema = z.object({
 
 export const TsServerDefinitionLocationRequestPayloadSchema = z.object({
   cellId: z.string(),
-  sessionId: z.string(),
   request: TsServerQuickInfoRequestSchema,
 });
 
@@ -153,7 +134,6 @@ export const TsServerCompletionEntriesPayloadSchema = z.object({
 });
 
 export const TsConfigUpdatePayloadSchema = z.object({
-  sessionId: z.string(),
   source: z.string(),
 });
 

--- a/packages/web/src/components/cells/get-completions.ts
+++ b/packages/web/src/components/cells/get-completions.ts
@@ -5,7 +5,6 @@ import { mapCMLocationToTsServer } from './util';
 
 export function getCompletions(
   context: CompletionContext,
-  sessionId: string,
   cell: CodeCellType,
   channel: SessionChannel,
 ): Promise<CompletionResult | null> {
@@ -43,7 +42,6 @@ export function getCompletions(
     channel.on('tsserver:cell:completions:response', callback);
 
     channel.push('tsserver:cell:completions:request', {
-      sessionId: sessionId,
       cellId: cell.id,
       request: {
         location: mapCMLocationToTsServer(cell.source, pos),

--- a/packages/web/src/components/cells/hover.ts
+++ b/packages/web/src/components/cells/hover.ts
@@ -12,12 +12,7 @@ import { formatCode } from '@srcbook/components/src/lib/code-theme';
 import { type ThemeType } from '@srcbook/components/src/components/use-theme';
 
 /** Hover extension for TS server information */
-export function tsHover(
-  sessionId: string,
-  cell: CodeCellType,
-  channel: SessionChannel,
-  theme: ThemeType,
-): Extension {
+export function tsHover(cell: CodeCellType, channel: SessionChannel, theme: ThemeType): Extension {
   return hoverTooltip(async (view, pos) => {
     if (cell.language !== 'typescript') {
       return null; // bail early if not typescript
@@ -58,7 +53,6 @@ export function tsHover(
           mount() {
             channel.on('tsserver:cell:quickinfo:response', callback);
             channel.push('tsserver:cell:quickinfo:request', {
-              sessionId: sessionId,
               cellId: cell.id,
               request: { location: mapCMLocationToTsServer(cell.source, pos) },
             });

--- a/packages/web/src/components/use-package-json.tsx
+++ b/packages/web/src/components/use-package-json.tsx
@@ -4,7 +4,6 @@ import {
   PackageJsonCellType,
   PackageJsonCellUpdateAttrsType,
 } from '@srcbook/shared';
-import { SessionType } from '@/types';
 import { OutputType } from '@srcbook/components/src/types';
 import { SessionChannel } from '@/clients/websocket';
 import { useCells } from '@srcbook/components/src/components/use-cell';
@@ -34,7 +33,6 @@ export interface PackageJsonContextValue {
 const PackageJsonContext = createContext<PackageJsonContextValue | undefined>(undefined);
 
 type ProviderPropsType = {
-  session: SessionType;
   channel: SessionChannel;
   children: React.ReactNode;
 };
@@ -48,7 +46,7 @@ type ProviderPropsType = {
  * 2. Decouple the rest of the code from treating package.json
  *    as a cell since we want to move away from that.
  */
-export function PackageJsonProvider({ channel, session, children }: ProviderPropsType) {
+export function PackageJsonProvider({ channel, children }: ProviderPropsType) {
   const { cells, updateCell: updateCellOnClient, getOutput, clearOutput } = useCells();
 
   const cell = cells.find((cell) => cell.type === 'package.json') as PackageJsonCellType;
@@ -82,7 +80,7 @@ export function PackageJsonProvider({ channel, session, children }: ProviderProp
         channel.push('deps:install', { packages });
       }
     },
-    [cell, channel, session.id, updateCellOnClient, clearOutput],
+    [cell, channel, updateCellOnClient, clearOutput],
   );
 
   useEffect(() => {

--- a/packages/web/src/components/use-package-json.tsx
+++ b/packages/web/src/components/use-package-json.tsx
@@ -68,7 +68,7 @@ export function PackageJsonProvider({ channel, session, children }: ProviderProp
   const [validationError, setValidationError] = useState<string | null>(null);
 
   useEffectOnce(() => {
-    channel.push('deps:validate', { sessionId: session.id });
+    channel.push('deps:validate', {});
   });
 
   const npmInstall = useCallback(
@@ -79,7 +79,7 @@ export function PackageJsonProvider({ channel, session, children }: ProviderProp
         updateCellOnClient({ ...cell, status: 'running' });
         clearOutput(cell.id);
         setOutdated(false);
-        channel.push('deps:install', { sessionId: session.id, packages });
+        channel.push('deps:install', { packages });
       }
     },
     [cell, channel, session.id, updateCellOnClient, clearOutput],
@@ -97,7 +97,6 @@ export function PackageJsonProvider({ channel, session, children }: ProviderProp
 
   function updateCellOnServer(updates: PackageJsonCellUpdateAttrsType) {
     channel.push('cell:update', {
-      sessionId: session.id,
       cellId: cell.id,
       updates,
     });

--- a/packages/web/src/components/use-tsconfig-json.tsx
+++ b/packages/web/src/components/use-tsconfig-json.tsx
@@ -43,7 +43,6 @@ export function TsConfigProvider({ channel, session, children }: ProviderPropsTy
       if (error === null) {
         channel.push('tsconfig.json:update', {
           source,
-          sessionId: session.id,
         });
       }
     },

--- a/packages/web/src/components/use-tsconfig-json.tsx
+++ b/packages/web/src/components/use-tsconfig-json.tsx
@@ -46,7 +46,7 @@ export function TsConfigProvider({ channel, session, children }: ProviderPropsTy
         });
       }
     },
-    [session.id, setSource, channel, setValidationError],
+    [setSource, channel, setValidationError],
   );
 
   const context: TsConfigContextValue = {

--- a/packages/web/src/routes/session.tsx
+++ b/packages/web/src/routes/session.tsx
@@ -96,7 +96,7 @@ function SessionPage() {
 
   return (
     <CellsProvider cells={session.cells}>
-      <PackageJsonProvider session={session} channel={channel}>
+      <PackageJsonProvider channel={channel}>
         <TsConfigProvider session={session} channel={channel}>
           {VITE_SRCBOOK_DEBUG_RENDER_SESSION_AS_READ_ONLY ? (
             <Session readOnly session={session} srcbooks={srcbooks} config={config} />

--- a/packages/web/src/routes/session.tsx
+++ b/packages/web/src/routes/session.tsx
@@ -74,7 +74,7 @@ function SessionPage() {
       oldChannel.unsubscribe();
 
       if (connectedSessionLanguageRef.current === 'typescript') {
-        oldChannel.push('tsserver:stop', { sessionId: session.id });
+        oldChannel.push('tsserver:stop', {});
       }
     }
 
@@ -88,7 +88,7 @@ function SessionPage() {
     channel.subscribe();
 
     if (session.language === 'typescript') {
-      channel.push('tsserver:start', { sessionId: session.id });
+      channel.push('tsserver:start', {});
     }
 
     forceComponentRerender();
@@ -170,7 +170,6 @@ function Session(props: SessionProps) {
     removeCell(cell);
 
     channel.push('cell:delete', {
-      sessionId: session.id,
       cellId: cell.id,
     });
   }
@@ -232,7 +231,6 @@ function Session(props: SessionProps) {
       return;
     }
     channel.push('cell:update', {
-      sessionId: session.id,
       cellId: cell.id,
       updates,
     });
@@ -250,11 +248,11 @@ function Session(props: SessionProps) {
     switch (type) {
       case 'code':
         cell = createCodeCell(index, session.language);
-        channel.push('cell:create', { sessionId: session.id, index, cell });
+        channel.push('cell:create', { index, cell });
         break;
       case 'markdown':
         cell = createMarkdownCell(index);
-        channel.push('cell:create', { sessionId: session.id, index, cell });
+        channel.push('cell:create', { index, cell });
         break;
       case 'generate-ai':
         cell = createGenerateAiCell(index);
@@ -280,7 +278,7 @@ function Session(props: SessionProps) {
           newCell = createMarkdownCell(insertIdx, cell);
           break;
       }
-      channel.push('cell:create', { sessionId: session.id, index: insertIdx, cell: newCell });
+      channel.push('cell:create', { index: insertIdx, cell: newCell });
     }
   }
 


### PR DESCRIPTION
Some improvements to ws client:

1. Pass more context into handler. This allows us to access params (like sessionId) from the topic name (e.g., `sessions:123`). Previously we would also pass this value in the payload but that is redundant since we should be able to get it from the topic. We also pass in the event in case that is ever helpful.
2. Pass in a "connection" to the handler. This allows us to "reply" to one connected client. We've been broadcasting messages to all clients. I'll be using this in some future work.
3. Remove "outgoing" validating on the server as it's not really needed and was creating more noise for no gain.