### PR TITLE
Install the packages that the AI recommends + add changeset version

### DIFF
--- a/packages/api/prompts/app-builder.txt
+++ b/packages/api/prompts/app-builder.txt
@@ -25,19 +25,19 @@
 ## Instructions
 
 - Your job is to come up with the relevant changes, you do so by suggesting a <plan> with one or more <action> and a <planDescription>
-There can be one or more <action> in a <plan>.
-A <planDescription> is a brief description of your plan in plain english. It will be shown to the user as context.
-An <Action> is one of:
+- There can be one or more <action> in a <plan>.
+- A <planDescription> is a brief description of your plan in plain english. It will be shown to the user as context.
+- An <action> is one of:
     - type="file": a new or updated file with ALL of the new contents
-    - type="command": a command that the user will run in the command line. Should be a *single* command that we'll show to the user to approve.
-
+    - type="command": a command that the user will run in the command line. Currently the only supported command is 'npm install': it allows you to install one or more npm packages.
+- When installing dependencies, don't update the package.json file. Instead use the <action type="command"> with the <commandType>npm install</commandType>; running this command will update the package.json.
 - Only respond with the plan, all information you provide should be in it.
 - You will receive a user request like "build a todo list app" or "build a food logger". It might be a lot more requirements, but keep your MVP functional and simple.
 - You should use localStorage for storage, unless specifically requested otherwise
 - Your stack is React, vite, typescript, tailwind. Keep things simple. 
 - The goal is to get a FUNCTIONAL MVP. All of the parts for this MVP should be included.
 - Your job is to be precise and effective, so avoid extraneous steps even if they offer convenience.
-- Do not talk or worry about testing. The user wants to _use_ the app. That is the core goal, for it to _work_.
+- Do not talk or worry about testing. The user wants to _use_ the app: the core goal is for it to _work_.
 
 
 ## Example response
@@ -49,36 +49,37 @@ An <Action> is one of:
   </planDescription>
   <action type="file">
     <description>
-      {Short justification of changes. Be as brief as possible, like a commit message}
+      <![CDATA[
+        {Short justification of changes. Be as brief as possible, like a commit message}
+      ]]>
     </description>
-    <file filename="package.json">
-        <![CDATA[
-          {... file contents (ALL OF THE FILE)}
-        ]]>
+    <file filename="{the filename like src/App.tsx}">
+      <![CDATA[
+        {... file contents (ALL OF THE FILE)}
+      ]]>
     </file>
   </action>
   <action type="file">
     <description>
-        <![CDATA[
-          {Short justification of changes. Be as brief as possible, like a commit message}
-        ]]>
+      <![CDATA[
+        {Short justification of changes. Be as brief as possible, like a commit message}
+      ]]>
     </description>
-  <file filename="./App.tsx">
-    <![CDATA[
-      {... file contents (ALL OF THE FILE)}
-    ]]>
-  </file>
+    <file filename="{the filename like package.json}">
+      <![CDATA[
+        {... file contents (ALL OF THE FILE)}
+      ]]>
+    </file>
+  </action>
   <action type="command">
-  <description>
-    <![CDATA[
-      {Short description of changes. Be brief, like a commit message}
-    ]]>
-  </description>
-  <command>
-    <![CDATA[
-      {one terminal command (not multiple), example: 'npm install lodash'}
-    ]]>
-  </command>
+    <description>
+      <![CDATA[
+        {Short description of changes. Be brief, like a commit message}
+      ]]>
+    </description>
+    <commandType>npm install</commandType>
+    <package>{package1}</package>
+    <package>{package2}</package>
   </action>
   ...
 </plan>

--- a/packages/api/prompts/app-editor.txt
+++ b/packages/api/prompts/app-editor.txt
@@ -24,17 +24,18 @@
 ## Instructions 
 
 - Your job is to come up with the relevant changes, you do so by suggesting a <plan> with one or more <action> and a <planDescription>
-There can be one or more <action> in a <plan>.
-A <planDescription> is a brief description of your plan in plain english. It will be shown to the user as context.
-An <Action> is one of:
+- There can be one or more <action> in a <plan>.
+- A <planDescription> is a brief description of your plan in plain english. It will be shown to the user as context.
+- An <action> is one of:
     - type="file": a new or updated file with ALL of the new contents
-    - type="command": a command that the user will run in the command line. Should be a *single* command that we'll show to the user to approve.
+    - type="command": a command that the user will run in the command line. Currently the only supported command is 'npm install': it allows you to install one or more npm packages.
+- When installing dependencies, don't update the package.json file. Instead use the <action type="command"> with the <commandType>npm install</commandType>; running this command will update the package.json.
 - Only respond with the plan, all information you provide should be in it.
-- You should use localStorage for storage, unless specifically requested otherwise
+- You should use localStorage for storage, unless specifically requested otherwise.
 - Your stack is React, vite, typescript, tailwind. Keep things simple. 
 - The goal is to get a FUNCTIONAL MVP. All of the parts for this MVP should be included.
 - Your job is to be precise and effective, so avoid extraneous steps even if they offer convenience.
-- Do not talk or worry about testing. The user wants to _use_ the app. That is the core goal, for it to _work_.
+- Do not talk or worry about testing. The user wants to _use_ the app: the core goal is for it to _work_.
 
 
 ## Example response
@@ -46,36 +47,37 @@ An <Action> is one of:
   </planDescription>
   <action type="file">
     <description>
-      {Short justification of changes. Be as brief as possible, like a commit message}
+      <![CDATA[
+        {Short justification of changes. Be as brief as possible, like a commit message}
+      ]]>
     </description>
-    <file filename="package.json">
-        <![CDATA[
-          {... file contents (ALL OF THE FILE)}
-        ]]>
+    <file filename="{the filename like src/App.tsx}">
+      <![CDATA[
+        {... file contents (ALL OF THE FILE)}
+      ]]>
     </file>
   </action>
   <action type="file">
     <description>
-        <![CDATA[
-          {Short justification of changes. Be as brief as possible, like a commit message}
-        ]]>
+      <![CDATA[
+        {Short justification of changes. Be as brief as possible, like a commit message}
+      ]]>
     </description>
-  <file filename="./App.tsx">
-    <![CDATA[
-      {... file contents (ALL OF THE FILE)}
-    ]]>
-  </file>
+    <file filename="{the filename like package.json}">
+      <![CDATA[
+        {... file contents (ALL OF THE FILE)}
+      ]]>
+    </file>
+  </action
   <action type="command">
-  <description>
-    <![CDATA[
-      {Short description of changes. Be brief, like a commit message}
-    ]]>
-  </description>
-  <command>
-    <![CDATA[
-      {one terminal command (not multiple), example: 'npm install lodash'}
-    ]]>
-  </command>
+    <description>
+      <![CDATA[
+        Install required packages for state management and routing
+      ]]>
+    </description>
+    <commandType>npm install</commandType>
+    <package>react-redux</package>
+    <package>react-router-dom</package>
   </action>
   ...
 </plan>

--- a/packages/api/test/plan-parser.test.mts
+++ b/packages/api/test/plan-parser.test.mts
@@ -1,0 +1,134 @@
+import { expect, test, describe } from 'vitest';
+import { parsePlan } from '../ai/plan-parser.mjs';
+import { type App as DBAppType } from '../db/schema.mjs';
+import { vi } from 'vitest';
+
+// Mock the loadFile function
+vi.mock('../apps/disk.mjs', () => ({
+  loadFile: vi.fn().mockImplementation((_app, filePath) => {
+    if (filePath === 'src/App.tsx') {
+      return Promise.resolve({ source: 'Original App.tsx content' });
+    }
+    return Promise.reject(new Error('File not found'));
+  }),
+}));
+
+const mockApp: DBAppType = {
+  id: 123,
+  externalId: '123',
+  name: 'Test App',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  history: '',
+  historyVersion: 1,
+};
+
+const mockXMLResponse = `
+<plan>
+  <planDescription>Implement a basic todo list app</planDescription>
+  <action type="file">
+    <description>Update App.tsx with todo list functionality</description>
+    <file filename="src/App.tsx">
+      <![CDATA[
+import React, { useState, useEffect } from 'react';
+
+interface Todo {
+  id: number;
+  text: string;
+  completed: boolean;
+}
+
+function App() {
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [inputValue, setInputValue] = useState('');
+
+  useEffect(() => {
+    const storedTodos = localStorage.getItem('todos');
+    if (storedTodos) {
+      setTodos(JSON.parse(storedTodos));
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('todos', JSON.stringify(todos));
+  }, [todos]);
+
+  const addTodo = () => {
+    if (inputValue.trim() !== '') {
+      setTodos([...todos, { id: Date.now(), text: inputValue, completed: false }]);
+      setInputValue('');
+    }
+  };
+
+  const toggleTodo = (id: number) => {
+    setTodos(todos.map(todo =>
+      todo.id === id ? { ...todo, completed: !todo.completed } : todo
+    ));
+  };
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Todo List</h1>
+      <div className="flex mb-4">
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          className="flex-grow p-2 border rounded-l"
+          placeholder="Add a new todo"
+        />
+        <button onClick={addTodo} className="bg-blue-500 text-white p-2 rounded-r">Add</button>
+      </div>
+      <ul>
+        {todos.map(todo => (
+          <li key={todo.id} className="flex items-center mb-2">
+            <input
+              type="checkbox"
+              checked={todo.completed}
+              onChange={() => toggleTodo(todo.id)}
+              className="mr-2"
+            />
+            <span className={todo.completed ? 'line-through' : ''}>{todo.text}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default App;
+      ]]>
+    </file>
+  </action>
+  <action type="command">
+    <description>Install required packages</description>
+    <commandType>npm install</commandType>
+    <package>@types/react</package>
+    <package>@types/react-dom</package>
+  </action>
+</plan>
+`;
+
+describe('parsePlan', () => {
+  test('should correctly parse a plan with file and command actions', async () => {
+    const plan = await parsePlan(mockXMLResponse, mockApp);
+
+    expect(plan.description).toBe('Implement a basic todo list app');
+    expect(plan.actions).toHaveLength(2);
+
+    // Check file action
+    const fileAction = plan.actions[0] as any;
+    expect(fileAction.type).toBe('file');
+    expect(fileAction.path).toBe('src/App.tsx');
+    expect(fileAction.modified).toContain('function App()');
+    expect(fileAction.original).toBe('Original App.tsx content');
+    expect(fileAction.description).toBe('Update App.tsx with todo list functionality');
+
+    // Check command action
+    const commandAction = plan.actions[1] as any;
+    expect(commandAction.type).toBe('command');
+    expect(commandAction.command).toBe('npm install');
+    expect(commandAction.packages).toEqual(['@types/react', '@types/react-dom']);
+    expect(commandAction.description).toBe('Install required packages');
+  });
+});

--- a/packages/shared/src/types/history.mts
+++ b/packages/shared/src/types/history.mts
@@ -14,11 +14,14 @@ export type UserMessageType = {
   message: string;
 };
 
-export type CommandMessageType = {
+type NpmInstallCommand = {
   type: 'command';
-  command: string;
+  command: 'npm install';
+  packages: string[];
   description: string;
 };
+
+export type CommandMessageType = NpmInstallCommand;
 
 export type DiffMessageType = {
   type: 'diff';

--- a/packages/web/src/components/apps/diff-stats.tsx
+++ b/packages/web/src/components/apps/diff-stats.tsx
@@ -4,7 +4,7 @@ import { calculateSquares } from './lib/diff';
 export function DiffStats(props: { additions: number; deletions: number; className?: string }) {
   return (
     <div className={cn('flex items-center gap-2', props.className)}>
-      <span className="text-green-400">-{props.additions}</span>
+      <span className="text-green-500">-{props.additions}</span>
       <span className="text-red-400">+{props.deletions}</span>
     </div>
   );

--- a/packages/web/src/components/apps/types.ts
+++ b/packages/web/src/components/apps/types.ts
@@ -1,3 +1,5 @@
+import { CommandMessageType } from '@srcbook/shared';
+
 export type FileType = {
   type: 'file';
   modified: string;
@@ -8,16 +10,8 @@ export type FileType = {
   description: string;
 };
 
-type NpmInstallCommandType = {
-  type: 'command';
-  command: 'npm install';
-  packages: string[];
-  description: string;
-};
-
-export type CommandType = NpmInstallCommandType;
-
-export type PlanItemType = FileType | CommandType;
+// TODO this should likely all be shared types eventually.
+export type PlanItemType = FileType | CommandMessageType;
 
 export type PlanType = {
   description: string;

--- a/packages/web/src/components/apps/types.ts
+++ b/packages/web/src/components/apps/types.ts
@@ -8,11 +8,14 @@ export type FileType = {
   description: string;
 };
 
-export type CommandType = {
+type NpmInstallCommandType = {
   type: 'command';
-  content: string;
+  command: 'npm install';
+  packages: string[];
   description: string;
 };
+
+export type CommandType = NpmInstallCommandType;
 
 export type PlanItemType = FileType | CommandType;
 

--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -77,7 +77,7 @@ function Chat({
                 </p>
               );
             } else if (message.type === 'command') {
-              const packages = message.command.match(/npm install (.+)/)?.[1];
+              const packages = message.packages;
               if (!packages) {
                 console.error(
                   'The only supported command is `npm install <packages>`. Got:',
@@ -87,12 +87,12 @@ function Chat({
               }
               return (
                 <div className="text-sm space-y-1" key={index}>
-                  <p>{message.description}</p>
+                  <p>Install dependencies</p>
                   <div className="flex justify-between items-center gap-1">
                     <p className="font-mono bg-inline-code rounded-md p-2 overflow-x-scroll whitespace-nowrap flex-grow">
-                      {message.command}
+                      {`npm install ${packages.join(' ')}`}
                     </p>
-                    <Button onClick={() => npmInstall(packages.split(' '))}>Run</Button>
+                    <Button onClick={() => npmInstall(packages)}>Run</Button>
                   </div>
                 </div>
               );
@@ -306,14 +306,18 @@ export function DraggableChatPanel(props: { children: React.ReactNode }): React.
         style={{
           bottom: `${position.y}px`,
           right: `${position.x}px`,
-          cursor: isDragging ? 'grabbing' : 'grab',
           userSelect: 'none',
           zIndex: 100,
         }}
         onMouseDown={handleMouseDown}
       >
         <div className="flex items-end gap-1">
-          <GripHorizontal className="text-gray-400 drag-handle bg-background" />
+          <GripHorizontal
+            className={cn(
+              'text-gray-400 drag-handle bg-background/10 rounded-sm',
+              isDragging ? 'cursor-grabbing' : 'cursor-grab',
+            )}
+          />
           {props.children}
         </div>
       </div>
@@ -363,7 +367,8 @@ export function ChatPanel(props: PropsType): React.JSX.Element {
     const historyEntries = commandUpdates.map((update) => {
       const entry: CommandMessageType = {
         type: 'command',
-        command: update.content,
+        command: update.command,
+        packages: update.packages,
         description: update.description,
       };
       return entry;


### PR DESCRIPTION
## Description

- Ability to install npm packages when the AI suggests it
- Prompts now ask the AI to give us `<commandType>npm install</commandType>` rather than any terminal command
- Add a test to the plan parsing
- Tweak some rough edges on the draggable UX


![CleanShot 2024-10-17 at 21 17 50](https://github.com/user-attachments/assets/deecb533-6843-4962-ac43-92f466797efe)
