### PR TITLE
Add commands to chatbox + improve edit prompt

### DIFF
--- a/packages/api/prompts/app-editor.txt
+++ b/packages/api/prompts/app-editor.txt
@@ -1,3 +1,4 @@
+## Context
 - You are helping a user build a front-end website application. You should behave like an extremely competent senior engineer.
 
 - The user wants to make a change to update or fix the app. Your goal is to help him with that request by suggesting updates for files.
@@ -18,58 +19,35 @@
 
 - You will be passed the app with the above <project> format, as well as the user request, passed as:
 <userRequest>
-{user request in plain english}
+  {user request in plain english}
 </userRequest>
 
-- Your job is to come up with the relevant changes, you do so by suggesting a <plan> with one or more <action>.
+## Instructions 
+- Your job is to come up with the relevant changes, you do so by suggesting a <plan> with one or more <action>. 
 There can be one or more <action> in a <plan>.
 An <Action> is one of:
     - type="file": an updated file with ALL of the new contents
-    - type="command": a command that the user will run in the command line
+    - type="command": a command that the user will run in the command line. Should be a *single* command that we'll show to the user to approve.
 
-Only respond with the plan, all information you want to provide should be in it.
+- Only respond with the plan, all information you want to provide should be in it.
 
-## Example response (some real values and some placeholders):
+## Example response (you would fill out values in the {...} brackets)
 
 <plan>
   <action type="file">
-    <description>{Short justification of changes. Be as brief as possible, like a commit message}</description>
+    <description>
+      {Short justification of changes. Be as brief as possible, like a commit message}
+    </description>
     <file filename="package.json">
         <![CDATA[
-        {
-        "name": "$GIVE_IT_A_GOOD_NAME",
-        "private": true,
-        "version": "0.0.1",
-        "type": "module",
-        "scripts": {
-            "dev": "vite",
-            "build": "tsc -b && vite build",
-            "preview": "vite preview"
-        },
-        "dependencies": {
-            "react": "^18.3.1",
-            "react-dom": "^18.3.1"
-        },
-        "devDependencies": {
-            "@types/react": "^18.3.6",
-            "@types/react-dom": "^18.3.0",
-            "@vitejs/plugin-react": "^4.3.1",
-            "globals": "^15.9.0",
-            "typescript": "^5.5.3",
-            "vite": "^5.4.6",
-            "autoprefixer": "^10.4.20",
-            "postcss": "^8.4.45",
-            "tailwindcss": "^3.4.11",
-
-        }
-        }
+          {... file contents (ALL OF THE FILE)}
         ]]>
     </file>
-</action>
-<action type="file">
+  </action>
+  <action type="file">
     <description>
         <![CDATA[
-    {Short description of changes}
+          {Short justification of changes. Be as brief as possible, like a commit message}
         ]]>
     </description>
   <file filename="./App.tsx">
@@ -79,14 +57,14 @@ Only respond with the plan, all information you want to provide should be in it.
   </file>
   <action type="command">
   <description>
-        <![CDATA[
-    {Install dependencies}
-        ]]>
-        </description>
+    <![CDATA[
+      {Short description of changes. Be brief, like a commit message}
+    ]]>
+  </description>
   <command>
-   <![CDATA]
-  npm install
-  ]]>
+    <![CDATA[
+      {one terminal command (not multiple), example: 'npm install lodash'}
+    ]]>
   </command>
   </action>
   ...

--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -31,12 +31,18 @@ type UserMessageType = {
   message: string;
 };
 
+type CommandMessageType = {
+  type: 'command';
+  command: string;
+  description: string;
+};
+
 type SummaryMessageType = {
   type: 'summary';
   summary: PlanType;
 };
 
-type MessageType = UserMessageType | SummaryMessageType;
+type MessageType = UserMessageType | SummaryMessageType | CommandMessageType;
 
 type HistoryType = Array<MessageType>;
 
@@ -55,7 +61,7 @@ function Chat({
 }) {
   return (
     <div className="rounded-xl bg-background w-[440px] border shadow-xl max-h-[75vh] overflow-y-hidden">
-      <div className="flex justify-between h-[40px] items-center border-b">
+      <div className="flex justify-between h-[40px] items-center border-b px-1">
         <span className="text-sm px-2">Chat</span>
         <span className="flex">
           <Button variant="icon" className="h-7 w-7 p-1.5 border-none">
@@ -74,6 +80,21 @@ function Chat({
                 <p className="text-sm bg-inline-code rounded-md p-2 w-fit" key={index}>
                   {message.message}
                 </p>
+              );
+            } else if (message.type === 'command') {
+              return (
+                <div className="text-sm space-y-1">
+                  <p className="">{message.description}</p>
+                  <div className="flex justify-between items-center gap-1">
+                    <p
+                      className="font-mono bg-inline-code rounded-md p-2 overflow-x-scroll whitespace-nowrap"
+                      key={index}
+                    >
+                      {message.command}
+                    </p>
+                    <Button onClick={() => console.log('run command', message.command)}>Run</Button>
+                  </div>
+                </div>
               );
             } else if (message.type === 'summary') {
               return <SummaryBox key={index} summary={message.summary} app={app} />;
@@ -135,7 +156,7 @@ function SummaryBox({ summary, app }: { summary: PlanType; app: AppType }) {
   return (
     <div className="px-2 py-1.5 rounded border overflow-y-auto bg-ai border border-ai-border text-ai-foreground">
       <div className="flex flex-col justify-between min-h-full gap-4">
-        <div className="text-sm font-mono">{app.name}</div>
+        <div className="">{app.name}</div>
         <div>
           {summary.map((item: PlanItemType) => {
             if (item.type === 'file') {
@@ -179,13 +200,16 @@ export function ChatPanel(props: PropsType): React.JSX.Element {
         if (fileUpdate.type === 'file') {
           await createFile(fileUpdate.dirname, fileUpdate.basename, fileUpdate.content);
         } else if (fileUpdate.type === 'command') {
-          // TODO: execute the commands in the right order.
-          console.log('command', fileUpdate.content);
+          setHistory((prevHistory) => [
+            ...prevHistory,
+            { type: 'command', command: fileUpdate.content, description: fileUpdate.description },
+          ]);
         }
       });
     }
 
-    setHistory((prevHistory) => [...prevHistory, { type: 'summary', summary: plan }]);
+    const fileUpdates = plan.filter((item: PlanItemType) => item.type === 'file');
+    setHistory((prevHistory) => [...prevHistory, { type: 'summary', summary: fileUpdates }]);
   };
 
   const handleClose = () => {

--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -92,7 +92,9 @@ function Chat({
                     >
                       {message.command}
                     </p>
-                    <Button onClick={() => console.log('run command', message.command)}>Run</Button>
+                    <Button onClick={() => alert('TODO: run command' + message.command)}>
+                      Run
+                    </Button>
                   </div>
                 </div>
               );


### PR DESCRIPTION
I noticed the prompt was sending double commands, example:
```
<command>
npm install abc
npm install def
</command>
```
I polished things up a little, and made some further intuitive edits (vibe checked at this point..)

Also, adding the commands into the chat box. Super ugly for now but want to have the skeleton functionality out
![CleanShot 2024-10-15 at 15 00 49](https://github.com/user-attachments/assets/593765fd-a9c4-4b6e-bf1d-81ad40a0abcb)
