### PR TITLE
Improve diff panel. Fix switching to code tab when we apply changes

### DIFF
--- a/packages/web/src/components/apps/diff-modal.tsx
+++ b/packages/web/src/components/apps/diff-modal.tsx
@@ -6,7 +6,7 @@ import {
   DialogTitle,
   DialogDescription,
 } from '@srcbook/components/src/components/ui/dialog';
-import { Undo2Icon, XIcon } from 'lucide-react';
+import { Undo2Icon } from 'lucide-react';
 import type { FileDiffType } from '@srcbook/shared';
 import { DiffSquares, DiffStats } from './diff-stats';
 import { DiffEditor } from './editor';
@@ -33,7 +33,7 @@ export default function DiffModal({ files, onClose, onUndoAll }: PropsType) {
       >
         {/* Got browser console warnings without this */}
         <DialogDescription className="sr-only">View diff of files changed</DialogDescription>
-        <DiffModalHeader onClose={onClose} onUndoAll={onUndoAll} />
+        <DiffModalHeader numFiles={files.length} onClose={onClose} onUndoAll={onUndoAll} />
         <div className="flex-1 overflow-y-auto p-6 flex flex-col gap-6">
           {files.map((file) => (
             <FileDiff key={file.path} file={file} />
@@ -44,21 +44,26 @@ export default function DiffModal({ files, onClose, onUndoAll }: PropsType) {
   );
 }
 
-function DiffModalHeader({ onClose, onUndoAll }: { onClose: () => void; onUndoAll: () => void }) {
+function DiffModalHeader({
+  numFiles,
+  onClose,
+  onUndoAll,
+}: {
+  numFiles: number;
+  onClose: () => void;
+  onUndoAll: () => void;
+}) {
   return (
     <div className="h-12 px-4 flex items-center justify-between border-b border-border">
       <div>
-        <DialogTitle className="font-semibold">Files changed</DialogTitle>
+        <DialogTitle className="font-semibold">{`${numFiles} files changed`}</DialogTitle>
       </div>
       <div className="flex items-center space-x-3">
         <Button variant="secondary" className="flex items-center space-x-1.5" onClick={onUndoAll}>
           <Undo2Icon size={16} />
           <span>Undo all</span>
         </Button>
-        <Button variant="icon" className="h-8 w-8 p-1.5 border-none" onClick={onClose}>
-          <XIcon size={16} />
-          <span className="sr-only">Close</span>
-        </Button>
+        <Button onClick={onClose}>Done</Button>
       </div>
     </div>
   );

--- a/packages/web/src/components/apps/panels/explorer.tsx
+++ b/packages/web/src/components/apps/panels/explorer.tsx
@@ -189,8 +189,9 @@ function FileTree(props: {
         <EditNameNode
           depth={depth}
           name={newEntry.basename}
-          onSubmit={(name) => {
-            createFile(tree.path, name);
+          onSubmit={async (name) => {
+            const diskEntry = await createFile(tree.path, name);
+            openFile(diskEntry);
             setNewEntry(null);
           }}
           onCancel={() => setNewEntry(null)}

--- a/packages/web/src/components/apps/use-files.tsx
+++ b/packages/web/src/components/apps/use-files.tsx
@@ -25,7 +25,7 @@ export interface FilesContextValue {
   fileTree: DirEntryType;
   openedFile: FileType | null;
   openFile: (entry: FileEntryType) => Promise<void>;
-  createFile: (dirname: string, basename: string, source?: string) => Promise<void>;
+  createFile: (dirname: string, basename: string, source?: string) => Promise<FileEntryType>;
   updateFile: (file: FileType, attrs: Partial<FileType>) => void;
   renameFile: (entry: FileEntryType, name: string) => Promise<void>;
   deleteFile: (entry: FileEntryType) => Promise<void>;
@@ -74,9 +74,9 @@ export function FilesProvider({ app, channel, rootDirEntries, children }: Provid
       const { data: fileEntry } = await doCreateFile(app.id, dirname, basename, source);
       fileTreeRef.current = createNode(fileTreeRef.current, fileEntry);
       forceComponentRerender(); // required
-      openFile(fileEntry);
+      return fileEntry;
     },
-    [app.id, openFile],
+    [app.id],
   );
 
   const updateFile = useCallback(


### PR DESCRIPTION
- Improve the diff panel
- Ability to reapply latest diff
- Fix bug: previously, when calling `createFile` we finish by `opening` [ the file](https://github.com/srcbookdev/srcbook/blob/main/packages/web/src/components/apps/use-files.tsx#L77). 

I saw 2 fixes:

1. Keep the open side effect and modify the automatic useEffect in <Editor> which automatically switches the tab when a file is open. Replace this with a mechanism that switches the tab only when we click on the sidebar
2. Remove the open side effect, so we can create files and if we want them to open we need to do it manually.

This implements 2 which I think is cleaner and easier to reason about (less side effects).