### PR TITLE
New code/preview switcher

### DIFF
--- a/packages/web/src/components/apps/sidebar.tsx
+++ b/packages/web/src/components/apps/sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import {
   ChevronsLeftIcon,
@@ -22,6 +22,7 @@ import SettingsPanel from './panels/settings';
 import { useFiles } from './use-files';
 import { SrcbookLogo } from '../logos';
 import { Link } from 'react-router-dom';
+import { useHeaderTab } from './use-header-tab';
 
 type PanelType = 'explorer' | 'settings';
 
@@ -46,6 +47,23 @@ export default function Sidebar() {
   function setPanel(nextPanel: PanelType) {
     _setPanel(nextPanel === panel ? null : nextPanel);
   }
+
+  // When the user changes to the preview, close the open side panel
+  // When the user goes back to the code, re-open the side panel if it was already opened
+  const { tab } = useHeaderTab();
+  const [sidePanelPreviousValue, setSidePanelPreviousValue] = useState<PanelType | null>(null);
+  useEffect(() => {
+    if (tab === "code" && sidePanelPreviousValue !== null) {
+      _setPanel(sidePanelPreviousValue);
+      setSidePanelPreviousValue(null);
+      return;
+    };
+
+    if (tab === 'preview' && panel !== null) {
+      setSidePanelPreviousValue(panel);
+      _setPanel(null);
+    }
+  }, [tab, panel, sidePanelPreviousValue]);
 
   return (
     <>

--- a/packages/web/src/components/apps/sidebar.tsx
+++ b/packages/web/src/components/apps/sidebar.tsx
@@ -53,11 +53,11 @@ export default function Sidebar() {
   const { tab } = useHeaderTab();
   const [sidePanelPreviousValue, setSidePanelPreviousValue] = useState<PanelType | null>(null);
   useEffect(() => {
-    if (tab === "code" && sidePanelPreviousValue !== null) {
+    if (tab === 'code' && sidePanelPreviousValue !== null) {
       _setPanel(sidePanelPreviousValue);
       setSidePanelPreviousValue(null);
       return;
-    };
+    }
 
     if (tab === 'preview' && panel !== null) {
       setSidePanelPreviousValue(panel);

--- a/packages/web/src/components/apps/sidebar.tsx
+++ b/packages/web/src/components/apps/sidebar.tsx
@@ -44,13 +44,9 @@ export default function Sidebar() {
   const [showFeedback, setShowFeedback] = useState(false);
   const [panel, _setPanel] = useState<PanelType | null>(openedFile === null ? 'explorer' : null);
 
-  function setPanel(nextPanel: PanelType) {
-    _setPanel(nextPanel === panel ? null : nextPanel);
-  }
-
   // When the user changes to the preview, close the open side panel
   // When the user goes back to the code, re-open the side panel if it was already opened
-  const { tab } = useHeaderTab();
+  const { tab, switchTab } = useHeaderTab();
   const [sidePanelPreviousValue, setSidePanelPreviousValue] = useState<PanelType | null>(null);
   useEffect(() => {
     if (tab === 'code' && sidePanelPreviousValue !== null) {
@@ -64,6 +60,11 @@ export default function Sidebar() {
       _setPanel(null);
     }
   }, [tab, panel, sidePanelPreviousValue]);
+
+  function setPanel(nextPanel: PanelType) {
+    switchTab('code');
+    _setPanel(nextPanel === panel ? null : nextPanel);
+  }
 
   return (
     <>

--- a/packages/web/src/components/apps/use-header-tab.tsx
+++ b/packages/web/src/components/apps/use-header-tab.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export type HeaderTab = 'code' | 'preview';
+
+export interface HeaderTabContextValue {
+  tab: HeaderTab;
+  switchTab: (newTab: HeaderTab) => void;
+}
+
+const HeaderTabContext = createContext<HeaderTabContextValue | undefined>(undefined);
+
+type ProviderPropsType = {
+  children: React.ReactNode;
+};
+
+export function HeaderTabProvider({ children }: ProviderPropsType) {
+  const [tab, setTab] = useState<HeaderTab>('code');
+
+  return (
+    <HeaderTabContext.Provider value={{ tab, switchTab: setTab }}>
+      {children}
+    </HeaderTabContext.Provider>
+  );
+}
+
+export function useHeaderTab(): HeaderTabContextValue {
+  return useContext(HeaderTabContext) as HeaderTabContextValue;
+}

--- a/packages/web/src/components/apps/use-preview.tsx
+++ b/packages/web/src/components/apps/use-preview.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 
 import { AppChannel } from '@/clients/websocket';
 import { PreviewStatusPayloadType } from '@srcbook/shared';
+import useEffectOnce from '@/components/use-effect-once';
 
 export type PreviewStatusType = 'booting' | 'connecting' | 'running' | 'stopped';
 
@@ -41,6 +42,11 @@ export function PreviewProvider({ channel, children }: ProviderPropsType) {
   function stop() {
     channel.push('preview:stop', {});
   }
+
+  // When the page initially loads, start the vite server
+  useEffectOnce(() => {
+    start();
+  });
 
   return (
     <PreviewContext.Provider value={{ url, status, stop, start }}>

--- a/packages/web/src/components/apps/workspace/editor/editor.tsx
+++ b/packages/web/src/components/apps/workspace/editor/editor.tsx
@@ -9,26 +9,39 @@ import { useFiles } from '../../use-files';
 import { AppType, FileType } from '@srcbook/shared';
 import EditorHeader from './header';
 import { extname } from '../../lib/path';
+import { useState } from 'react';
+import { Preview } from '../preview';
 
 type PropsType = {
   app: AppType;
 };
 
 export function Editor(props: PropsType) {
+  const [tab, setTab] = useState<'code' | 'preview'>('code');
   const { openedFile, updateFile } = useFiles();
 
   return (
     <div className="flex flex-col">
-      <EditorHeader app={props.app} className="shrink-0 h-12 max-h-12" />
-      <div className="p-3 w-full flex-1">
-        {openedFile ? (
-          <CodeEditor file={openedFile} onChange={updateFile} />
-        ) : (
-          <div className="h-full flex items-center justify-center text-tertiary-foreground">
-            Use the file explorer to open a file for editing
-          </div>
-        )}
-      </div>
+      <EditorHeader
+        app={props.app}
+        tab={tab}
+        onChangeTab={setTab}
+        className="shrink-0 h-12 max-h-12"
+      />
+      {tab === "code" ? (
+        <div className="p-3 w-full flex-1">
+          {openedFile ? (
+            <CodeEditor file={openedFile} onChange={updateFile} />
+          ) : (
+            <div className="h-full flex items-center justify-center text-tertiary-foreground">
+              Use the file explorer to open a file for editing
+            </div>
+          )}
+        </div>
+      ) : null}
+      {tab === "preview" ? (
+        <Preview />
+      ) : null}
     </div>
   );
 }

--- a/packages/web/src/components/apps/workspace/editor/editor.tsx
+++ b/packages/web/src/components/apps/workspace/editor/editor.tsx
@@ -28,7 +28,7 @@ export function Editor(props: PropsType) {
         onChangeTab={switchTab}
         className="shrink-0 h-12 max-h-12"
       />
-      {tab === "code" ? (
+      {tab === 'code' ? (
         <div className="p-3 w-full flex-1">
           {openedFile ? (
             <CodeEditor file={openedFile} onChange={updateFile} />
@@ -39,9 +39,7 @@ export function Editor(props: PropsType) {
           )}
         </div>
       ) : null}
-      {tab === "preview" ? (
-        <Preview />
-      ) : null}
+      {tab === 'preview' ? <Preview /> : null}
     </div>
   );
 }

--- a/packages/web/src/components/apps/workspace/editor/editor.tsx
+++ b/packages/web/src/components/apps/workspace/editor/editor.tsx
@@ -11,6 +11,7 @@ import EditorHeader from './header';
 import { extname } from '../../lib/path';
 import { Preview } from '../preview';
 import { useHeaderTab } from '../../use-header-tab';
+import { cn } from '@/lib/utils.ts';
 
 type PropsType = {
   app: AppType;
@@ -39,7 +40,14 @@ export function Editor(props: PropsType) {
           )}
         </div>
       ) : null}
-      {tab === 'preview' ? <Preview /> : null}
+
+      {/*
+      NOTE: applying hidden conditional like this keeps the iframe from getting mounted/unmounted
+      and causing a flash of unstyled content
+      */}
+      <div className={cn('w-full h-full', { hidden: tab !== 'preview' })}>
+        <Preview />
+      </div>
     </div>
   );
 }

--- a/packages/web/src/components/apps/workspace/editor/editor.tsx
+++ b/packages/web/src/components/apps/workspace/editor/editor.tsx
@@ -9,15 +9,15 @@ import { useFiles } from '../../use-files';
 import { AppType, FileType } from '@srcbook/shared';
 import EditorHeader from './header';
 import { extname } from '../../lib/path';
-import { useState } from 'react';
 import { Preview } from '../preview';
+import { useHeaderTab } from '../../use-header-tab';
 
 type PropsType = {
   app: AppType;
 };
 
 export function Editor(props: PropsType) {
-  const [tab, setTab] = useState<'code' | 'preview'>('code');
+  const { tab, switchTab } = useHeaderTab();
   const { openedFile, updateFile } = useFiles();
 
   return (
@@ -25,7 +25,7 @@ export function Editor(props: PropsType) {
       <EditorHeader
         app={props.app}
         tab={tab}
-        onChangeTab={setTab}
+        onChangeTab={switchTab}
         className="shrink-0 h-12 max-h-12"
       />
       {tab === "code" ? (

--- a/packages/web/src/components/apps/workspace/editor/header.tsx
+++ b/packages/web/src/components/apps/workspace/editor/header.tsx
@@ -10,14 +10,13 @@ import {
 } from '@srcbook/components/src/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { usePreview } from '../../use-preview';
-
-type EditorHeaderTab = 'code' | 'preview';
+import { HeaderTab } from '../../use-header-tab';
 
 type PropsType = {
   app: AppType;
   className?: string;
-  tab: EditorHeaderTab;
-  onChangeTab: (newTab: EditorHeaderTab) => void;
+  tab: HeaderTab;
+  onChangeTab: (newTab: HeaderTab) => void;
 };
 
 export default function EditorHeader(props: PropsType) {

--- a/packages/web/src/components/apps/workspace/editor/header.tsx
+++ b/packages/web/src/components/apps/workspace/editor/header.tsx
@@ -33,7 +33,7 @@ export default function EditorHeader(props: PropsType) {
     <>
       <header
         className={cn(
-          'w-full flex items-center justify-between bg-background z-50 text-sm border-b border-b-border',
+          'w-full flex items-center justify-between bg-background z-50 text-sm border-b border-b-border relative',
           props.className,
         )}
       >
@@ -42,7 +42,7 @@ export default function EditorHeader(props: PropsType) {
             <h3 className="px-1.5 font-semibold">{props.app.name}</h3>
           </div>
 
-          <div className="flex bg-muted h-7 rounded-sm">
+          <div className="absolute left-1/2 -translate-x-1/2 flex bg-muted h-7 rounded-sm">
             <button
               className={cn(
                 'flex gap-2 justify-center items-center w-24 text-foreground rounded-l-sm',
@@ -106,10 +106,6 @@ export default function EditorHeader(props: PropsType) {
                   <TooltipContent>Stop dev server</TooltipContent>
                 </Tooltip>
               </TooltipProvider>
-            ) : null}
-            {props.tab !== 'preview' ? (
-              // NOTE: render this button here as a "placeholder" to eliminate layout shift
-              <Button variant="icon" size="icon" disabled className="invisible" />
             ) : null}
 
             <div

--- a/packages/web/src/components/apps/workspace/editor/header.tsx
+++ b/packages/web/src/components/apps/workspace/editor/header.tsx
@@ -1,4 +1,11 @@
-import { ShareIcon, PlayIcon, StopCircleIcon, EllipsisIcon, CodeIcon, PlayCircleIcon } from 'lucide-react';
+import {
+  ShareIcon,
+  PlayIcon,
+  StopCircleIcon,
+  EllipsisIcon,
+  CodeIcon,
+  PlayCircleIcon,
+} from 'lucide-react';
 import type { AppType } from '@srcbook/shared';
 
 import { Button } from '@srcbook/components/src/components/ui/button';
@@ -37,19 +44,27 @@ export default function EditorHeader(props: PropsType) {
 
           <div className="flex bg-muted h-7 rounded-sm">
             <button
-              className={cn("flex gap-2 justify-center items-center w-24 text-foreground rounded-l-sm", {
-                "bg-foreground text-background rounded-sm border border-border": props.tab === "code",
-              })}
-              onClick={() => props.onChangeTab("code")}
+              className={cn(
+                'flex gap-2 justify-center items-center w-24 text-foreground rounded-l-sm',
+                {
+                  'bg-foreground text-background rounded-sm border border-border':
+                    props.tab === 'code',
+                },
+              )}
+              onClick={() => props.onChangeTab('code')}
             >
               <CodeIcon size={14} />
               Code
             </button>
             <button
-              className={cn("flex gap-2 justify-center items-center w-24 text-foreground rounded-l-sm", {
-                "bg-foreground text-background rounded-sm border border-border": props.tab === "preview",
-              })}
-              onClick={() => props.onChangeTab("preview")}
+              className={cn(
+                'flex gap-2 justify-center items-center w-24 text-foreground rounded-l-sm',
+                {
+                  'bg-foreground text-background rounded-sm border border-border':
+                    props.tab === 'preview',
+                },
+              )}
+              onClick={() => props.onChangeTab('preview')}
             >
               <PlayIcon size={14} />
               Preview
@@ -57,7 +72,7 @@ export default function EditorHeader(props: PropsType) {
           </div>
 
           <div className="flex items-center gap-2">
-            {props.tab === "preview" && previewStatus === "stopped" ? (
+            {props.tab === 'preview' && previewStatus === 'stopped' ? (
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -70,11 +85,11 @@ export default function EditorHeader(props: PropsType) {
                       <PlayCircleIcon size={18} />
                     </Button>
                   </TooltipTrigger>
-                <TooltipContent>Start dev server</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+                  <TooltipContent>Start dev server</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             ) : null}
-            {props.tab === "preview" && previewStatus !== "stopped" ? (
+            {props.tab === 'preview' && previewStatus !== 'stopped' ? (
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -83,7 +98,7 @@ export default function EditorHeader(props: PropsType) {
                       size="icon"
                       onClick={stopPreview}
                       className="active:translate-y-0"
-                      disabled={previewStatus === "booting" || previewStatus === "connecting"}
+                      disabled={previewStatus === 'booting' || previewStatus === 'connecting'}
                     >
                       <StopCircleIcon size={18} />
                     </Button>
@@ -92,12 +107,14 @@ export default function EditorHeader(props: PropsType) {
                 </Tooltip>
               </TooltipProvider>
             ) : null}
-            {props.tab !== "preview" ? (
+            {props.tab !== 'preview' ? (
               // NOTE: render this button here as a "placeholder" to eliminate layout shift
               <Button variant="icon" size="icon" disabled className="invisible" />
             ) : null}
 
-            <div className={cn("w-[1px] h-6 bg-border mx-2", { "invisible": props.tab !== "preview" })} />
+            <div
+              className={cn('w-[1px] h-6 bg-border mx-2', { invisible: props.tab !== 'preview' })}
+            />
 
             <TooltipProvider>
               <Tooltip>

--- a/packages/web/src/components/apps/workspace/editor/header.tsx
+++ b/packages/web/src/components/apps/workspace/editor/header.tsx
@@ -1,4 +1,4 @@
-import { ShareIcon, PlayIcon, StopCircleIcon, EllipsisIcon } from 'lucide-react';
+import { ShareIcon, PlayIcon, StopCircleIcon, EllipsisIcon, CodeIcon, PlayCircleIcon } from 'lucide-react';
 import type { AppType } from '@srcbook/shared';
 
 import { Button } from '@srcbook/components/src/components/ui/button';
@@ -11,27 +11,23 @@ import {
 import { cn } from '@/lib/utils';
 import { usePreview } from '../../use-preview';
 
+type EditorHeaderTab = 'code' | 'preview';
+
 type PropsType = {
   app: AppType;
   className?: string;
+  tab: EditorHeaderTab;
+  onChangeTab: (newTab: EditorHeaderTab) => void;
 };
 
 export default function EditorHeader(props: PropsType) {
   const { start: startPreview, stop: stopPreview, status: previewStatus } = usePreview();
 
-  function togglePreview() {
-    if (previewStatus === 'running') {
-      stopPreview();
-    } else if (previewStatus === 'stopped') {
-      startPreview();
-    }
-  }
-
   return (
     <>
       <header
         className={cn(
-          'w-full flex items-center justify-between bg-background z-50 text-sm',
+          'w-full flex items-center justify-between bg-background z-50 text-sm border-b border-b-border',
           props.className,
         )}
       >
@@ -40,7 +36,70 @@ export default function EditorHeader(props: PropsType) {
             <h3 className="px-1.5 font-semibold">{props.app.name}</h3>
           </div>
 
+          <div className="flex bg-muted h-7 rounded-sm">
+            <button
+              className={cn("flex gap-2 justify-center items-center w-24 text-foreground rounded-l-sm", {
+                "bg-foreground text-background rounded-sm border border-border": props.tab === "code",
+              })}
+              onClick={() => props.onChangeTab("code")}
+            >
+              <CodeIcon size={14} />
+              Code
+            </button>
+            <button
+              className={cn("flex gap-2 justify-center items-center w-24 text-foreground rounded-l-sm", {
+                "bg-foreground text-background rounded-sm border border-border": props.tab === "preview",
+              })}
+              onClick={() => props.onChangeTab("preview")}
+            >
+              <PlayIcon size={14} />
+              Preview
+            </button>
+          </div>
+
           <div className="flex items-center gap-2">
+            {props.tab === "preview" && previewStatus === "stopped" ? (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="icon"
+                      size="icon"
+                      onClick={startPreview}
+                      className="active:translate-y-0"
+                    >
+                      <PlayCircleIcon size={18} />
+                    </Button>
+                  </TooltipTrigger>
+                <TooltipContent>Start dev server</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+            ) : null}
+            {props.tab === "preview" && previewStatus !== "stopped" ? (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="icon"
+                      size="icon"
+                      onClick={stopPreview}
+                      className="active:translate-y-0"
+                      disabled={previewStatus === "booting" || previewStatus === "connecting"}
+                    >
+                      <StopCircleIcon size={18} />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Stop dev server</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : null}
+            {props.tab !== "preview" ? (
+              // NOTE: render this button here as a "placeholder" to eliminate layout shift
+              <Button variant="icon" size="icon" disabled className="invisible" />
+            ) : null}
+
+            <div className={cn("w-[1px] h-6 bg-border mx-2", { "invisible": props.tab !== "preview" })} />
+
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -71,16 +130,6 @@ export default function EditorHeader(props: PropsType) {
                 <TooltipContent>More options</TooltipContent>
               </Tooltip>
             </TooltipProvider>
-            <Button
-              onClick={togglePreview}
-              variant="secondary"
-              className="active:translate-y-0 gap-1.5"
-              disabled={!(previewStatus === 'stopped' || previewStatus === 'running')}
-            >
-              {previewStatus === 'stopped' && <PlayIcon size={16} />}
-              {previewStatus === 'running' && <StopCircleIcon size={16} />}
-              Preview
-            </Button>
           </div>
         </nav>
       </header>

--- a/packages/web/src/components/apps/workspace/preview.tsx
+++ b/packages/web/src/components/apps/workspace/preview.tsx
@@ -22,11 +22,15 @@ export function Preview(props: PropsType) {
       }
 
       return (
-        <div className={cn(props.className)}>
+        <div className={cn("w-full h-full", props.className)}>
           <iframe className="w-full h-full" src={url} title="App preview" />
         </div>
       );
     case 'stopped':
-      return null;
+      return (
+        <div className={cn('flex justify-center items-center w-full h-full', props.className)}>
+          <span className="text-tertiary-foreground">Stopped</span>
+        </div>
+      );
   }
 }

--- a/packages/web/src/components/apps/workspace/preview.tsx
+++ b/packages/web/src/components/apps/workspace/preview.tsx
@@ -22,7 +22,7 @@ export function Preview(props: PropsType) {
       }
 
       return (
-        <div className={cn("w-full h-full", props.className)}>
+        <div className={cn('w-full h-full', props.className)}>
           <iframe className="w-full h-full" src={url} title="App preview" />
         </div>
       );

--- a/packages/web/src/routes/apps.tsx
+++ b/packages/web/src/routes/apps.tsx
@@ -64,20 +64,11 @@ export function AppsPage() {
 }
 
 function Apps(props: { app: AppType }) {
-  const { status: previewStatus } = usePreview();
-  const previewVisible = previewStatus === 'booting' || previewStatus === 'running';
-
   return (
     <div className="h-screen max-h-screen flex">
       <Sidebar />
-      <div
-        className={cn(
-          'w-full h-full grid divide-x divide-border',
-          previewVisible ? 'grid-cols-2' : 'grid-cols-1',
-        )}
-      >
+      <div className="w-full h-full grid">
         <Editor app={props.app} />
-        {previewVisible ? <Preview /> : null}
       </div>
       <ChatPanel app={props.app} />
     </div>

--- a/packages/web/src/routes/apps.tsx
+++ b/packages/web/src/routes/apps.tsx
@@ -8,10 +8,10 @@ import { useEffect, useRef } from 'react';
 import { AppChannel } from '@/clients/websocket';
 import { FilesProvider } from '@/components/apps/use-files';
 import { Editor } from '@/components/apps/workspace/editor/editor';
-import { Preview } from '@/components/apps/workspace/preview';
-import { PreviewProvider, usePreview } from '@/components/apps/use-preview';
+import { PreviewProvider } from '@/components/apps/use-preview';
 import { cn } from '@/lib/utils';
 import { ChatPanel } from '@/components/chat';
+import { HeaderTabProvider } from '@/components/apps/use-header-tab';
 
 async function loader({ params }: LoaderFunctionArgs) {
   const [{ data: app }, { data: rootDirEntries }] = await Promise.all([
@@ -57,7 +57,9 @@ export function AppsPage() {
       rootDirEntries={rootDirEntries}
     >
       <PreviewProvider channel={channelRef.current}>
-        <Apps app={app} />
+        <HeaderTabProvider>
+          <Apps app={app} />
+        </HeaderTabProvider>
       </PreviewProvider>
     </FilesProvider>
   );

--- a/packages/web/src/routes/apps.tsx
+++ b/packages/web/src/routes/apps.tsx
@@ -9,7 +9,6 @@ import { AppChannel } from '@/clients/websocket';
 import { FilesProvider } from '@/components/apps/use-files';
 import { Editor } from '@/components/apps/workspace/editor/editor';
 import { PreviewProvider } from '@/components/apps/use-preview';
-import { cn } from '@/lib/utils';
 import { ChatPanel } from '@/components/chat';
 import { HeaderTabProvider } from '@/components/apps/use-header-tab';
 


### PR DESCRIPTION
Implements the new code/preview switcher interface in figma.

<img width="1291" alt="Screenshot 2024-10-15 at 4 56 26 PM" src="https://github.com/user-attachments/assets/5c8c2391-e4fc-4427-a4fb-764650f4ac16">
<img width="1292" alt="Screenshot 2024-10-15 at 4 56 37 PM" src="https://github.com/user-attachments/assets/b11c9707-1d11-44f9-9e80-67093c95ea88">
