### PR TITLE
Update file tree entry types to include dirname and basename

### DIFF
--- a/packages/shared/src/types/apps.mts
+++ b/packages/shared/src/types/apps.mts
@@ -11,16 +11,24 @@ export type AppType = {
 
 export type DirEntryType = {
   type: 'directory';
-  name: string;
+  // The full path relative to app root, e.g. src/assets
   path: string;
+  // The path dirname relative to app root, e.g. src
+  dirname: string;
+  // The path basename relative to app root, e.g. assets
+  basename: string;
   // null if not loaded
   children: FsEntryTreeType | null;
 };
 
 export type FileEntryType = {
   type: 'file';
-  name: string;
+  // The full path relative to app root, e.g. src/components/input.tsx
   path: string;
+  // The path dirname relative to app root, e.g. src/components
+  dirname: string;
+  // The path basename relative to app root, e.g. input.tsx
+  basename: string;
 };
 
 export type FsEntryTreeType = Array<FileEntryType | DirEntryType>;

--- a/packages/web/src/components/apps/lib/file-tree.ts
+++ b/packages/web/src/components/apps/lib/file-tree.ts
@@ -210,11 +210,16 @@ function doCreateNode(tree: DirEntryType, node: DirEntryType | FileEntryType): D
     return tree;
   }
 
+  // To avoid duplicate entries in the tree, ensure that we 'upsert' here.
   if (tree.path === node.dirname) {
-    // To avoid duplicate entries in the tree, ensure that we 'upsert' here.
-    const children = tree.children.map((entry) => {
-      return entry.path === node.path ? node : entry;
-    });
+    const idx = tree.children.findIndex((entry) => entry.path === node.path);
+    const children = [...tree.children];
+
+    if (idx === -1) {
+      children.push(node);
+    } else {
+      children.splice(idx, 1, node);
+    }
 
     return { ...tree, children };
   }

--- a/packages/web/src/components/apps/lib/file-tree.ts
+++ b/packages/web/src/components/apps/lib/file-tree.ts
@@ -1,7 +1,5 @@
 import type { DirEntryType, FileEntryType, FsEntryTreeType } from '@srcbook/shared';
 
-import { dirname } from './path';
-
 /**
  * Sorts a file tree (in place) by name. Folders come first, then files.
  */
@@ -11,7 +9,7 @@ export function sortTree(tree: DirEntryType): DirEntryType {
     if (b.type === 'directory') sortTree(b);
     if (a.type === 'directory' && b.type === 'file') return -1;
     if (a.type === 'file' && b.type === 'directory') return 1;
-    return a.name.localeCompare(b.name);
+    return a.basename.localeCompare(b.basename);
   });
 
   return tree;
@@ -204,19 +202,15 @@ export function deleteNode(tree: DirEntryType, path: string): DirEntryType {
  * Create a new node in the file tree.
  */
 export function createNode(tree: DirEntryType, node: DirEntryType | FileEntryType): DirEntryType {
-  return sortTree(doCreateNode(tree, node, dirname(node.path)));
+  return sortTree(doCreateNode(tree, node));
 }
 
-function doCreateNode(
-  tree: DirEntryType,
-  node: DirEntryType | FileEntryType,
-  dirname: string,
-): DirEntryType {
+function doCreateNode(tree: DirEntryType, node: DirEntryType | FileEntryType): DirEntryType {
   if (tree.children === null) {
     return tree;
   }
 
-  if (tree.path === dirname) {
+  if (tree.path === node.dirname) {
     // To avoid duplicate entries in the tree, ensure that we 'upsert' here.
     const children = tree.children.map((entry) => {
       return entry.path === node.path ? node : entry;
@@ -227,7 +221,7 @@ function doCreateNode(
 
   const children = tree.children.map((entry) => {
     if (entry.type === 'directory') {
-      return doCreateNode(entry, node, dirname);
+      return doCreateNode(entry, node);
     } else {
       return entry;
     }

--- a/packages/web/src/components/apps/lib/path.ts
+++ b/packages/web/src/components/apps/lib/path.ts
@@ -1,24 +1,6 @@
 // This file and client side code assumes posix paths. It is incomplete and handles basic
 // functionality. That should be ok as we expect a subset of behavior and assume simple paths.
 
-const ROOT_PATH = '.';
-
-export function dirname(path: string): string {
-  path = path.trim();
-
-  if (path === '' || path === ROOT_PATH) {
-    return ROOT_PATH;
-  }
-
-  const parts = path.split('/');
-
-  if (parts.length === 1) {
-    return '.';
-  }
-
-  return parts.slice(0, parts.length - 1).join('/');
-}
-
 export function extname(path: string) {
   const idx = path.lastIndexOf('.');
   return idx === -1 ? '' : path.slice(idx);

--- a/packages/web/src/components/apps/panels/explorer.tsx
+++ b/packages/web/src/components/apps/panels/explorer.tsx
@@ -9,7 +9,6 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from '@srcbook/components/src/components/ui/context-menu';
-import { dirname } from '../lib/path';
 
 export default function ExplorerPanel() {
   const { fileTree } = useFiles();
@@ -33,13 +32,21 @@ export default function ExplorerPanel() {
       </ContextMenuTrigger>
       <ContextMenuContent>
         <ContextMenuItem
-          onClick={() => setNewEntry({ type: 'file', path: 'untitled', name: 'untitled' })}
+          onClick={() =>
+            setNewEntry({ type: 'file', path: 'untitled', dirname: '.', basename: 'untitled' })
+          }
         >
           New file...
         </ContextMenuItem>
         <ContextMenuItem
           onClick={() =>
-            setNewEntry({ type: 'directory', path: 'untitled', name: 'untitled', children: null })
+            setNewEntry({
+              type: 'directory',
+              path: 'untitled',
+              dirname: '.',
+              basename: 'untitled',
+              children: null,
+            })
           }
         >
           New folder...
@@ -90,12 +97,12 @@ function FileTree(props: {
 
   const elements = [];
 
-  if (newEntry !== null && newEntry.type === 'directory' && dirname(newEntry.path) === tree.path) {
+  if (newEntry !== null && newEntry.type === 'directory' && newEntry.dirname === tree.path) {
     elements.push(
       <li key={newEntry.path}>
         <EditNameNode
           depth={depth}
-          name={newEntry.name}
+          name={newEntry.basename}
           onSubmit={(name) => {
             createFolder(tree.path, name);
             setNewEntry(null);
@@ -114,7 +121,7 @@ function FileTree(props: {
         <li key={entry.path}>
           <EditNameNode
             depth={depth}
-            name={entry.name}
+            name={entry.basename}
             onSubmit={(name) => {
               renameFolder(entry, name);
               setEditingEntry(null);
@@ -128,7 +135,7 @@ function FileTree(props: {
         <li key={entry.path}>
           <FolderNode
             depth={depth}
-            label={entry.name}
+            label={entry.basename}
             opened={opened}
             onClick={() => toggleFolder(entry)}
             onDelete={() => deleteFolder(entry)}
@@ -137,7 +144,12 @@ function FileTree(props: {
               if (!isFolderOpen(entry)) {
                 openFolder(entry);
               }
-              setNewEntry({ type: 'file', path: entry.path + '/untitled', name: 'untitled' });
+              setNewEntry({
+                type: 'file',
+                path: entry.path + '/untitled',
+                dirname: entry.path,
+                basename: 'untitled',
+              });
             }}
             onNewfolder={() => {
               if (!isFolderOpen(entry)) {
@@ -146,7 +158,8 @@ function FileTree(props: {
               setNewEntry({
                 type: 'directory',
                 path: entry.path + '/untitled',
-                name: 'untitled',
+                dirname: entry.path,
+                basename: 'untitled',
                 children: null,
               });
             }}
@@ -170,12 +183,12 @@ function FileTree(props: {
     }
   }
 
-  if (newEntry !== null && newEntry.type === 'file' && dirname(newEntry.path) === tree.path) {
+  if (newEntry !== null && newEntry.type === 'file' && newEntry.dirname === tree.path) {
     elements.push(
       <li key={newEntry.path}>
         <EditNameNode
           depth={depth}
-          name={newEntry.name}
+          name={newEntry.basename}
           onSubmit={(name) => {
             createFile(tree.path, name);
             setNewEntry(null);
@@ -192,7 +205,7 @@ function FileTree(props: {
         <li key={entry.path}>
           <EditNameNode
             depth={depth}
-            name={entry.name}
+            name={entry.basename}
             onSubmit={(name) => {
               renameFile(entry, name);
               setEditingEntry(null);
@@ -206,7 +219,7 @@ function FileTree(props: {
         <li key={entry.path}>
           <FileNode
             depth={depth}
-            label={entry.name}
+            label={entry.basename}
             active={openedFile?.path === entry.path}
             onClick={() => openFile(entry)}
             onDelete={() => deleteFile(entry)}

--- a/packages/web/src/components/apps/use-files.tsx
+++ b/packages/web/src/components/apps/use-files.tsx
@@ -109,7 +109,7 @@ export function FilesProvider({ app, channel, rootDirEntries, children }: Provid
       const { data: newEntry } = await doRenameFile(app.id, entry.path, name);
       setOpenedFile((openedFile) => {
         if (openedFile && openedFile.path === entry.path) {
-          return { ...openedFile, path: newEntry.path, name: newEntry.name };
+          return { ...openedFile, path: newEntry.path, name: newEntry.basename };
         }
         return openedFile;
       });

--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -281,7 +281,12 @@ export function ChatPanel(props: PropsType): React.JSX.Element {
         createFile(file.dirname, file.basename, file.original);
       } else {
         // TODO: this needs some testing, this shows the idea only
-        deleteFile({ type: 'file', name: file.basename, path: file.path });
+        deleteFile({
+          type: 'file',
+          path: file.path,
+          dirname: file.dirname,
+          basename: file.basename,
+        });
       }
     }
     setFileDiffs([]);


### PR DESCRIPTION
File tree types now include:

* `path` the full path -- can be used as unique file/folder id (this existed already)
* `dirname`
* `basename` (this existed previously as `name`)

This is part of an effort to make file and file tree types A) very easy to use and B) as similar to one another as possible.

This PR also fixes a bug when inserting a node in the file tree introduced #373 where we removed the ability to insert a new node into the tree.
