### PR TITLE
More robust process handling for apps

### DIFF
--- a/packages/api/apps/processes.mts
+++ b/packages/api/apps/processes.mts
@@ -1,0 +1,99 @@
+import { ChildProcess } from 'node:child_process';
+import { pathToApp } from './disk.mjs';
+import { npmInstall as execNpmInstall, vite as execVite } from '../exec.mjs';
+
+export type ProcessType = 'npm:install' | 'vite:server';
+
+export interface NpmInstallProcessType {
+  type: 'npm:install';
+  process: ChildProcess;
+}
+
+export interface ViteServerProcessType {
+  type: 'vite:server';
+  process: ChildProcess;
+  port: number | null;
+}
+
+export type AppProcessType = NpmInstallProcessType | ViteServerProcessType;
+
+class Processes {
+  private map: Map<string, AppProcessType> = new Map();
+
+  has(appId: string, type: ProcessType) {
+    return this.map.has(this.toKey(appId, type));
+  }
+
+  get(appId: string, type: ProcessType) {
+    return this.map.get(this.toKey(appId, type));
+  }
+
+  set(appId: string, process: AppProcessType) {
+    this.map.set(this.toKey(appId, process.type), process);
+  }
+
+  del(appId: string, type: ProcessType) {
+    return this.map.delete(this.toKey(appId, type));
+  }
+
+  private toKey(appId: string, type: ProcessType) {
+    return `${appId}:${type}`;
+  }
+}
+
+const processes = new Processes();
+
+export function getAppProcess(appId: string, type: 'npm:install'): NpmInstallProcessType;
+export function getAppProcess(appId: string, type: 'vite:server'): ViteServerProcessType;
+export function getAppProcess(appId: string, type: ProcessType): AppProcessType {
+  switch (type) {
+    case 'npm:install':
+      return processes.get(appId, type) as NpmInstallProcessType;
+    case 'vite:server':
+      return processes.get(appId, type) as ViteServerProcessType;
+  }
+}
+
+export function setAppProcess(appId: string, process: AppProcessType) {
+  processes.set(appId, process);
+}
+
+export function deleteAppProcess(appId: string, process: ProcessType) {
+  processes.del(appId, process);
+}
+
+/**
+ * Runs npm install for the given app.
+ *
+ * If there's already a process running npm install, it will return that process.
+ */
+export function npmInstall(
+  appId: string,
+  options: Omit<Parameters<typeof execNpmInstall>[0], 'cwd'>,
+) {
+  if (!processes.has(appId, 'npm:install')) {
+    processes.set(appId, {
+      type: 'npm:install',
+      process: execNpmInstall({ cwd: pathToApp(appId), ...options }),
+    });
+  }
+
+  return processes.get(appId, 'npm:install');
+}
+
+/**
+ * Runs a vite dev server for the given app.
+ *
+ * If there's already a process running the vite dev server, it will return that process.
+ */
+export function viteServer(appId: string, options: Omit<Parameters<typeof execVite>[0], 'cwd'>) {
+  if (!processes.has(appId, 'vite:server')) {
+    processes.set(appId, {
+      type: 'vite:server',
+      process: execVite({ cwd: pathToApp(appId), ...options }),
+      port: null,
+    });
+  }
+
+  return processes.get(appId, 'vite:server');
+}

--- a/packages/api/exec.mts
+++ b/packages/api/exec.mts
@@ -45,10 +45,12 @@ export function spawnCall(options: SpawnCallRequestType) {
   child.stdout.on('data', stdout);
   child.stderr.on('data', stderr);
 
-  // Ensure we always listen to this event even if it is a noop
-  // because it can fail without a callback here in some cases.
   child.on('error', (err) => {
-    onError && onError(err);
+    if (onError) {
+      onError(err);
+    } else {
+      console.error(err);
+    }
   });
 
   child.on('exit', (code, signal) => {

--- a/packages/api/server/channels/app.mts
+++ b/packages/api/server/channels/app.mts
@@ -125,13 +125,13 @@ async function previewStart(
       // Make sure we clean up the app process and inform the client.
       deleteAppProcess(app.externalId, 'vite:server');
 
-      if (error.code === 'ENOENT') {
-        wss.broadcast(`app:${app.externalId}`, 'preview:status', {
-          url: null,
-          status: 'stopped',
-          code: null,
-        });
-      }
+      // TODO: Use a different event to communicate to the client there was an error.
+      // If the error is ENOENT, for example, it means node_modules and/or vite is missing.
+      wss.broadcast(`app:${app.externalId}`, 'preview:status', {
+        url: null,
+        status: 'stopped',
+        code: null,
+      });
     },
   });
 }

--- a/packages/api/server/channels/app.mts
+++ b/packages/api/server/channels/app.mts
@@ -120,7 +120,7 @@ async function previewStart(
         code: code,
       });
     },
-    onError: (error) => {
+    onError: (_error) => {
       // Errors happen when we try to run vite before node modules are installed.
       // Make sure we clean up the app process and inform the client.
       deleteAppProcess(app.externalId, 'vite:server');

--- a/packages/web/src/components/apps/use-package-json.tsx
+++ b/packages/web/src/components/apps/use-package-json.tsx
@@ -56,8 +56,8 @@ export function PackageJsonProvider({ channel, children }: ProviderPropsType) {
     async (packages?: Array<string>) => {
       addLog(
         'info',
-        'npm',
-        `Running ${!packages ? 'npm install' : `npm install ${packages.join(' ')}`}`,
+        'srcbook',
+        `Running ${!packages ? 'npm install' : `npm install ${packages.join(' ')}`}...`,
       );
 
       // NOTE: caching of the log output is required here because socket events that call callback
@@ -78,7 +78,7 @@ export function PackageJsonProvider({ channel, children }: ProviderPropsType) {
 
           addLog(
             'info',
-            'npm',
+            'srcbook',
             `${!packages ? 'npm install' : `npm install ${packages.join(' ')}`} exited with status code ${code}`,
           );
 


### PR DESCRIPTION
This PR:

- [x] Stores all app-related processes (npm install, vite dev server) in a more robust map. We can use this to synchronize calls and ensure we only have one process for each running at any given time.
- [x] Fixes the following bug: Preview server doesn't run because no node_modules yet. When this happens, the child process emits an `error` event (containing an error with code 'ENOENT') but no `exit` event. Since it doesn't emit `exit`, we don't call the `onExit` handler and therefore never remove the process from the process map. Subsequent calls to start the server won't work because the process map thinks there's an existing process for the vite server, but that process is dead and never ran. Because it never ran, the port is null and thus we see `locahost:null` as the URL for the dev server.

### TODO

The following still needs to be addressed but will do so in subsequent PR(s)

- [ ] We should either A) remove the [npm install calls in apps.mts](https://github.com/srcbookdev/srcbook/blob/main/packages/api/apps/app.mts#L39-L100) and let the client handle all installing or B) kick off npm install when the app is created on the backend and hook into the process map introduced in this PR ensuring we synchronize npm installs (sketch for this approach is here: https://github.com/srcbookdev/srcbook/pull/412)
- [ ] The client is a bit buggy with npm install calls, sometimes when the npm install toast prompts me, I install and after install finishes (even successfully), i immediately get prompted to install again. I can reproduce this by allowing non AI apps to be created (no prompt in create modal) and also remove the install call in apps.mts.
- [ ] I occasionally still see npm install failing. When this happens, the app gets into a bad state. With this PR, if I re-run npm install on the client, the dev server and other things seem to start working again. But we need to figure out why npm installs fail sometimes