### PR TITLE
Add a planId to generations, log generations & user feedback

### DIFF
--- a/packages/api/ai/generate.mts
+++ b/packages/api/ai/generate.mts
@@ -13,7 +13,7 @@ import Path from 'node:path';
 import { PROMPTS_DIR } from '../constants.mjs';
 import { encode, decodeCells } from '../srcmd.mjs';
 import { buildProjectXml, type FileContent } from '../ai/app-parser.mjs';
-import { AppGenerationLog, logAppGeneration } from './logger.mjs';
+import { type AppGenerationLog, logAppGeneration } from './logger.mjs';
 
 const makeGenerateSrcbookSystemPrompt = () => {
   return readFileSync(Path.join(PROMPTS_DIR, 'srcbook-generator.txt'), 'utf-8');

--- a/packages/api/ai/generate.mts
+++ b/packages/api/ai/generate.mts
@@ -280,6 +280,9 @@ export async function editApp(
     llm_request: { model, system: systemPrompt, prompt: userPrompt },
     llm_response: result,
   };
-  logAppGeneration(log);
+
+  if (process.env.SRCBOOK_DISABLE_ANALYTICS !== 'true') {
+    logAppGeneration(log);
+  }
   return result.text;
 }

--- a/packages/api/ai/generate.mts
+++ b/packages/api/ai/generate.mts
@@ -13,6 +13,7 @@ import Path from 'node:path';
 import { PROMPTS_DIR } from '../constants.mjs';
 import { encode, decodeCells } from '../srcmd.mjs';
 import { buildProjectXml, type FileContent } from '../ai/app-parser.mjs';
+import { AppGenerationLog, logAppGeneration } from './logger.mjs';
 
 const makeGenerateSrcbookSystemPrompt = () => {
   return readFileSync(Path.join(PROMPTS_DIR, 'srcbook-generator.txt'), 'utf-8');
@@ -262,6 +263,8 @@ export async function editApp(
   projectId: string,
   files: FileContent[],
   query: string,
+  appId: string,
+  planId: string,
 ): Promise<string> {
   const model = await getModel();
   const systemPrompt = makeAppEditorSystemPrompt();
@@ -271,5 +274,12 @@ export async function editApp(
     system: systemPrompt,
     prompt: userPrompt,
   });
+  const log: AppGenerationLog = {
+    appId,
+    planId,
+    llm_request: { model, system: systemPrompt, prompt: userPrompt },
+    llm_response: result,
+  };
+  logAppGeneration(log);
   return result.text;
 }

--- a/packages/api/ai/logger.mts
+++ b/packages/api/ai/logger.mts
@@ -5,7 +5,14 @@ export type AppGenerationLog = {
   llm_response: any;
 };
 
-async function logAppGeneration(log: AppGenerationLog): Promise<void> {
+/*
+ * Log the LLM request / response to the analytics server.
+ * For now this server is a custom implemention, consider moving to
+ * a formal LLM log service, or a generic log hosting service.
+ * In particular, this will not scale well when we split up app generation into
+ * multiple steps. We will need spans/traces at that point.
+ */
+export async function logAppGeneration(log: AppGenerationLog): Promise<void> {
   try {
     const response = await fetch('https://hub.srcbook.com/api/app_generation_log', {
       method: 'POST',
@@ -22,5 +29,3 @@ async function logAppGeneration(log: AppGenerationLog): Promise<void> {
     console.error('Error sending app generation log:', error);
   }
 }
-
-export { logAppGeneration };

--- a/packages/api/ai/logger.mts
+++ b/packages/api/ai/logger.mts
@@ -1,0 +1,26 @@
+export type AppGenerationLog = {
+  appId: string;
+  planId: string;
+  llm_request: any;
+  llm_response: any;
+};
+
+async function logAppGeneration(log: AppGenerationLog): Promise<void> {
+  try {
+    const response = await fetch('https://hub.srcbook.com/api/app_generation_log', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(log),
+    });
+
+    if (!response.ok) {
+      console.error('Error sending app generation log');
+    }
+  } catch (error) {
+    console.error('Error sending app generation log:', error);
+  }
+}
+
+export { logAppGeneration };

--- a/packages/api/ai/plan-parser.mts
+++ b/packages/api/ai/plan-parser.mts
@@ -64,6 +64,8 @@ type Command = NpmInstallCommand;
 export interface Plan {
   // The high level description of the plan
   // Will be shown to the user above the diff box.
+  id: string;
+  query: string;
   description: string;
   actions: (FileAction | Command)[];
 }
@@ -89,7 +91,12 @@ interface ParsedResult {
   };
 }
 
-export async function parsePlan(response: string, app: DBAppType): Promise<Plan> {
+export async function parsePlan(
+  response: string,
+  app: DBAppType,
+  query: string,
+  planId: string,
+): Promise<Plan> {
   try {
     const parser = new XMLParser({
       ignoreAttributes: false,
@@ -102,7 +109,12 @@ export async function parsePlan(response: string, app: DBAppType): Promise<Plan>
       throw new Error('Invalid response: missing plan tag');
     }
 
-    const plan: Plan = { actions: [], description: result.plan.planDescription };
+    const plan: Plan = {
+      id: planId,
+      query,
+      actions: [],
+      description: result.plan.planDescription,
+    };
     const actions = Array.isArray(result.plan.action) ? result.plan.action : [result.plan.action];
 
     for (const action of actions) {

--- a/packages/api/apps/app.mts
+++ b/packages/api/apps/app.mts
@@ -51,7 +51,7 @@ export async function createAppWithAi(data: CreateAppWithAiSchemaType): Promise<
 
   const files = await getFlatFilesForApp(app.externalId);
   const result = await generateApp(toValidPackageName(app.name), files, data.prompt);
-  const plan = await parsePlan(result, app);
+  const plan = await parsePlan(result, app, data.prompt, randomid());
   await applyPlan(app, plan);
 
   // Run npm install again since we don't have a good way of parsing the plan to know if we should...

--- a/packages/api/server/http.mts
+++ b/packages/api/server/http.mts
@@ -60,6 +60,7 @@ import {
   getFlatFilesForApp,
 } from '../apps/disk.mjs';
 import { CreateAppSchema } from '../apps/schemas.mjs';
+import { AppGenerationFeedbackType } from '@srcbook/shared';
 
 const app: Application = express();
 
@@ -551,7 +552,7 @@ router.post('/apps/:id/edit', cors(), async (req, res) => {
     }
     const validName = toValidPackageName(app.name);
     const files = await getFlatFilesForApp(String(app.externalId));
-    const result = await editApp(validName, files, query);
+    const result = await editApp(validName, files, query, id, planId);
     const parsedResult = await parsePlan(result, app, query, planId);
     return res.json({ data: parsedResult });
   } catch (e) {
@@ -731,4 +732,38 @@ router.post('/apps/:id/history', cors(), async (req, res) => {
   const { messages } = req.body;
   await appendToHistory(id, messages);
   return res.json({ data: { success: true } });
+});
+
+router.options('/apps/:id/feedback', cors());
+router.post('/apps/:id/feedback', cors(), async (req, res) => {
+  const { id } = req.params;
+  const { planId, feedback } = req.body as AppGenerationFeedbackType;
+  // check for privacy env var SRCBOOK_DISABLE_ANALYTICS and return 403 if true
+  if (process.env.SRCBOOK_DISABLE_ANALYTICS === 'true') {
+    return res.status(403).json({ error: 'Analytics are disabled' });
+  }
+
+  try {
+    const response = await fetch('https://hub.srcbook.com/api/app_generation_feedback', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        appId: id,
+        planId,
+        feedback,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const result = await response.json();
+    return res.json(result);
+  } catch (error) {
+    console.error('Error sending feedback:', error);
+    return res.status(500).json({ error: 'Failed to send feedback' });
+  }
 });

--- a/packages/api/server/http.mts
+++ b/packages/api/server/http.mts
@@ -738,7 +738,7 @@ router.options('/apps/:id/feedback', cors());
 router.post('/apps/:id/feedback', cors(), async (req, res) => {
   const { id } = req.params;
   const { planId, feedback } = req.body as AppGenerationFeedbackType;
-  // check for privacy env var SRCBOOK_DISABLE_ANALYTICS and return 403 if true
+
   if (process.env.SRCBOOK_DISABLE_ANALYTICS === 'true') {
     return res.status(403).json({ error: 'Analytics are disabled' });
   }

--- a/packages/api/server/http.mts
+++ b/packages/api/server/http.mts
@@ -542,7 +542,7 @@ router.get('/apps/:id/directories', cors(), async (req, res) => {
 router.options('/apps/:id/edit', cors());
 router.post('/apps/:id/edit', cors(), async (req, res) => {
   const { id } = req.params;
-  const { query } = req.body;
+  const { query, planId } = req.body;
   try {
     const app = await loadApp(id);
 
@@ -552,7 +552,7 @@ router.post('/apps/:id/edit', cors(), async (req, res) => {
     const validName = toValidPackageName(app.name);
     const files = await getFlatFilesForApp(String(app.externalId));
     const result = await editApp(validName, files, query);
-    const parsedResult = await parsePlan(result, app);
+    const parsedResult = await parsePlan(result, app, query, planId);
     return res.json({ data: parsedResult });
   } catch (e) {
     return error500(res, e as Error);

--- a/packages/api/test/plan-parser.test.mts
+++ b/packages/api/test/plan-parser.test.mts
@@ -111,8 +111,10 @@ export default App;
 
 describe('parsePlan', () => {
   test('should correctly parse a plan with file and command actions', async () => {
-    const plan = await parsePlan(mockXMLResponse, mockApp);
+    const plan = await parsePlan(mockXMLResponse, mockApp, 'test query', '123445');
 
+    expect(plan.id).toBe('123445');
+    expect(plan.query).toBe('test query');
     expect(plan.description).toBe('Implement a basic todo list app');
     expect(plan.actions).toHaveLength(2);
 

--- a/packages/shared/index.mts
+++ b/packages/shared/index.mts
@@ -8,5 +8,6 @@ export * from './src/types/tsserver.mjs';
 export * from './src/types/history.mjs';
 export * from './src/types/websockets.mjs';
 export * from './src/types/secrets.mjs';
+export * from './src/types/feedback.mjs';
 export * from './src/utils.mjs';
 export * from './src/ai.mjs';

--- a/packages/shared/src/types/feedback.mts
+++ b/packages/shared/src/types/feedback.mts
@@ -1,0 +1,4 @@
+export type AppGenerationFeedbackType = {
+  planId: string;
+  feedback: any;
+};

--- a/packages/shared/src/types/history.mts
+++ b/packages/shared/src/types/history.mts
@@ -12,24 +12,29 @@ export type FileDiffType = {
 export type UserMessageType = {
   type: 'user';
   message: string;
+  planId: string;
 };
 
-type NpmInstallCommand = {
+export type NpmInstallCommand = {
   type: 'command';
   command: 'npm install';
   packages: string[];
   description: string;
 };
 
-export type CommandMessageType = NpmInstallCommand;
+export type CommandMessageType = NpmInstallCommand & {
+  planId: string;
+};
 
 export type DiffMessageType = {
   type: 'diff';
+  planId: string;
   diff: FileDiffType[];
 };
 
 export type PlanMessageType = {
   type: 'plan';
+  planId: string;
   content: string;
 };
 

--- a/packages/web/src/clients/http/apps.ts
+++ b/packages/web/src/clients/http/apps.ts
@@ -1,4 +1,10 @@
-import type { AppType, DirEntryType, FileEntryType, FileType } from '@srcbook/shared';
+import type {
+  AppGenerationFeedbackType,
+  AppType,
+  DirEntryType,
+  FileEntryType,
+  FileType,
+} from '@srcbook/shared';
 import SRCBOOK_CONFIG from '@/config';
 import type { PlanType } from '@/components/apps/types';
 import type { HistoryType, MessageType } from '@srcbook/shared';
@@ -262,6 +268,15 @@ export async function appendToHistory(id: string, messages: MessageType | Messag
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ messages }),
+  });
+  return response.json();
+}
+
+export async function aiGenerationFeedback(id: string, feedback: AppGenerationFeedbackType) {
+  const response = await fetch(API_BASE_URL + `/apps/${id}/feedback`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(feedback),
   });
   return response.json();
 }

--- a/packages/web/src/clients/http/apps.ts
+++ b/packages/web/src/clients/http/apps.ts
@@ -224,11 +224,15 @@ export async function renameFile(
   return response.json();
 }
 
-export async function aiEditApp(id: string, query: string): Promise<{ data: PlanType }> {
+export async function aiEditApp(
+  id: string,
+  query: string,
+  planId: string,
+): Promise<{ data: PlanType }> {
   const response = await fetch(API_BASE_URL + `/apps/${id}/edit`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ query }),
+    body: JSON.stringify({ query, planId }),
   });
 
   if (!response.ok) {

--- a/packages/web/src/components/apps/AiFeedbackModal.tsx
+++ b/packages/web/src/components/apps/AiFeedbackModal.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@srcbook/components';
+import TextareaAutosize from 'react-textarea-autosize';
+
+interface AiFeedbackModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (feedback: string) => void;
+}
+
+export function AiFeedbackModal({ isOpen, onClose, onSubmit }: AiFeedbackModalProps) {
+  const [feedback, setFeedback] = React.useState('');
+
+  const handleSubmit = () => {
+    onSubmit(feedback);
+    setFeedback('');
+    onClose();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Provide Feedback</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <TextareaAutosize
+            placeholder="Tell us more about what went wrong..."
+            className="flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            value={feedback}
+            onChange={(e) => setFeedback(e.target.value)}
+            onKeyDown={handleKeyDown}
+            minRows={3}
+            maxRows={10}
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit}>Submit Feedback</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web/src/components/apps/types.ts
+++ b/packages/web/src/components/apps/types.ts
@@ -14,6 +14,8 @@ export type FileType = {
 export type PlanItemType = FileType | CommandMessageType;
 
 export type PlanType = {
+  id: string;
+  query: string;
   description: string;
   actions: Array<PlanItemType>;
 };

--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -9,6 +9,7 @@ import {
 import Markdown from './apps/markdown.js';
 import { diffFiles } from './apps/lib/diff.js';
 import TextareaAutosize from 'react-textarea-autosize';
+import { toast } from 'sonner';
 import {
   ArrowUp,
   Minus,
@@ -25,7 +26,12 @@ import {
   ThumbsDown,
 } from 'lucide-react';
 import * as React from 'react';
-import { aiEditApp, loadHistory, appendToHistory } from '@/clients/http/apps.js';
+import {
+  aiEditApp,
+  loadHistory,
+  appendToHistory,
+  aiGenerationFeedback,
+} from '@/clients/http/apps.js';
 import { AppType, randomid } from '@srcbook/shared';
 import { useFiles } from './apps/use-files';
 import { type FileType } from './apps/types';
@@ -285,13 +291,22 @@ function DiffBox({
           aria-label="Upvote"
           onClick={() => console.log('upvote', planId)}
         >
-          <ThumbsUp size={18} />
+          <ThumbsUp
+            size={18}
+            onClick={() => {
+              aiGenerationFeedback(app.id, { planId, feedback: { type: 'positive' } });
+              toast.success('thanks for the feedback!');
+            }}
+          />
         </Button>
         <Button
           variant="icon"
           className="h-7 w-7 p-1.5 border-none text-tertiary-foreground"
           aria-label="Downvote"
-          onClick={() => console.log('downvote', planId)}
+          onClick={() => {
+            aiGenerationFeedback(app.id, { planId, feedback: { type: 'negative' } });
+            toast.success('Thanks for the feedback!');
+          }}
         >
           <ThumbsDown size={18} />
         </Button>


### PR DESCRIPTION
We want to save logs of our AI generations, so we can improve the accuracy over time with prompt and architecture improvements.

For this, we implement an architecture which does 2 things:
- if analytics are enabled, send LLM generation log to our logging API
- if user clicks thumbs up / thumbs down, send that to our feedback API with a reference to the log

Note: this could leverage a third party tool like langsmith, traceloop et. al, but I don't want to commit to one of these yet and it's not particularly hard to log (what's not ideal is that we don't have a standardized logging system).

This PR also adds a modal for users to be able to give more context in the case of a negative thumbs down action 
![CleanShot 2024-10-21 at 10 34 03](https://github.com/user-attachments/assets/a4b83d55-5edc-4cb2-b666-280cf03e3d05)
