### PR TITLE
Make the chat panel draggable

### DIFF
--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -274,6 +274,7 @@ export function DraggableChatPanel(props: { children: React.ReactNode }): React.
           }}
         />
       )}
+      {/* eslint-disable-next-line */}
       <div
         ref={chatRef}
         className="fixed"

--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -255,7 +255,7 @@ export function DraggableChatPanel(props: { children: React.ReactNode }): React.
       document.removeEventListener('mousemove', handleMouseMove);
       document.removeEventListener('mouseup', handleMouseUp);
     };
-  }, [isDragging, showOverlay]);
+  }, [isDragging, showOverlay, handleMouseMove, handleMouseUp]);
 
   // Note: we show a full screen overlay otherwise the mouse events
   // don't fire correctly when hovering over the iframe.

--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -255,7 +255,8 @@ export function DraggableChatPanel(props: { children: React.ReactNode }): React.
       document.removeEventListener('mousemove', handleMouseMove);
       document.removeEventListener('mouseup', handleMouseUp);
     };
-  }, [isDragging, showOverlay, handleMouseMove, handleMouseUp]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDragging, showOverlay]);
 
   // Note: we show a full screen overlay otherwise the mouse events
   // don't fire correctly when hovering over the iframe.


### PR DESCRIPTION
The chat overlay is sometimes in the way. Until we re-work the layout, I have a quick fix that makes it draggable, so you can "pull it out of the way". 

https://github.com/user-attachments/assets/f2474c5b-cacc-4014-952f-27950a2e315a

