### PR TITLE
Add changeset for srcbook

### DIFF
--- a/.changeset/nine-tools-ring.md
+++ b/.changeset/nine-tools-ring.md
@@ -1,0 +1,5 @@
+---
+'srcbook': patch
+---
+
+Ability to open vite app in new tab. Better package management on app creation


### PR DESCRIPTION
Added it previously for @srcbook/web but not srcbook. Since srcbook does not depend on web, this doesn't get auto-propagated, so made a new patch.