### PR TITLE
Make WebSocket subscriptions receive ack to be considered subscribed

### DIFF
--- a/packages/api/server/channels/app.mts
+++ b/packages/api/server/channels/app.mts
@@ -138,6 +138,9 @@ async function previewStop(
     return;
   }
 
+  // Killing the process should result in its onExit handler being called.
+  // The onExit handler will remove the process from the processMetadata map
+  // and send the `preview:status` event with a value of 'stopped'
   result.process.kill('SIGTERM');
 }
 

--- a/packages/api/server/ws-client.mts
+++ b/packages/api/server/ws-client.mts
@@ -213,6 +213,7 @@ export default class WebSocketServer {
 
     if (event === 'subscribe') {
       conn.subscriptions.push(topic);
+      conn.reply(topic, 'subscribed', { id: payload.id });
       channel.onJoinCallback(topic, conn.socket);
       return;
     }

--- a/packages/web/src/components/apps/use-app.tsx
+++ b/packages/web/src/components/apps/use-app.tsx
@@ -21,19 +21,18 @@ export function AppProvider({ app: initialApp, children }: ProviderPropsType) {
 
   const channelRef = useRef(AppChannel.create(app.id));
 
-  // This is only meant to be run one time, when the component mounts.
   useEffect(() => {
-    channelRef.current.subscribe();
-    return () => channelRef.current.unsubscribe();
-  }, []);
-
-  useEffect(() => {
-    if (app.id === channelRef.current.appId) {
-      return;
+    // If the app ID has changed, create a new channel for the new app.
+    if (channelRef.current.appId !== app.id) {
+      channelRef.current.unsubscribe();
+      channelRef.current = AppChannel.create(app.id);
     }
 
-    channelRef.current.unsubscribe();
-    channelRef.current = AppChannel.create(app.id);
+    // Subscribe to the channel
+    channelRef.current.subscribe();
+
+    // Unsubscribe when the component is unmounted
+    return () => channelRef.current.unsubscribe();
   }, [app.id]);
 
   async function updateApp(attrs: { name: string }) {


### PR DESCRIPTION
This allows us to implement logic where we only send events once the server has confirmed our subscription. This ensures that the server will not try to broadcast something before we're subscribed, leading to events that never make it to the client.

This probably mostly only happens in dev because of the mounting/unmounting/remounting resulting in useEffect running multiple times initially. There's a small window where events can get dropped in that. In a production build, it's more unlikely we'd have issues here, but this is good in either case as subscriptions really should be acknowledged by the server before we start sending events.