### PR TITLE
Add an explicit "npm install" loading state, and start to gate features behind if node_modules exists

### DIFF
--- a/packages/api/fs-utils.mts
+++ b/packages/api/fs-utils.mts
@@ -9,6 +9,15 @@ export async function fileExists(filepath: string) {
   }
 }
 
+export async function directoryExists(dirpath: string) {
+  try {
+    const result = await fs.stat(dirpath);
+    return result.isDirectory();
+  } catch (error) {
+    return false;
+  }
+}
+
 export async function readFile(
   path: string,
 ): Promise<{ exists: true; contents: string } | { exists: false }> {

--- a/packages/shared/src/schemas/websockets.mts
+++ b/packages/shared/src/schemas/websockets.mts
@@ -188,6 +188,12 @@ export const DepsInstallStatusPayloadSchema = z.object({
   code: z.number().int(),
 });
 
+export const DepsClearPayloadSchema = z.object({});
+export const DepsStatusPayloadSchema = z.object({});
+export const DepsStatusResponsePayloadSchema = z.object({
+  nodeModulesExists: z.boolean(),
+});
+
 ///////////////////////
 // APPS & NOTEBOOKS //
 ///////////////////////

--- a/packages/shared/src/types/websockets.mts
+++ b/packages/shared/src/types/websockets.mts
@@ -39,6 +39,9 @@ import {
   PreviewStartPayloadSchema,
   DepsInstallLogPayloadSchema,
   DepsInstallStatusPayloadSchema,
+  DepsClearPayloadSchema,
+  DepsStatusPayloadSchema,
+  DepsStatusResponsePayloadSchema,
 } from '../schemas/websockets.mjs';
 
 export type CellExecPayloadType = z.infer<typeof CellExecPayloadSchema>;
@@ -55,6 +58,9 @@ export type AiGeneratedCellPayloadType = z.infer<typeof AiGeneratedCellPayloadSc
 export type AiFixDiagnosticsPayloadType = z.infer<typeof AiFixDiagnosticsPayloadSchema>;
 
 export type DepsInstallPayloadType = z.infer<typeof DepsInstallPayloadSchema>;
+export type DepsClearPayloadType = z.infer<typeof DepsClearPayloadSchema>;
+export type DepsStatusPayloadType = z.infer<typeof DepsStatusPayloadSchema>;
+export type DepsStatusResponsePayloadType = z.infer<typeof DepsStatusResponsePayloadSchema>;
 export type DepsValidateResponsePayloadType = z.infer<typeof DepsValidateResponsePayloadSchema>;
 export type DepsValidatePayloadType = z.infer<typeof DepsValidatePayloadSchema>;
 

--- a/packages/web/src/clients/websocket/index.ts
+++ b/packages/web/src/clients/websocket/index.ts
@@ -37,6 +37,9 @@ import {
   PreviewStopPayloadSchema,
   DepsInstallLogPayloadSchema,
   DepsInstallStatusPayloadSchema,
+  DepsClearPayloadSchema,
+  DepsStatusResponsePayloadSchema,
+  DepsStatusPayloadSchema,
 } from '@srcbook/shared';
 import Channel from '@/clients/websocket/channel';
 import WebSocketClient from '@/clients/websocket/client';
@@ -98,6 +101,7 @@ const IncomingAppEvents = {
   'preview:status': PreviewStatusPayloadSchema,
   'deps:install:log': DepsInstallLogPayloadSchema,
   'deps:install:status': DepsInstallStatusPayloadSchema,
+  'deps:status:response': DepsStatusResponsePayloadSchema,
 };
 
 const OutgoingAppEvents = {
@@ -108,6 +112,8 @@ const OutgoingAppEvents = {
   'preview:start': PreviewStartPayloadSchema,
   'preview:stop': PreviewStopPayloadSchema,
   'deps:install': DepsInstallPayloadSchema,
+  'deps:clear': DepsClearPayloadSchema,
+  'deps:status': DepsStatusPayloadSchema,
 };
 
 export class AppChannel extends Channel<typeof IncomingAppEvents, typeof OutgoingAppEvents> {

--- a/packages/web/src/components/apps/header.tsx
+++ b/packages/web/src/components/apps/header.tsx
@@ -60,6 +60,13 @@ export default function EditorHeader(props: PropsType) {
           }}
         />
       )}
+
+      {npmInstallStatus === "installing" ? (
+        <div className="fixed top-0 left-0 right-0 z-[51] h-0.5 pointer-events-none">
+          <div className="h-full w-full bg-white animate-indeterminate" />
+        </div>
+      ) : null}
+
       <header
         className={cn(
           'w-full flex items-center justify-between bg-background z-50 text-sm border-b border-b-border relative',

--- a/packages/web/src/components/apps/header.tsx
+++ b/packages/web/src/components/apps/header.tsx
@@ -61,7 +61,7 @@ export default function EditorHeader(props: PropsType) {
         />
       )}
 
-      {npmInstallStatus === "installing" ? (
+      {npmInstallStatus === 'installing' ? (
         <div className="fixed top-0 left-0 right-0 z-[51] h-0.5 pointer-events-none">
           <div className="h-full w-full bg-white animate-indeterminate" />
         </div>

--- a/packages/web/src/components/apps/header.tsx
+++ b/packages/web/src/components/apps/header.tsx
@@ -5,7 +5,6 @@ import {
   EllipsisIcon,
   PlayCircleIcon,
   Code2Icon,
-  Loader2Icon,
 } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { SrcbookLogo } from '@/components/logos';
@@ -112,19 +111,6 @@ export default function EditorHeader(props: PropsType) {
           </div>
 
           <div className="flex items-center gap-2">
-            {npmInstallStatus === "installing" ? (
-              <button
-                className={cn(
-                  "flex items-center gap-2 rounded-full border border-run px-2 h-8 bg-muted text-run",
-                  "outline-none focus-visible:ring-1 focus-visible:ring-ring",
-                )}
-                onClick={props.onShowPackagesPanel}
-              >
-                <Loader2Icon size={18} className="animate-spin" />
-                <span>Installing packages...</span>
-              </button>
-            ) : null}
-
             {props.tab === 'preview' && previewStatus === 'stopped' ? (
               <TooltipProvider>
                 <Tooltip>

--- a/packages/web/src/components/apps/header.tsx
+++ b/packages/web/src/components/apps/header.tsx
@@ -5,6 +5,7 @@ import {
   EllipsisIcon,
   PlayCircleIcon,
   Code2Icon,
+  Loader2Icon,
 } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { SrcbookLogo } from '@/components/logos';
@@ -24,10 +25,11 @@ import {
   DialogDescription,
 } from '@srcbook/components/src/components/ui/dialog';
 import { cn } from '@/lib/utils';
-import { usePreview } from './use-preview';
+import { usePackageJson } from './use-package-json';
 import { useApp } from './use-app';
 import { Input } from '@srcbook/components';
 import { useState } from 'react';
+import { usePreview } from './use-preview';
 
 export type EditorHeaderTab = 'code' | 'preview';
 
@@ -35,11 +37,13 @@ type PropsType = {
   className?: string;
   tab: EditorHeaderTab;
   onChangeTab: (newTab: EditorHeaderTab) => void;
+  onShowPackagesPanel: () => void;
 };
 
 export default function EditorHeader(props: PropsType) {
   const { app, updateApp } = useApp();
   const { start: startPreview, stop: stopPreview, status: previewStatus } = usePreview();
+  const { status: npmInstallStatus } = usePackageJson();
 
   const [nameChangeDialogOpen, setNameChangeDialogOpen] = useState(false);
 
@@ -108,6 +112,19 @@ export default function EditorHeader(props: PropsType) {
           </div>
 
           <div className="flex items-center gap-2">
+            {npmInstallStatus === "installing" ? (
+              <button
+                className={cn(
+                  "flex items-center gap-2 rounded-full border border-run px-2 h-8 bg-muted text-run",
+                  "outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                )}
+                onClick={props.onShowPackagesPanel}
+              >
+                <Loader2Icon size={18} className="animate-spin" />
+                <span>Installing packages...</span>
+              </button>
+            ) : null}
+
             {props.tab === 'preview' && previewStatus === 'stopped' ? (
               <TooltipProvider>
                 <Tooltip>

--- a/packages/web/src/components/apps/header.tsx
+++ b/packages/web/src/components/apps/header.tsx
@@ -43,7 +43,7 @@ type PropsType = {
 export default function EditorHeader(props: PropsType) {
   const { app, updateApp } = useApp();
   const { start: startPreview, stop: stopPreview, status: previewStatus } = usePreview();
-  const { status: npmInstallStatus } = usePackageJson();
+  const { status: npmInstallStatus, nodeModulesExists } = usePackageJson();
 
   const [nameChangeDialogOpen, setNameChangeDialogOpen] = useState(false);
 
@@ -134,6 +134,7 @@ export default function EditorHeader(props: PropsType) {
                       size="icon"
                       onClick={startPreview}
                       className="active:translate-y-0"
+                      disabled={nodeModulesExists !== true}
                     >
                       <PlayCircleIcon size={18} />
                     </Button>

--- a/packages/web/src/components/apps/package-install-note.tsx
+++ b/packages/web/src/components/apps/package-install-note.tsx
@@ -18,7 +18,7 @@ const PackageInstallNote: React.FunctionComponent = () => {
     ) {
       setShowPackageInstallNote(true);
     }
-  }, [nodeModulesExists]);
+  }, [nodeModulesExists, npmInstallStatus]);
 
   switch (npmInstallStatus) {
     case 'installing':

--- a/packages/web/src/components/apps/package-install-note.tsx
+++ b/packages/web/src/components/apps/package-install-note.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from "react";
-import { CircleAlertIcon, InfoIcon, Loader2Icon, XIcon } from "lucide-react";
+import { useEffect, useState } from 'react';
+import { CircleAlertIcon, InfoIcon, Loader2Icon, XIcon } from 'lucide-react';
 
 import { usePackageJson } from './use-package-json';
-import { useLogs } from "./use-logs";
-import { Button } from "@srcbook/components/src/components/ui/button";
+import { useLogs } from './use-logs';
+import { Button } from '@srcbook/components/src/components/ui/button';
 import { cn } from '@/lib/utils';
 
 const PackageInstallNote: React.FunctionComponent = () => {
@@ -12,21 +12,26 @@ const PackageInstallNote: React.FunctionComponent = () => {
   const [showPackageInstallNote, setShowPackageInstallNote] = useState(false);
 
   useEffect(() => {
-    if (nodeModulesExists === false && (npmInstallStatus === "idle" || npmInstallStatus === "complete")) {
+    if (
+      nodeModulesExists === false &&
+      (npmInstallStatus === 'idle' || npmInstallStatus === 'complete')
+    ) {
       setShowPackageInstallNote(true);
     }
   }, [nodeModulesExists]);
 
   switch (npmInstallStatus) {
-    case "installing":
+    case 'installing':
       return (
-        <div className={cn(
-          "absolute bottom-4 left-4 z-50 bg-muted border flex items-center gap-4 h-16 px-4",
-          "rounded-lg transition-all duration-150 ease-in-out",
-          {
-            "opacity-0 -bottom-8": !showPackageInstallNote,
-          },
-        )}>
+        <div
+          className={cn(
+            'absolute bottom-4 left-4 z-50 bg-muted border flex items-center gap-4 h-16 px-4',
+            'rounded-lg transition-all duration-150 ease-in-out',
+            {
+              'opacity-0 -bottom-8': !showPackageInstallNote,
+            },
+          )}
+        >
           <Loader2Icon size={18} className="animate-spin" />
           <span className="select-none">Installing Packages...</span>
 
@@ -36,19 +41,23 @@ const PackageInstallNote: React.FunctionComponent = () => {
               alert('todo');
               setShowPackageInstallNote(false);
             }}
-          >Cancel</Button>
+          >
+            Cancel
+          </Button>
         </div>
       );
 
-    case "failed":
+    case 'failed':
       return (
-        <div className={cn(
-          "absolute bottom-4 left-4 z-50 bg-muted border flex flex-col gap-4 p-4",
-          "rounded-lg transition-all duration-150 ease-in-out",
-          {
-            "opacity-0 -bottom-8": !showPackageInstallNote,
-          },
-        )}>
+        <div
+          className={cn(
+            'absolute bottom-4 left-4 z-50 bg-muted border flex flex-col gap-4 p-4',
+            'rounded-lg transition-all duration-150 ease-in-out',
+            {
+              'opacity-0 -bottom-8': !showPackageInstallNote,
+            },
+          )}
+        >
           <div className="flex items-center gap-4">
             <CircleAlertIcon size={18} />
             <span className="font-medium select-none">Packages failed to install</span>
@@ -70,21 +79,25 @@ const PackageInstallNote: React.FunctionComponent = () => {
                 togglePane();
                 setShowPackageInstallNote(false);
               }}
-            >More info</Button>
+            >
+              More info
+            </Button>
           </div>
         </div>
       );
 
-    case "idle":
-    case "complete":
+    case 'idle':
+    case 'complete':
       return (
-        <div className={cn(
-          "absolute bottom-4 left-4 z-50 bg-muted border flex items-center gap-4 h-16 px-4",
-          "rounded-lg transition-all duration-150 ease-in-out",
-          {
-            "opacity-0 -bottom-8": !showPackageInstallNote,
-          },
-        )}>
+        <div
+          className={cn(
+            'absolute bottom-4 left-4 z-50 bg-muted border flex items-center gap-4 h-16 px-4',
+            'rounded-lg transition-all duration-150 ease-in-out',
+            {
+              'opacity-0 -bottom-8': !showPackageInstallNote,
+            },
+          )}
+        >
           <InfoIcon size={18} />
           <span className="select-none">Packages need to be installed</span>
 
@@ -92,7 +105,9 @@ const PackageInstallNote: React.FunctionComponent = () => {
             <Button
               className="active:translate-y-0"
               onClick={() => npmInstall().then(() => setShowPackageInstallNote(false))}
-            >Install</Button>
+            >
+              Install
+            </Button>
 
             <Button
               variant="secondary"

--- a/packages/web/src/components/apps/package-install-note.tsx
+++ b/packages/web/src/components/apps/package-install-note.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import { CircleAlertIcon, InfoIcon, Loader2Icon, XIcon } from "lucide-react";
+
+import { usePackageJson } from './use-package-json';
+import { useLogs } from "./use-logs";
+import { Button } from "@srcbook/components/src/components/ui/button";
+import { cn } from '@/lib/utils';
+
+const PackageInstallNote: React.FunctionComponent = () => {
+  const { togglePane } = useLogs();
+  const { status: npmInstallStatus, npmInstall, nodeModulesExists } = usePackageJson();
+  const [showPackageInstallNote, setShowPackageInstallNote] = useState(false);
+
+  useEffect(() => {
+    if (nodeModulesExists === false && (npmInstallStatus === "idle" || npmInstallStatus === "complete")) {
+      setShowPackageInstallNote(true);
+    }
+  }, [nodeModulesExists]);
+
+  switch (npmInstallStatus) {
+    case "installing":
+      return (
+        <div className={cn(
+          "absolute bottom-4 left-4 z-50 bg-muted border flex items-center gap-4 h-16 px-4",
+          "rounded-lg transition-all duration-150 ease-in-out",
+          {
+            "opacity-0 -bottom-8": !showPackageInstallNote,
+          },
+        )}>
+          <Loader2Icon size={18} className="animate-spin" />
+          <span className="select-none">Installing Packages...</span>
+
+          <Button
+            className="active:translate-y-0"
+            onClick={() => {
+              alert('todo');
+              setShowPackageInstallNote(false);
+            }}
+          >Cancel</Button>
+        </div>
+      );
+
+    case "failed":
+      return (
+        <div className={cn(
+          "absolute bottom-4 left-4 z-50 bg-muted border flex flex-col gap-4 p-4",
+          "rounded-lg transition-all duration-150 ease-in-out",
+          {
+            "opacity-0 -bottom-8": !showPackageInstallNote,
+          },
+        )}>
+          <div className="flex items-center gap-4">
+            <CircleAlertIcon size={18} />
+            <span className="font-medium select-none">Packages failed to install</span>
+
+            <Button
+              variant="secondary"
+              size="icon"
+              onClick={() => setShowPackageInstallNote(false)}
+              className="active:translate-y-0"
+            >
+              <XIcon size={18} />
+            </Button>
+          </div>
+
+          <div className="flex justify-end">
+            <Button
+              className="active:translate-y-0"
+              onClick={() => {
+                togglePane();
+                setShowPackageInstallNote(false);
+              }}
+            >More info</Button>
+          </div>
+        </div>
+      );
+
+    case "idle":
+    case "complete":
+      return (
+        <div className={cn(
+          "absolute bottom-4 left-4 z-50 bg-muted border flex items-center gap-4 h-16 px-4",
+          "rounded-lg transition-all duration-150 ease-in-out",
+          {
+            "opacity-0 -bottom-8": !showPackageInstallNote,
+          },
+        )}>
+          <InfoIcon size={18} />
+          <span className="select-none">Packages need to be installed</span>
+
+          <div className="flex items-center gap-2">
+            <Button
+              className="active:translate-y-0"
+              onClick={() => npmInstall().then(() => setShowPackageInstallNote(false))}
+            >Install</Button>
+
+            <Button
+              variant="secondary"
+              size="icon"
+              onClick={() => setShowPackageInstallNote(false)}
+              className="active:translate-y-0"
+            >
+              <XIcon size={18} />
+            </Button>
+          </div>
+        </div>
+      );
+  }
+};
+
+export default PackageInstallNote;

--- a/packages/web/src/components/apps/panels/settings.tsx
+++ b/packages/web/src/components/apps/panels/settings.tsx
@@ -21,8 +21,8 @@ export default function SettingsPanel() {
         </Button>
       </div>
       <div>
-        exists={nodeModulesExists ? 'true' : 'false'}
-        <Button onClick={() => clearNodeModules()} variant="secondary" disabled={!nodeModulesExists}>
+        exists={JSON.stringify(nodeModulesExists)}
+        <Button onClick={() => clearNodeModules()} variant="secondary" disabled={nodeModulesExists !== true}>
           Clear node_modules
         </Button>
       </div>

--- a/packages/web/src/components/apps/panels/settings.tsx
+++ b/packages/web/src/components/apps/panels/settings.tsx
@@ -2,7 +2,7 @@ import { Button } from '@srcbook/components/src/components/ui/button';
 import { usePackageJson } from '../use-package-json';
 
 export default function SettingsPanel() {
-  const { status, output, npmInstall } = usePackageJson();
+  const { status, output, npmInstall, clearNodeModules, nodeModulesExists } = usePackageJson();
 
   return (
     <div className="flex flex-col gap-4 px-5 w-[360px]">
@@ -18,6 +18,12 @@ export default function SettingsPanel() {
           disabled={status === 'installing'}
         >
           Run npm install uuid
+        </Button>
+      </div>
+      <div>
+        exists={nodeModulesExists ? 'true' : 'false'}
+        <Button onClick={() => clearNodeModules()} variant="secondary" disabled={!nodeModulesExists}>
+          Clear node_modules
         </Button>
       </div>
 

--- a/packages/web/src/components/apps/panels/settings.tsx
+++ b/packages/web/src/components/apps/panels/settings.tsx
@@ -22,7 +22,11 @@ export default function SettingsPanel() {
       </div>
       <div>
         exists={JSON.stringify(nodeModulesExists)}
-        <Button onClick={() => clearNodeModules()} variant="secondary" disabled={nodeModulesExists !== true}>
+        <Button
+          onClick={() => clearNodeModules()}
+          variant="secondary"
+          disabled={nodeModulesExists !== true}
+        >
           Clear node_modules
         </Button>
       </div>

--- a/packages/web/src/components/apps/sidebar.tsx
+++ b/packages/web/src/components/apps/sidebar.tsx
@@ -22,7 +22,6 @@ import FeedbackDialog from '../feedback-dialog';
 import { cn } from '@/lib/utils';
 import ExplorerPanel from './panels/explorer';
 import SettingsPanel from './panels/settings';
-import { useFiles } from './use-files';
 
 export type PanelType = 'explorer' | 'settings';
 

--- a/packages/web/src/components/apps/sidebar.tsx
+++ b/packages/web/src/components/apps/sidebar.tsx
@@ -24,7 +24,7 @@ import ExplorerPanel from './panels/explorer';
 import SettingsPanel from './panels/settings';
 import { useFiles } from './use-files';
 
-type PanelType = 'explorer' | 'settings';
+export type PanelType = 'explorer' | 'settings';
 
 function getTitleForPanel(panel: PanelType | null): string | null {
   switch (panel) {
@@ -37,16 +37,19 @@ function getTitleForPanel(panel: PanelType | null): string | null {
   }
 }
 
-export default function Sidebar() {
+type SidebarProps = {
+  panel: PanelType | null;
+  onChangePanel: (newPanel: PanelType | null) => void;
+};
+
+export default function Sidebar({ panel, onChangePanel }: SidebarProps) {
   const { theme, toggleTheme } = useTheme();
-  const { openedFile } = useFiles();
 
   const [showShortcuts, setShowShortcuts] = useState(false);
   const [showFeedback, setShowFeedback] = useState(false);
-  const [panel, _setPanel] = useState<PanelType | null>(openedFile === null ? 'explorer' : null);
 
   function setPanel(nextPanel: PanelType) {
-    _setPanel(nextPanel === panel ? null : nextPanel);
+    onChangePanel(nextPanel === panel ? null : nextPanel);
   }
 
   return (

--- a/packages/web/src/components/apps/use-package-json.tsx
+++ b/packages/web/src/components/apps/use-package-json.tsx
@@ -1,13 +1,16 @@
-import React, { createContext, useCallback, useContext, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import { OutputType } from '@srcbook/components/src/types';
 import { AppChannel } from '@/clients/websocket';
-import { DepsInstallLogPayloadType, DepsInstallStatusPayloadType } from '@srcbook/shared';
+import { DepsInstallLogPayloadType, DepsInstallStatusPayloadType, DepsStatusResponsePayloadType } from '@srcbook/shared';
 import { useLogs } from './use-logs';
 
 type NpmInstallStatus = 'idle' | 'installing' | 'complete' | 'failed';
 
 export interface PackageJsonContextValue {
   npmInstall: (packages?: string[]) => void;
+  clearNodeModules: () => void;
+
+  nodeModulesExists: boolean;
   status: NpmInstallStatus;
   installing: boolean;
   failed: boolean;
@@ -24,8 +27,24 @@ type ProviderPropsType = {
 export function PackageJsonProvider({ channel, children }: ProviderPropsType) {
   const [status, setStatus] = useState<NpmInstallStatus>('idle');
   const [output, setOutput] = useState<Array<OutputType>>([]);
+  const [nodeModulesExists, setNodeModulesExists] = useState<boolean>(false);
 
   const { addError } = useLogs();
+
+  useEffect(() => {
+    channel.push("deps:status", {});
+  }, [channel]);
+
+  useEffect(() => {
+    const callback = (data: DepsStatusResponsePayloadType) => {
+      setNodeModulesExists(data.nodeModulesExists);
+    };
+    channel.on('deps:status:response', callback);
+
+    return () => {
+      channel.off('deps:status:response', callback);
+    };
+  }, [channel]);
 
   const npmInstall = useCallback(
     (packages?: Array<string>) => {
@@ -57,8 +76,14 @@ export function PackageJsonProvider({ channel, children }: ProviderPropsType) {
     [channel, addError],
   );
 
+  const clearNodeModules = useCallback(() => {
+    channel.push('deps:clear', {});
+  }, [channel]);
+
   const context: PackageJsonContextValue = {
     npmInstall,
+    clearNodeModules,
+    nodeModulesExists,
     status,
     installing: status === 'installing',
     failed: status === 'failed',

--- a/packages/web/src/components/apps/use-package-json.tsx
+++ b/packages/web/src/components/apps/use-package-json.tsx
@@ -10,7 +10,7 @@ export interface PackageJsonContextValue {
   npmInstall: (packages?: string[]) => void;
   clearNodeModules: () => void;
 
-  nodeModulesExists: boolean;
+  nodeModulesExists: boolean | null;
   status: NpmInstallStatus;
   installing: boolean;
   failed: boolean;
@@ -27,7 +27,7 @@ type ProviderPropsType = {
 export function PackageJsonProvider({ channel, children }: ProviderPropsType) {
   const [status, setStatus] = useState<NpmInstallStatus>('idle');
   const [output, setOutput] = useState<Array<OutputType>>([]);
-  const [nodeModulesExists, setNodeModulesExists] = useState<boolean>(false);
+  const [nodeModulesExists, setNodeModulesExists] = useState<boolean | null>(null);
 
   const { addError } = useLogs();
 

--- a/packages/web/src/components/apps/use-package-json.tsx
+++ b/packages/web/src/components/apps/use-package-json.tsx
@@ -87,6 +87,7 @@ export function PackageJsonProvider({ channel, children }: ProviderPropsType) {
 
   const clearNodeModules = useCallback(() => {
     channel.push('deps:clear', {});
+    setOutput([]);
   }, [channel]);
 
   const context: PackageJsonContextValue = {

--- a/packages/web/src/components/apps/use-package-json.tsx
+++ b/packages/web/src/components/apps/use-package-json.tsx
@@ -1,7 +1,11 @@
 import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import { OutputType } from '@srcbook/components/src/types';
 import { AppChannel } from '@/clients/websocket';
-import { DepsInstallLogPayloadType, DepsInstallStatusPayloadType, DepsStatusResponsePayloadType } from '@srcbook/shared';
+import {
+  DepsInstallLogPayloadType,
+  DepsInstallStatusPayloadType,
+  DepsStatusResponsePayloadType,
+} from '@srcbook/shared';
 import { useLogs } from './use-logs';
 
 type NpmInstallStatus = 'idle' | 'installing' | 'complete' | 'failed';
@@ -32,7 +36,7 @@ export function PackageJsonProvider({ channel, children }: ProviderPropsType) {
   const { addError } = useLogs();
 
   useEffect(() => {
-    channel.push("deps:status", {});
+    channel.push('deps:status', {});
   }, [channel]);
 
   useEffect(() => {

--- a/packages/web/src/components/apps/use-preview.tsx
+++ b/packages/web/src/components/apps/use-preview.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
 
 import { AppChannel } from '@/clients/websocket';
 import { PreviewStatusPayloadType } from '@srcbook/shared';
@@ -53,9 +53,9 @@ export function PreviewProvider({ channel, children }: ProviderPropsType) {
     channel.push('preview:start', {});
   }
 
-  function stop() {
+  const stop = useCallback(() => {
     channel.push('preview:stop', {});
-  }
+  }, [channel]);
 
   // If the node_modules directory gets deleted, then stop the preview server
   useEffect(() => {
@@ -63,7 +63,7 @@ export function PreviewProvider({ channel, children }: ProviderPropsType) {
       return;
     }
     stop();
-  }, [nodeModulesExists]);
+  }, [nodeModulesExists, stop]);
 
   // When the page initially loads, start the vite server
   useEffectOnce(() => {

--- a/packages/web/src/components/apps/workspace/editor.tsx
+++ b/packages/web/src/components/apps/workspace/editor.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import { Preview } from './preview';
 import { cn } from '@/lib/utils.ts';
 import { CodeEditor } from '../editor';
-import PackageInstallNote from '../../package-install-note';
+import PackageInstallNote from '../package-install-note';
 
 type EditorProps = {
   tab: EditorHeaderTab;

--- a/packages/web/src/components/apps/workspace/editor.tsx
+++ b/packages/web/src/components/apps/workspace/editor.tsx
@@ -5,9 +5,13 @@ import { Preview } from './preview';
 import { cn } from '@/lib/utils.ts';
 import { CodeEditor } from '../editor';
 
-type EditorProps = { tab: EditorHeaderTab; onChangeTab: (newTab: EditorHeaderTab) => void };
+type EditorProps = {
+  tab: EditorHeaderTab;
+  onChangeTab: (newTab: EditorHeaderTab) => void;
+  onShowPackagesPanel: () => void;
+};
 
-export function Editor({ tab, onChangeTab }: EditorProps) {
+export function Editor({ tab, onChangeTab, onShowPackagesPanel }: EditorProps) {
   const { openedFile, updateFile } = useFiles();
 
   useEffect(() => {
@@ -41,7 +45,7 @@ export function Editor({ tab, onChangeTab }: EditorProps) {
         and causing a flash of unstyled content
         */}
       <div className={cn('w-full h-full', { hidden: tab !== 'preview' })}>
-        <Preview isActive={tab === 'preview'} />
+        <Preview isActive={tab === 'preview'} onShowPackagesPanel={onShowPackagesPanel} />
       </div>
     </div>
   );

--- a/packages/web/src/components/apps/workspace/editor.tsx
+++ b/packages/web/src/components/apps/workspace/editor.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { Preview } from './preview';
 import { cn } from '@/lib/utils.ts';
 import { CodeEditor } from '../editor';
+import PackageInstallNote from '../../package-install-note';
 
 type EditorProps = {
   tab: EditorHeaderTab;
@@ -22,7 +23,9 @@ export function Editor({ tab, onChangeTab, onShowPackagesPanel }: EditorProps) {
   }, [openedFile, onChangeTab]);
 
   return (
-    <div className="grow shrink flex flex-col w-full h-full overflow-hidden">
+    <div className="relative grow shrink flex flex-col w-full h-full overflow-hidden">
+      <PackageInstallNote />
+
       {tab === 'code' ? (
         /* Careful to ensure this div always consumes full height of parent container and only overflows via scroll */
         <div className="w-full flex-1 overflow-auto">

--- a/packages/web/src/components/apps/workspace/preview.tsx
+++ b/packages/web/src/components/apps/workspace/preview.tsx
@@ -4,14 +4,17 @@ import { useEffect, useState } from 'react';
 import { Loader2Icon } from 'lucide-react';
 import { useLogs } from '../use-logs';
 import { Button } from '@srcbook/components/src/components/ui/button';
+import { usePackageJson } from '../use-package-json';
 
 type PropsType = {
   isActive?: boolean;
+  onShowPackagesPanel: () => void;
   className?: string;
 };
 
 export function Preview(props: PropsType) {
   const { url, status, start, lastStoppedError } = usePreview();
+  const { status: npmInstallStatus, nodeModulesExists } = usePackageJson();
   const { togglePane } = useLogs();
 
   const isActive = props.isActive ?? true;
@@ -25,6 +28,36 @@ export function Preview(props: PropsType) {
       setStartAttempted(false);
     }
   }, [isActive, status, start, startAttempted]);
+
+  if (nodeModulesExists === false) {
+    switch (npmInstallStatus) {
+      case "idle":
+      case "complete":
+        break;
+      case "installing":
+        return (
+          <div className={cn('flex justify-center items-center w-full h-full', props.className)}>
+            <div className="flex flex-col gap-6 items-center border border-border p-8 border-dashed rounded-md">
+              <span>Dependencies installing...</span>
+              <Button variant="secondary" onClick={props.onShowPackagesPanel}>
+                View logs
+              </Button>
+            </div>
+          </div>
+        );
+      case "failed":
+        return (
+          <div className={cn('flex justify-center items-center w-full h-full', props.className)}>
+            <div className="flex flex-col gap-6 items-center border border-border p-8 border-dashed rounded-md">
+              <span className="text-red-400">Dependencies installation failed</span>
+              <Button variant="secondary" onClick={togglePane}>
+                Open errors pane
+              </Button>
+            </div>
+          </div>
+        );
+    }
+  }
 
   switch (status) {
     case 'connecting':

--- a/packages/web/src/components/apps/workspace/preview.tsx
+++ b/packages/web/src/components/apps/workspace/preview.tsx
@@ -14,49 +14,27 @@ type PropsType = {
 
 export function Preview(props: PropsType) {
   const { url, status, start, lastStoppedError } = usePreview();
-  const { status: npmInstallStatus, nodeModulesExists } = usePackageJson();
+  const { nodeModulesExists } = usePackageJson();
   const { togglePane } = useLogs();
 
   const isActive = props.isActive ?? true;
 
   const [startAttempted, setStartAttempted] = useState(false);
   useEffect(() => {
-    if (isActive && status === 'stopped' && !startAttempted) {
+    if (isActive && nodeModulesExists && status === 'stopped' && !startAttempted) {
       setStartAttempted(true);
       start();
     } else if (!isActive) {
       setStartAttempted(false);
     }
-  }, [isActive, status, start, startAttempted]);
+  }, [isActive, nodeModulesExists, status, start, startAttempted]);
 
   if (nodeModulesExists === false) {
-    switch (npmInstallStatus) {
-      case "idle":
-      case "complete":
-        break;
-      case "installing":
-        return (
-          <div className={cn('flex justify-center items-center w-full h-full', props.className)}>
-            <div className="flex flex-col gap-6 items-center border border-border p-8 border-dashed rounded-md">
-              <span>Dependencies installing...</span>
-              <Button variant="secondary" onClick={props.onShowPackagesPanel}>
-                View logs
-              </Button>
-            </div>
-          </div>
-        );
-      case "failed":
-        return (
-          <div className={cn('flex justify-center items-center w-full h-full', props.className)}>
-            <div className="flex flex-col gap-6 items-center border border-border p-8 border-dashed rounded-md">
-              <span className="text-red-400">Dependencies installation failed</span>
-              <Button variant="secondary" onClick={togglePane}>
-                Open errors pane
-              </Button>
-            </div>
-          </div>
-        );
-    }
+    return (
+      <div className={cn('flex justify-center items-center w-full h-full', props.className)}>
+        <span className="text-tertiary-foreground">Dependencies not installed</span>
+      </div>
+    );
   }
 
   switch (status) {

--- a/packages/web/src/routes/apps.tsx
+++ b/packages/web/src/routes/apps.tsx
@@ -86,16 +86,12 @@ function Apps() {
         tab={tab}
         onChangeTab={setTab}
         className="shrink-0 h-12 max-h-12"
-        onShowPackagesPanel={() => setPanel("settings")}
+        onShowPackagesPanel={() => setPanel('settings')}
       />
       <div className="h-[calc(100vh-3rem)] flex">
         <Sidebar panel={panel} onChangePanel={setPanel} />
         <div className="grow shrink h-full flex flex-col w-0">
-          <Editor
-            tab={tab}
-            onChangeTab={setTab}
-            onShowPackagesPanel={() => setPanel("settings")}
-          />
+          <Editor tab={tab} onChangeTab={setTab} onShowPackagesPanel={() => setPanel('settings')} />
           <Statusbar />
         </div>
         <ChatPanel triggerDiffModal={triggerDiffModal} />

--- a/packages/web/src/routes/apps.tsx
+++ b/packages/web/src/routes/apps.tsx
@@ -55,13 +55,13 @@ export function AppsPage() {
   return (
     <AppProvider key={app.id} app={app}>
       <FilesProvider channel={channelRef.current} rootDirEntries={rootDirEntries}>
-        <PreviewProvider channel={channelRef.current}>
-          <LogsProvider channel={channelRef.current}>
-            <PackageJsonProvider channel={channelRef.current}>
+        <LogsProvider channel={channelRef.current}>
+          <PackageJsonProvider channel={channelRef.current}>
+            <PreviewProvider channel={channelRef.current}>
               <Apps />
-            </PackageJsonProvider>
-          </LogsProvider>
-        </PreviewProvider>
+            </PreviewProvider>
+          </PackageJsonProvider>
+        </LogsProvider>
       </FilesProvider>
     </AppProvider>
   );

--- a/packages/web/src/routes/apps.tsx
+++ b/packages/web/src/routes/apps.tsx
@@ -15,8 +15,9 @@ import { PackageJsonProvider } from '@/components/apps/use-package-json';
 import { ChatPanel } from '@/components/chat';
 import DiffModal from '@/components/apps/diff-modal';
 import { FileDiffType } from '@srcbook/shared';
-import EditorHeader, { EditorHeaderTab } from '../components/apps/header';
+import EditorHeader, { EditorHeaderTab } from '@/components/apps/header';
 import { AppProvider } from '@/components/apps/use-app';
+import PackageInstallNote from '@/components/apps/package-install-note';
 
 async function loader({ params }: LoaderFunctionArgs) {
   const [{ data: app }, { data: rootDirEntries }] = await Promise.all([

--- a/packages/web/src/routes/apps.tsx
+++ b/packages/web/src/routes/apps.tsx
@@ -3,11 +3,11 @@ import { useLoaderData, type LoaderFunctionArgs } from 'react-router-dom';
 import type { AppType, DirEntryType } from '@srcbook/shared';
 
 import { loadApp, loadDirectory } from '@/clients/http/apps';
-import Sidebar from '@/components/apps/sidebar';
+import Sidebar, { PanelType } from '@/components/apps/sidebar';
 import { useEffect, useRef, useState } from 'react';
 import Statusbar from '@/components/apps/statusbar';
 import { AppChannel } from '@/clients/websocket';
-import { FilesProvider } from '@/components/apps/use-files';
+import { FilesProvider, useFiles } from '@/components/apps/use-files';
 import { Editor } from '@/components/apps/workspace/editor';
 import { PreviewProvider } from '@/components/apps/use-preview';
 import { LogsProvider } from '@/components/apps/use-logs';
@@ -69,6 +69,10 @@ export function AppsPage() {
 
 function Apps() {
   const [tab, setTab] = useState<EditorHeaderTab>('code');
+
+  const { openedFile } = useFiles();
+  const [panel, setPanel] = useState<PanelType | null>(openedFile === null ? 'explorer' : null);
+
   const [diffModalProps, triggerDiffModal] = useState<{
     files: FileDiffType[];
     onUndoAll: () => void;
@@ -77,9 +81,14 @@ function Apps() {
   return (
     <>
       {diffModalProps && <DiffModal {...diffModalProps} onClose={() => triggerDiffModal(null)} />}
-      <EditorHeader tab={tab} onChangeTab={setTab} className="shrink-0 h-12 max-h-12" />
+      <EditorHeader
+        tab={tab}
+        onChangeTab={setTab}
+        className="shrink-0 h-12 max-h-12"
+        onShowPackagesPanel={() => setPanel("settings")}
+      />
       <div className="h-[calc(100vh-3rem)] flex">
-        <Sidebar />
+        <Sidebar panel={panel} onChangePanel={setPanel} />
         <div className="grow shrink h-full flex flex-col w-0">
           <Editor tab={tab} onChangeTab={setTab} />
           <Statusbar />

--- a/packages/web/src/routes/apps.tsx
+++ b/packages/web/src/routes/apps.tsx
@@ -90,7 +90,11 @@ function Apps() {
       <div className="h-[calc(100vh-3rem)] flex">
         <Sidebar panel={panel} onChangePanel={setPanel} />
         <div className="grow shrink h-full flex flex-col w-0">
-          <Editor tab={tab} onChangeTab={setTab} />
+          <Editor
+            tab={tab}
+            onChangeTab={setTab}
+            onShowPackagesPanel={() => setPanel("settings")}
+          />
           <Statusbar />
         </div>
         <ChatPanel triggerDiffModal={triggerDiffModal} />

--- a/packages/web/src/routes/apps.tsx
+++ b/packages/web/src/routes/apps.tsx
@@ -17,7 +17,6 @@ import DiffModal from '@/components/apps/diff-modal';
 import { FileDiffType } from '@srcbook/shared';
 import EditorHeader, { EditorHeaderTab } from '@/components/apps/header';
 import { AppProvider } from '@/components/apps/use-app';
-import PackageInstallNote from '@/components/apps/package-install-note';
 
 async function loader({ params }: LoaderFunctionArgs) {
   const [{ data: app }, { data: rootDirEntries }] = await Promise.all([

--- a/packages/web/tailwind.config.js
+++ b/packages/web/tailwind.config.js
@@ -191,12 +191,17 @@ module.exports = {
           from: { height: 'var(--radix-collapsible-content-height)' },
           to: { height: '0' },
         },
+        indeterminate: {
+          '0%': { transform: 'translateX(-100%)' },
+          '100%': { transform: 'translateX(100%)' },
+        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
         'collapsible-down': 'collapsible-down 1s ease-out',
         'collapsible-up': 'collapsible-up 1s ease-out',
+        indeterminate: 'indeterminate 1s infinite linear',
       },
       typography: {
         DEFAULT: {


### PR DESCRIPTION
This pull request does a few things:
1. Implements (mostly) the package installation states in figma.
2. Adds a new `deps:clean` action that allows the app to remove the `node_modules` directory
  a. I introduced this largely for my own testing. If this isn't actually a good idea to have in the app long term, I can remove it.
4. Adds a new `deps:status` and `deps:status:response` action that allows the app to get information about the installed dependencies. Right now this returns an object with a `nodeModulesExists` key, which is used by the app to determine if the user has installed dependencies yet.
5. Makes some adjustments to the preview tab to take into account this new installation state. Namely, instead of auto installing dependencies like before, it now blocks and the user is expected to click the "install" button in the new popup in the lower left corner.

Note that this still doesn't rename `settings` to `packages` or refine the panel's interface - I ran out of time today. I will get to that on monday! There's also some additional interface guarding work left.


https://github.com/user-attachments/assets/609befb0-b448-4a1a-941c-ddd07ed5a4f1

