### PR TITLE
`npm install` should always include sockets messages

### DIFF
--- a/packages/api/server/channels/app.mts
+++ b/packages/api/server/channels/app.mts
@@ -50,11 +50,16 @@ async function previewStart(
   const existingProcess = processMetadata.get(app.externalId);
 
   if (existingProcess) {
-    wss.broadcast(`app:${app.externalId}`, 'preview:status', {
-      status: 'running',
-      url: `http://localhost:${existingProcess.port}/`,
-    });
-    return;
+    if (existingProcess.port === null) {
+      existingProcess.process.kill('SIGTERM');
+      processMetadata.delete(app.externalId);
+    } else {
+      wss.broadcast(`app:${app.externalId}`, 'preview:status', {
+        status: 'running',
+        url: `http://localhost:${existingProcess.port}/`,
+      });
+      return;
+    }
   }
 
   wss.broadcast(`app:${app.externalId}`, 'preview:status', {

--- a/packages/web/src/components/apps/package-install-toast.tsx
+++ b/packages/web/src/components/apps/package-install-toast.tsx
@@ -33,6 +33,8 @@ const PackageInstallToast: React.FunctionComponent = () => {
   useEffect(() => {
     if (nodeModulesExists === false && (status === 'idle' || status === 'complete')) {
       setShowToast(true);
+    } else if (nodeModulesExists === true) {
+      setShowToast(false);
     }
   }, [nodeModulesExists, status]);
 

--- a/packages/web/src/components/apps/use-package-json.tsx
+++ b/packages/web/src/components/apps/use-package-json.tsx
@@ -52,6 +52,17 @@ export function PackageJsonProvider({ channel, children }: ProviderPropsType) {
     };
   }, [channel]);
 
+  useEffect(() => {
+    const callback = ({ status }: DepsInstallStatusPayloadType) => {
+      setStatus(status);
+    };
+    channel.on('deps:install:status', callback);
+
+    return () => {
+      channel.off('deps:install:status', callback);
+    };
+  }, [channel]);
+
   const npmInstall = useCallback(
     async (packages?: Array<string>) => {
       addLog(
@@ -74,7 +85,6 @@ export function PackageJsonProvider({ channel, children }: ProviderPropsType) {
         const statusCallback = ({ status, code }: DepsInstallStatusPayloadType) => {
           channel.off('deps:install:log', logCallback);
           channel.off('deps:install:status', statusCallback);
-          setStatus(status);
 
           addLog(
             'info',

--- a/packages/web/src/components/apps/use-preview.tsx
+++ b/packages/web/src/components/apps/use-preview.tsx
@@ -56,9 +56,10 @@ export function PreviewProvider({ channel, children }: ProviderPropsType) {
   }, [channel, addLog]);
 
   async function start() {
-    if (nodeModulesExists === false) {
-      await npmInstall();
-    }
+    // NOTE: only run this if status !== 'installing' maybe?
+    // if (nodeModulesExists === false) {
+    //   await npmInstall();
+    // }
     channel.push('preview:start', {});
   }
 


### PR DESCRIPTION
This change includes:
- Adding socket broadcasts for all npm installs globally in the app
- Making sure that if a process has a null port to not send that to the client, kill+restart it instead
  - I've noticed even with ben's recent change some situations where a `null` port makes its way to the client, so I'm hoping this makes that case impossible.
- Hide the installation toast when a server driven npm install finishes
- Temporarily disable npm install when starting the app: This is to eliminate possible cases as part of some experimentation
  - This should be undone before this change gets merged!