### PR TITLE
Remove typescript javascript concept; add banner if AI is not enabled

### DIFF
--- a/packages/api/apps/disk.mts
+++ b/packages/api/apps/disk.mts
@@ -84,16 +84,21 @@ export async function createViteApp(app: DBAppType) {
 }
 
 /**
- * Scaffolds a new Vite app with the specified language.
- * Uses the react-typescript/ or react-javascript dirs as templates,
- * then updates the package.json name and index.html with the app name.
+ * Scaffolds a new Vite app using a predefined template.
+ *
+ * The current template includes: React, TypeScript, Vite, Tailwind CSS
+ *
+ * This function performs the following steps:
+ * 1. Copies all template files to the destination directory
+ * 2. Updates the package.json with the new app name
+ * 3. Updates the index.html title with the app name
  *
  * @param {DBAppType} app - The database app object.
  * @param {string} destDir - The destination directory for the app.
  * @returns {Promise<void>}
  */
 async function scaffold(app: DBAppType, destDir: string) {
-  const template = `react-${app.language}`;
+  const template = `react-typescript`;
 
   function write(file: string, content?: string) {
     const targetPath = Path.join(destDir, file);

--- a/packages/api/apps/schemas.mts
+++ b/packages/api/apps/schemas.mts
@@ -2,7 +2,6 @@ import z from 'zod';
 
 export const CreateAppSchema = z.object({
   name: z.string(),
-  language: z.union([z.literal('typescript'), z.literal('javascript')]),
   prompt: z.string().optional(),
 });
 

--- a/packages/api/db/schema.mts
+++ b/packages/api/db/schema.mts
@@ -48,7 +48,6 @@ export type SecretsToSession = typeof secretsToSession.$inferSelect;
 export const apps = sqliteTable('apps', {
   id: integer('id').primaryKey(),
   name: text('name').notNull(),
-  language: text('language').notNull(),
   externalId: text('external_id').notNull().unique(),
   createdAt: integer('created_at', { mode: 'timestamp' })
     .notNull()

--- a/packages/api/drizzle/0011_remove_language_from_apps.sql
+++ b/packages/api/drizzle/0011_remove_language_from_apps.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `apps` DROP COLUMN `language`;

--- a/packages/api/drizzle/meta/0011_snapshot.json
+++ b/packages/api/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,246 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "07a808e8-5059-4731-9f5b-d1a3fc530501",
+  "prevId": "aeb418fb-06df-4fc2-8afc-f18d95014b46",
+  "tables": {
+    "apps": {
+      "name": "apps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "apps_external_id_unique": {
+          "name": "apps_external_id_unique",
+          "columns": [
+            "external_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "config": {
+      "name": "config",
+      "columns": {
+        "base_dir": {
+          "name": "base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_language": {
+          "name": "default_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'typescript'"
+        },
+        "openai_api_key": {
+          "name": "openai_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anthropic_api_key": {
+          "name": "anthropic_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled_analytics": {
+          "name": "enabled_analytics",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "srcbook_installation_id": {
+          "name": "srcbook_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1sjh794sjt9c5fi122a0lg83n4'"
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openai'"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'gpt-4o'"
+        },
+        "ai_base_url": {
+          "name": "ai_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subscription_email": {
+          "name": "subscription_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "secrets": {
+      "name": "secrets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "secrets_name_unique": {
+          "name": "secrets_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "secrets_to_sessions": {
+      "name": "secrets_to_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "secrets_to_sessions_session_id_secret_id_unique": {
+          "name": "secrets_to_sessions_session_id_secret_id_unique",
+          "columns": [
+            "session_id",
+            "secret_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "secrets_to_sessions_secret_id_secrets_id_fk": {
+          "name": "secrets_to_sessions_secret_id_secrets_id_fk",
+          "tableFrom": "secrets_to_sessions",
+          "tableTo": "secrets",
+          "columnsFrom": [
+            "secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1726808187994,
       "tag": "0010_create_apps",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1729112512747,
+      "tag": "0011_remove_language_from_apps",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/server/http.mts
+++ b/packages/api/server/http.mts
@@ -434,7 +434,7 @@ router.post('/apps', cors(), async (req, res) => {
 
   posthog.capture({
     event: 'user created app',
-    properties: { language: attrs.language, withPrompt: typeof attrs.prompt === 'string' },
+    properties: { prompt: typeof attrs.prompt === 'string' ? attrs.prompt : 'N/A' },
   });
 
   try {
@@ -442,6 +442,7 @@ router.post('/apps', cors(), async (req, res) => {
       const app = await createAppWithAi({ name: attrs.name, prompt: attrs.prompt });
       return res.json({ data: serializeApp(app) });
     } else {
+      // TODO do we really need to keep this?
       const app = await createApp(attrs);
       return res.json({ data: serializeApp(app) });
     }

--- a/packages/shared/src/types/apps.mts
+++ b/packages/shared/src/types/apps.mts
@@ -1,12 +1,10 @@
 import z from 'zod';
 
 import { FileSchema } from '../schemas/apps.mjs';
-import { CodeLanguageType } from './cells.mjs';
 
 export type AppType = {
   id: string;
   name: string;
-  language: CodeLanguageType;
   createdAt: number;
   updatedAt: number;
 };

--- a/packages/web/src/clients/http/apps.ts
+++ b/packages/web/src/clients/http/apps.ts
@@ -1,10 +1,4 @@
-import type {
-  AppType,
-  CodeLanguageType,
-  DirEntryType,
-  FileEntryType,
-  FileType,
-} from '@srcbook/shared';
+import type { AppType, DirEntryType, FileEntryType, FileType } from '@srcbook/shared';
 import SRCBOOK_CONFIG from '@/config';
 
 const API_BASE_URL = `${SRCBOOK_CONFIG.api.origin}/api`;
@@ -12,7 +6,6 @@ const API_BASE_URL = `${SRCBOOK_CONFIG.api.origin}/api`;
 export async function createApp(request: {
   name: string;
   prompt?: string;
-  language: CodeLanguageType;
 }): Promise<{ data: AppType }> {
   const response = await fetch(API_BASE_URL + '/apps', {
     method: 'POST',

--- a/packages/web/src/components/apps/create-modal.tsx
+++ b/packages/web/src/components/apps/create-modal.tsx
@@ -12,8 +12,6 @@ import {
 } from '@srcbook/components/src/components/ui/dialog';
 
 import { HelpCircle, Sparkles, Loader2 } from 'lucide-react';
-import { CodeLanguageType } from '@srcbook/shared';
-import { JavaScriptLogo, TypeScriptLogo } from '../logos';
 import { Textarea } from '@srcbook/components/src/components/ui/textarea';
 import {
   TooltipContent,
@@ -24,13 +22,12 @@ import {
 
 type PropsType = {
   onClose: () => void;
-  onCreate: (name: string, language: CodeLanguageType, prompt?: string) => Promise<void>;
+  onCreate: (name: string, prompt?: string) => Promise<void>;
 };
 
 export default function CreateAppModal({ onClose, onCreate }: PropsType) {
   const [name, setName] = useState('');
   const [prompt, setPrompt] = useState('');
-  const [language, setLanguage] = useState<CodeLanguageType>('typescript');
 
   const [submitting, setSubmitting] = useState(false);
 
@@ -45,7 +42,7 @@ export default function CreateAppModal({ onClose, onCreate }: PropsType) {
     setSubmitting(true);
 
     try {
-      await onCreate(name, language, prompt.trim() === '' ? undefined : prompt);
+      await onCreate(name, prompt.trim() === '' ? undefined : prompt);
     } finally {
       setSubmitting(false);
     }
@@ -68,31 +65,6 @@ export default function CreateAppModal({ onClose, onCreate }: PropsType) {
           </DialogDescription>
         </DialogHeader>
         <form name="app" onSubmit={onSubmit} className="mt-3 flex flex-col gap-6">
-          <div className="grid grid-cols-2 gap-6">
-            <LanguageSelector
-              id="app-language-typescript"
-              name="app[language]"
-              value="typescript"
-              selected={language === 'typescript'}
-              onSelect={() => setLanguage('typescript')}
-              className="font-mono text-sm"
-            >
-              <TypeScriptLogo className="mb-2" />
-              TypeScript
-            </LanguageSelector>
-            <LanguageSelector
-              id="app-language-javascript"
-              name="app[language]"
-              value="javascript"
-              selected={language === 'javascript'}
-              onSelect={() => setLanguage('javascript')}
-              className="font-mono text-sm"
-            >
-              <JavaScriptLogo className="mb-2" />
-              JavaScript
-            </LanguageSelector>
-          </div>
-
           <div className="space-y-1">
             <label htmlFor="name" className="text-sm text-tertiary-foreground">
               App name
@@ -154,38 +126,5 @@ export default function CreateAppModal({ onClose, onCreate }: PropsType) {
         </form>
       </DialogContent>
     </Dialog>
-  );
-}
-
-function LanguageSelector(props: {
-  id: string;
-  name: string;
-  value: CodeLanguageType;
-  selected: boolean;
-  onSelect: () => void;
-  className?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <label
-      htmlFor={props.id}
-      className={cn(
-        'flex flex-col items-center justify-center w-full min-w-[216px] max-w-[216px] h-24 p-3 cursor-pointer',
-        'bg-background text-tertiary-foreground hover:text-foreground border rounded-sm hover:border-ring transition-colors',
-        props.selected && 'border-ring text-foreground',
-        props.className,
-      )}
-    >
-      <input
-        type="radio"
-        id={props.id}
-        name={props.name}
-        value={props.value}
-        checked={props.selected}
-        onChange={props.onSelect}
-        className="hidden"
-      />
-      {props.children}
-    </label>
   );
 }

--- a/packages/web/src/components/apps/create-modal.tsx
+++ b/packages/web/src/components/apps/create-modal.tsx
@@ -61,10 +61,10 @@ export default function CreateAppModal({ onClose, onCreate }: PropsType) {
         <DialogHeader>
           <DialogTitle>Create application</DialogTitle>
           <DialogDescription className="text-base">
-            Create a React app powered by Vite and Tailwind.
+            Create a web app powered by React, Vite and Tailwind.
           </DialogDescription>
         </DialogHeader>
-        <form name="app" onSubmit={onSubmit} className="mt-3 flex flex-col gap-6">
+        <form name="app" onSubmit={onSubmit} className="flex flex-col gap-6">
           <div className="space-y-1">
             <label htmlFor="name" className="text-sm text-tertiary-foreground">
               App name
@@ -94,7 +94,7 @@ export default function CreateAppModal({ onClose, onCreate }: PropsType) {
                     <HelpCircle size={16} className="text-tertiary-foreground" />
                   </TooltipTrigger>
                   <TooltipContent className="text-sm" side="left">
-                    Optionally use AI to scaffold your app
+                    Use AI to scaffold your app
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>

--- a/packages/web/src/components/apps/create-modal.tsx
+++ b/packages/web/src/components/apps/create-modal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { cn } from '@/lib/utils';
 import { Input } from '@srcbook/components/src/components/ui/input';
 import { Button } from '@srcbook/components/src/components/ui/button';
+import { useNavigate } from 'react-router-dom';
 import {
   Dialog,
   DialogContent,
@@ -19,6 +20,7 @@ import {
   TooltipTrigger,
   Tooltip,
 } from '@srcbook/components/src/components/ui/tooltip';
+import { useSettings } from '../use-settings';
 
 type PropsType = {
   onClose: () => void;
@@ -28,6 +30,9 @@ type PropsType = {
 export default function CreateAppModal({ onClose, onCreate }: PropsType) {
   const [name, setName] = useState('');
   const [prompt, setPrompt] = useState('');
+
+  const { aiEnabled } = useSettings();
+  const navigate = useNavigate();
 
   const [submitting, setSubmitting] = useState(false);
 
@@ -63,6 +68,18 @@ export default function CreateAppModal({ onClose, onCreate }: PropsType) {
           <DialogDescription className="text-base">
             Create a web app powered by React, Vite and Tailwind.
           </DialogDescription>
+
+          {!aiEnabled && (
+            <div className="flex items-center justify-between bg-warning text-warning-foreground rounded-sm text-sm px-3 py-1 mt-4">
+              <p>AI provider not configured.</p>
+              <button
+                className="font-medium underline cursor-pointer"
+                onClick={() => navigate('/settings')}
+              >
+                Settings
+              </button>
+            </div>
+          )}
         </DialogHeader>
         <form name="app" onSubmit={onSubmit} className="flex flex-col gap-6">
           <div className="space-y-1">
@@ -113,7 +130,7 @@ export default function CreateAppModal({ onClose, onCreate }: PropsType) {
               Cancel
             </Button>
 
-            <Button disabled={submitting} type="submit">
+            <Button disabled={!aiEnabled || submitting} type="submit">
               {submitting ? (
                 <div className="flex items-center gap-2">
                   <Loader2 className="h-4 w-4 animate-spin" /> Generating...

--- a/packages/web/src/components/srcbook-cards.tsx
+++ b/packages/web/src/components/srcbook-cards.tsx
@@ -177,7 +177,6 @@ export function SrcbookCard(props: SrcbookCardPropsType) {
 
 type AppCardPropsType = {
   name: string;
-  language: CodeLanguageType;
   onClick: () => void;
   onDelete: () => void;
 };
@@ -198,9 +197,7 @@ export function AppCard(props: AppCardPropsType) {
         <h5 className="font-semibold leading-[18px] line-clamp-2">{props.name}</h5>
       </span>
       <div className="flex justify-end">
-        <code className="font-mono group-hover:hidden text-tertiary-foreground">
-          {props.language === 'javascript' ? 'JS' : 'TS'}
-        </code>
+        <code className="font-mono group-hover:hidden text-tertiary-foreground">'TS'</code>
         <button
           type="button"
           onClick={onDelete}

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -153,7 +153,6 @@ export default function Home() {
               <AppCard
                 key={app.id}
                 name={app.name}
-                language={app.language}
                 onClick={() => navigate(`/apps/${app.id}`)}
                 onDelete={() => setAppToDelete(app)}
               />

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -81,8 +81,8 @@ export default function Home() {
     openSrcbook(result.path);
   }
 
-  async function onCreateApp(name: string, language: CodeLanguageType, prompt?: string) {
-    const { data: app } = await createApp({ name, language, prompt });
+  async function onCreateApp(name: string, prompt?: string) {
+    const { data: app } = await createApp({ name, prompt });
     navigate(`/apps/${app.id}`);
   }
 
@@ -129,7 +129,6 @@ export default function Home() {
             <AppCard
               key={app.id}
               name={app.name}
-              language={app.language}
               onClick={() => navigate(`/apps/${app.id}`)}
               onDelete={() => setAppToDelete(app)}
             />


### PR DESCRIPTION
We previously separated out the concept of "TypeScript" apps from "JavaScript" apps.
This PR removes that concept. In the future, a better concept we could build upon is that of "templates". You could choose your starting template and that would scaffold a different app based on that. This would be a way to do JS / TS but also allows for other template choices like web framework, UI framework, etc...

In this PR, I also add a warning banner for the app creation if AI is not enabled. This is because app creation without AI really isn't very exciting yet, and I'd rather funnel people towards using the AI. Screenshots attached

![CleanShot 2024-10-16 at 14 14 13](https://github.com/user-attachments/assets/c152f4f9-bb49-4f9b-9a82-d258cbe7b256)
![CleanShot 2024-10-16 at 14 12 24](https://github.com/user-attachments/assets/d89d1307-694f-4d36-9a5e-9ce38d343e68)
