### PR TITLE
Improve logs and preview server behavior

### DIFF
--- a/packages/shared/src/schemas/websockets.mts
+++ b/packages/shared/src/schemas/websockets.mts
@@ -168,8 +168,7 @@ export const PreviewStatusPayloadSchema = z.union([
   z.object({
     url: z.string().nullable(),
     status: z.literal('stopped'),
-    stoppedSuccessfully: z.boolean(),
-    logs: z.string().nullable(),
+    code: z.number().int().nullable(),
   }),
 ]);
 

--- a/packages/web/src/components/apps/use-logs.tsx
+++ b/packages/web/src/components/apps/use-logs.tsx
@@ -5,7 +5,7 @@ import { DepsInstallLogPayloadType, PreviewLogPayloadType } from '@srcbook/share
 
 export type LogMessage = {
   type: 'stderr' | 'stdout' | 'info';
-  source: 'vite' | 'npm install';
+  source: 'srcbook' | 'vite' | 'npm';
   timestamp: Date;
   message: string;
 };
@@ -78,7 +78,7 @@ export function LogsProvider({ channel, children }: ProviderPropsType) {
 
     function onDepsInstallLog(payload: DepsInstallLogPayloadType) {
       for (const row of payload.log.data.split('\n')) {
-        addLog(payload.log.type, 'npm install', row);
+        addLog(payload.log.type, 'npm', row);
       }
     }
     channel.on('deps:install:log', onDepsInstallLog);

--- a/packages/web/src/components/apps/use-package-json.tsx
+++ b/packages/web/src/components/apps/use-package-json.tsx
@@ -56,7 +56,7 @@ export function PackageJsonProvider({ channel, children }: ProviderPropsType) {
     async (packages?: Array<string>) => {
       addLog(
         'info',
-        'npm install',
+        'npm',
         `Running ${!packages ? 'npm install' : `npm install ${packages.join(' ')}`}`,
       );
 
@@ -78,7 +78,7 @@ export function PackageJsonProvider({ channel, children }: ProviderPropsType) {
 
           addLog(
             'info',
-            'npm install',
+            'npm',
             `${!packages ? 'npm install' : `npm install ${packages.join(' ')}`} exited with status code ${code}`,
           );
 

--- a/packages/web/src/routes/apps/preview.tsx
+++ b/packages/web/src/routes/apps/preview.tsx
@@ -15,7 +15,7 @@ export default function AppPreview() {
 }
 
 function Preview() {
-  const { url, status, start, lastStoppedError } = usePreview();
+  const { url, status, start, exitCode } = usePreview();
   const { nodeModulesExists } = usePackageJson();
   const { togglePane } = useLogs();
 
@@ -56,11 +56,11 @@ function Preview() {
     case 'stopped':
       return (
         <div className="flex justify-center items-center w-full h-full">
-          {lastStoppedError === null ? (
-            <span className="text-tertiary-foreground">Stopped preview server.</span>
+          {exitCode === null || exitCode === 0 ? (
+            <span className="text-tertiary-foreground">Dev server is stopped.</span>
           ) : (
             <div className="flex flex-col gap-6 items-center border border-border p-8 border-dashed rounded-md">
-              <span className="text-red-400">Preview server stopped with an error!</span>
+              <span className="text-red-400">Dev server exited with an error.</span>
               <Button variant="secondary" onClick={togglePane}>
                 Open errors pane
               </Button>


### PR DESCRIPTION
When playing around with the app, I saw some vite dev server behavior I wasn't sure on and then the logs (somewhat lacking) made it more confusing to me. I wasn't sure if we had tried to re-boot it, or what. I also didn't see anything about it shutting down. Then I noticed some websocket events were firing multiple times.

This PR:

1. Removes the duplicated websocket events
2. Fixes a bug where we are replying to a specific connection rather than broadcasting during the lifetime of a running preview server. This has a couple issues:
    1. That connection may no longer exist (e.g., user refreshes page)
    2. This would only forward output to one client. If I have multiple tabs open, I wouldn't see the output in the other tab(s).
3. Adds consistent logging for the preview server states (booting, running, stopping)
4. Cleans the logs. Adds a "srcbook" source to differentiate from vite or other output.

### Initial boot
<img width="1380" alt="Screenshot 2024-10-21 at 9 05 14 PM" src="https://github.com/user-attachments/assets/89b34e75-6d06-4f99-933e-3dfc0f8d8342">

### Stopped the server which caused it to auto-restart
<img width="1380" alt="Screenshot 2024-10-21 at 9 05 43 PM" src="https://github.com/user-attachments/assets/d4f6ec5a-ac4e-4187-a96b-0f2d0fb002a5">

