### PR TITLE
Ensure socket messages are always sent for all npm installs

### DIFF
--- a/packages/api/apps/app.mts
+++ b/packages/api/apps/app.mts
@@ -4,7 +4,7 @@ import { type App as DBAppType, apps as appsTable } from '../db/schema.mjs';
 import { applyPlan, createViteApp, deleteViteApp, getFlatFilesForApp } from './disk.mjs';
 import { CreateAppSchemaType, CreateAppWithAiSchemaType } from './schemas.mjs';
 import { asc, desc, eq } from 'drizzle-orm';
-import { npmInstall, waitForProcessToComplete } from './processes.mjs';
+import { npmInstall } from './processes.mjs';
 import { generateApp } from '../ai/generate.mjs';
 import { toValidPackageName } from '../apps/utils.mjs';
 import { getPackagesToInstall, parsePlan } from '../ai/plan-parser.mjs';
@@ -56,7 +56,7 @@ export async function createAppWithAi(data: CreateAppWithAiSchemaType): Promise<
   const packagesToInstall = getPackagesToInstall(plan);
 
   if (packagesToInstall.length > 0) {
-    await waitForProcessToComplete(firstNpmInstallProcess);
+    await firstNpmInstallProcess;
 
     console.log('installing packages', packagesToInstall);
     npmInstall(app.externalId, {

--- a/packages/api/apps/app.mts
+++ b/packages/api/apps/app.mts
@@ -1,10 +1,10 @@
 import { randomid, type AppType } from '@srcbook/shared';
 import { db } from '../db/index.mjs';
 import { type App as DBAppType, apps as appsTable } from '../db/schema.mjs';
-import { applyPlan, createViteApp, deleteViteApp, pathToApp, getFlatFilesForApp } from './disk.mjs';
+import { applyPlan, createViteApp, deleteViteApp, getFlatFilesForApp } from './disk.mjs';
 import { CreateAppSchemaType, CreateAppWithAiSchemaType } from './schemas.mjs';
 import { asc, desc, eq } from 'drizzle-orm';
-import { npmInstall } from '../exec.mjs';
+import { deleteAppProcess, npmInstall, waitForProcessToComplete } from './processes.mjs';
 import { generateApp } from '../ai/generate.mjs';
 import { toValidPackageName } from '../apps/utils.mjs';
 import { getPackagesToInstall, parsePlan } from '../ai/plan-parser.mjs';
@@ -36,8 +36,7 @@ export async function createAppWithAi(data: CreateAppWithAiSchemaType): Promise<
   await createViteApp(app);
   // Note: we don't surface issues or retries and this is "running in the background".
   // In this case it works in our favor because we'll kickoff generation while it happens
-  npmInstall({
-    cwd: pathToApp(app.externalId),
+  const firstNpmInstallProcess = npmInstall(app.externalId, {
     stdout(data) {
       console.log(data.toString('utf8'));
     },
@@ -46,6 +45,9 @@ export async function createAppWithAi(data: CreateAppWithAiSchemaType): Promise<
     },
     onExit(code) {
       console.log(`npm install exit code: ${code}`);
+
+      // We must clean up this process so that we can run npm install again
+      deleteAppProcess(app.externalId, 'npm:install');
     },
   });
 
@@ -57,9 +59,10 @@ export async function createAppWithAi(data: CreateAppWithAiSchemaType): Promise<
   const packagesToInstall = getPackagesToInstall(plan);
 
   if (packagesToInstall.length > 0) {
+    await waitForProcessToComplete(firstNpmInstallProcess);
+
     console.log('installing packages', packagesToInstall);
-    npmInstall({
-      cwd: pathToApp(app.externalId),
+    npmInstall(app.externalId, {
       packages: packagesToInstall,
       stdout(data) {
         console.log(data.toString('utf8'));
@@ -69,6 +72,9 @@ export async function createAppWithAi(data: CreateAppWithAiSchemaType): Promise<
       },
       onExit(code) {
         console.log(`npm install exit code: ${code}`);
+
+        // We must clean up this process so that we can run npm install again
+        deleteAppProcess(app.externalId, 'npm:install');
       },
     });
   }
@@ -86,8 +92,7 @@ export async function createApp(data: CreateAppSchemaType): Promise<DBAppType> {
   // TODO: handle this better.
   // This should be done somewhere else and surface issues or retries.
   // Not awaiting here because it's "happening in the background".
-  npmInstall({
-    cwd: pathToApp(app.externalId),
+  npmInstall(app.externalId, {
     stdout(data) {
       console.log(data.toString('utf8'));
     },
@@ -96,6 +101,9 @@ export async function createApp(data: CreateAppSchemaType): Promise<DBAppType> {
     },
     onExit(code) {
       console.log(`npm install exit code: ${code}`);
+
+      // We must clean up this process so that we can run npm install again
+      deleteAppProcess(app.externalId, 'npm:install');
     },
   });
 

--- a/packages/api/apps/processes.mts
+++ b/packages/api/apps/processes.mts
@@ -121,7 +121,7 @@ export function npmInstall(
           options.stderr(data);
         }
       },
-      onExit: (code) => {
+      onExit: (code, signal) => {
         // We must clean up this process so that we can run npm install again
         deleteAppProcess(appId, 'npm:install');
 
@@ -134,6 +134,10 @@ export function npmInstall(
           wss.broadcast(`app:${appId}`, 'deps:status:response', {
             nodeModulesExists: true,
           });
+        }
+
+        if (options.onExit) {
+          options.onExit(code, signal);
         }
       },
     }),

--- a/packages/api/apps/processes.mts
+++ b/packages/api/apps/processes.mts
@@ -1,6 +1,7 @@
 import { ChildProcess } from 'node:child_process';
 import { pathToApp } from './disk.mjs';
 import { npmInstall as execNpmInstall, vite as execVite } from '../exec.mjs';
+import { wss } from '../index.mjs';
 
 export type ProcessType = 'npm:install' | 'vite:server';
 
@@ -84,19 +85,58 @@ export async function waitForProcessToComplete(process: AppProcessType): Promise
  */
 export function npmInstall(
   appId: string,
-  options: Omit<Parameters<typeof execNpmInstall>[0], 'cwd'> & { onStart?: () => void },
+  options: Omit<Partial<Parameters<typeof execNpmInstall>[0]>, 'cwd'> & { onStart?: () => void },
 ) {
   const runningProcess = processes.get(appId, 'npm:install');
   if (runningProcess) {
     return runningProcess;
   }
 
+  wss.broadcast(`app:${appId}`, 'deps:install:status', { status: 'installing' });
   if (options.onStart) {
     options.onStart();
   }
+
   const newlyStartedProcess: NpmInstallProcessType = {
     type: 'npm:install',
-    process: execNpmInstall({ cwd: pathToApp(appId), ...options }),
+    process: execNpmInstall({
+      ...options,
+
+      cwd: pathToApp(appId),
+      stdout: (data) => {
+        wss.broadcast(`app:${appId}`, 'deps:install:log', {
+          log: { type: 'stdout', data: data.toString('utf8') },
+        });
+
+        if (options.stdout) {
+          options.stdout(data);
+        }
+      },
+      stderr: (data) => {
+        wss.broadcast(`app:${appId}`, 'deps:install:log', {
+          log: { type: 'stderr', data: data.toString('utf8') },
+        });
+
+        if (options.stderr) {
+          options.stderr(data);
+        }
+      },
+      onExit: (code) => {
+        // We must clean up this process so that we can run npm install again
+        deleteAppProcess(appId, 'npm:install');
+
+        wss.broadcast(`app:${appId}`, 'deps:install:status', {
+          status: code === 0 ? 'complete' : 'failed',
+          code,
+        });
+
+        if (code === 0) {
+          wss.broadcast(`app:${appId}`, 'deps:status:response', {
+            nodeModulesExists: true,
+          });
+        }
+      },
+    }),
   };
   processes.set(appId, newlyStartedProcess);
 

--- a/packages/api/apps/processes.mts
+++ b/packages/api/apps/processes.mts
@@ -69,13 +69,13 @@ export async function waitForProcessToComplete(process: AppProcessType): Promise
   }
 
   return new Promise((resolve, reject) => {
-    process.process.once("exit", () => {
+    process.process.once('exit', () => {
       resolve();
     });
-    process.process.once("error", (err) => {
+    process.process.once('error', (err) => {
       reject(err);
     });
-  })
+  });
 }
 
 /**

--- a/packages/api/server/channels/app.mts
+++ b/packages/api/server/channels/app.mts
@@ -235,9 +235,8 @@ export function register(wss: WebSocketServer) {
     .on('deps:clear', DepsInstallPayloadSchema, clearNodeModules)
     .on('deps:status', DepsStatusPayloadSchema, dependenciesStatus)
     .on('file:updated', FileUpdatedPayloadSchema, onFileUpdated)
-    .onJoin((topic, conn) => {
-      // FIXME: there's almost certainly a better way to get the app id than this?
-      const appExternalId = topic.replace(/^app:/, '');
+    .onJoin((_payload, context, conn) => {
+      const appExternalId = (context as AppContextType).params.appId;
 
       // When connecting, send back info about an in flight npm install if one exists
       const npmInstallProcess = getAppProcess(appExternalId, 'npm:install');

--- a/packages/api/server/channels/app.mts
+++ b/packages/api/server/channels/app.mts
@@ -164,11 +164,7 @@ async function previewStop(
   result.process.kill('SIGTERM');
 }
 
-async function dependenciesInstall(
-  payload: DepsInstallPayloadType,
-  context: AppContextType,
-  wss: WebSocketServer,
-) {
+async function dependenciesInstall(payload: DepsInstallPayloadType, context: AppContextType) {
   const app = await loadApp(context.params.appId);
 
   if (!app) {
@@ -235,9 +231,7 @@ export function register(wss: WebSocketServer) {
       previewStart(payload, context, wss),
     )
     .on('preview:stop', PreviewStopPayloadSchema, previewStop)
-    .on('deps:install', DepsInstallPayloadSchema, (payload, context) => {
-      dependenciesInstall(payload, context, wss);
-    })
+    .on('deps:install', DepsInstallPayloadSchema, dependenciesInstall)
     .on('deps:clear', DepsInstallPayloadSchema, clearNodeModules)
     .on('deps:status', DepsStatusPayloadSchema, dependenciesStatus)
     .on('file:updated', FileUpdatedPayloadSchema, onFileUpdated)

--- a/packages/api/server/channels/app.mts
+++ b/packages/api/server/channels/app.mts
@@ -269,5 +269,15 @@ export function register(wss: WebSocketServer) {
     })
     .on('deps:clear', DepsInstallPayloadSchema, clearNodeModules)
     .on('deps:status', DepsStatusPayloadSchema, dependenciesStatus)
-    .on('file:updated', FileUpdatedPayloadSchema, onFileUpdated);
+    .on('file:updated', FileUpdatedPayloadSchema, onFileUpdated)
+    .onJoin((topic, conn) => {
+      // FIXME: there's almost certainly a better way to get the app id than this?
+      const appExternalId = topic.replace(/^app:/, '');
+
+      // When connecting, send back info about an in flight npm install if one exists
+      const npmInstallProcess = getAppProcess(appExternalId, "npm:install");
+      if (npmInstallProcess) {
+        conn.reply(`app:${appExternalId}`, 'deps:install:status', { status: 'installing' });
+      }
+    });
 }

--- a/packages/api/server/channels/app.mts
+++ b/packages/api/server/channels/app.mts
@@ -178,6 +178,9 @@ async function dependenciesInstall(
   npmInstall(app.externalId, {
     args: [],
     packages: payload.packages ?? undefined,
+    onStart: () => {
+      wss.broadcast(`app:${app.externalId}`, 'deps:install:status', { status: 'installing' });
+    },
     stdout: (data) => {
       wss.broadcast(`app:${app.externalId}`, 'deps:install:log', {
         log: { type: 'stdout', data: data.toString('utf8') },

--- a/packages/api/server/channels/app.mts
+++ b/packages/api/server/channels/app.mts
@@ -176,36 +176,7 @@ async function dependenciesInstall(
   }
 
   npmInstall(app.externalId, {
-    args: [],
     packages: payload.packages ?? undefined,
-    onStart: () => {
-      wss.broadcast(`app:${app.externalId}`, 'deps:install:status', { status: 'installing' });
-    },
-    stdout: (data) => {
-      wss.broadcast(`app:${app.externalId}`, 'deps:install:log', {
-        log: { type: 'stdout', data: data.toString('utf8') },
-      });
-    },
-    stderr: (data) => {
-      wss.broadcast(`app:${app.externalId}`, 'deps:install:log', {
-        log: { type: 'stderr', data: data.toString('utf8') },
-      });
-    },
-    onExit: (code) => {
-      // We must clean up this process so that we can run npm install again
-      deleteAppProcess(app.externalId, 'npm:install');
-
-      wss.broadcast(`app:${app.externalId}`, 'deps:install:status', {
-        status: code === 0 ? 'complete' : 'failed',
-        code,
-      });
-
-      if (code === 0) {
-        wss.broadcast(`app:${app.externalId}`, 'deps:status:response', {
-          nodeModulesExists: true,
-        });
-      }
-    },
   });
 }
 

--- a/packages/api/server/channels/app.mts
+++ b/packages/api/server/channels/app.mts
@@ -246,7 +246,7 @@ export function register(wss: WebSocketServer) {
       const appExternalId = topic.replace(/^app:/, '');
 
       // When connecting, send back info about an in flight npm install if one exists
-      const npmInstallProcess = getAppProcess(appExternalId, "npm:install");
+      const npmInstallProcess = getAppProcess(appExternalId, 'npm:install');
       if (npmInstallProcess) {
         conn.reply(`app:${appExternalId}`, 'deps:install:status', { status: 'installing' });
       }

--- a/packages/api/server/ws-client.mts
+++ b/packages/api/server/ws-client.mts
@@ -60,7 +60,7 @@ export class Channel {
     }
   > = {};
 
-  onJoinCallback: (topic: string, ws: WebSocket) => void = () => {};
+  onJoinCallback: (topic: string, conn: ConnectionContextType) => void = () => {};
 
   constructor(topic: string) {
     this.topic = topic;
@@ -130,7 +130,7 @@ export class Channel {
     return this;
   }
 
-  onJoin(callback: (topic: string, ws: WebSocket) => void) {
+  onJoin(callback: (topic: string, conn: ConnectionContextType) => void) {
     this.onJoinCallback = callback;
     return this;
   }
@@ -214,7 +214,7 @@ export default class WebSocketServer {
     if (event === 'subscribe') {
       conn.subscriptions.push(topic);
       conn.reply(topic, 'subscribed', { id: payload.id });
-      channel.onJoinCallback(topic, conn.socket);
+      channel.onJoinCallback(topic, conn);
       return;
     }
 

--- a/packages/shared/src/schemas/websockets.mts
+++ b/packages/shared/src/schemas/websockets.mts
@@ -189,10 +189,13 @@ export const DepsInstallLogPayloadSchema = z.object({
   ]),
 });
 
-export const DepsInstallStatusPayloadSchema = z.object({
-  status: z.enum(['complete', 'failed']),
-  code: z.number().int(),
-});
+export const DepsInstallStatusPayloadSchema = z.union([
+  z.object({ status: z.literal('installing') }),
+  z.object({
+    status: z.enum(['complete', 'failed']),
+    code: z.number().int(),
+  }),
+]);
 
 export const DepsClearPayloadSchema = z.object({});
 export const DepsStatusPayloadSchema = z.object({});

--- a/packages/web/src/components/apps/package-install-toast.tsx
+++ b/packages/web/src/components/apps/package-install-toast.tsx
@@ -33,6 +33,8 @@ const PackageInstallToast: React.FunctionComponent = () => {
   useEffect(() => {
     if (nodeModulesExists === false && (status === 'idle' || status === 'complete')) {
       setShowToast(true);
+    } else if (nodeModulesExists === true) {
+      setShowToast(false);
     }
   }, [nodeModulesExists, status]);
 

--- a/packages/web/src/components/apps/use-package-json.tsx
+++ b/packages/web/src/components/apps/use-package-json.tsx
@@ -52,6 +52,17 @@ export function PackageJsonProvider({ channel, children }: ProviderPropsType) {
     };
   }, [channel]);
 
+  useEffect(() => {
+    const callback = ({ status }: DepsInstallStatusPayloadType) => {
+      setStatus(status);
+    };
+    channel.on('deps:install:status', callback);
+
+    return () => {
+      channel.off('deps:install:status', callback);
+    };
+  }, [channel]);
+
   const npmInstall = useCallback(
     async (packages?: Array<string>) => {
       addLog(
@@ -74,7 +85,6 @@ export function PackageJsonProvider({ channel, children }: ProviderPropsType) {
         const statusCallback = ({ status, code }: DepsInstallStatusPayloadType) => {
           channel.off('deps:install:log', logCallback);
           channel.off('deps:install:status', statusCallback);
-          setStatus(status);
 
           addLog(
             'info',

--- a/packages/web/src/components/apps/use-package-json.tsx
+++ b/packages/web/src/components/apps/use-package-json.tsx
@@ -84,10 +84,10 @@ export function PackageJsonProvider({ channel, children }: ProviderPropsType) {
 
         const statusCallback = (payload: DepsInstallStatusPayloadType) => {
           switch (payload.status) {
-            case "installing":
+            case 'installing':
               break;
-            case "failed":
-            case "complete":
+            case 'failed':
+            case 'complete':
               channel.off('deps:install:log', logCallback);
               channel.off('deps:install:status', statusCallback);
 


### PR DESCRIPTION
At a high level, this change should address the first two points in https://github.com/srcbookdev/srcbook/pull/418.

We had discussed previously the notion of whether making all `npm install`s client initiated would be an easy way to fix the first item. However, after getting more into this work, I opted to not do it this way. This was due to a mixture of not being able to come up with an elegant way to pass the state from the creation step to the actual apps interface to invoke the install, and that it seemed like it's likely folks could have multiple instances of a srcbook open and generally getting in the habit of broadcasting events so they all remain in sync no matter which instance caused an install to happen seemed like a good idea.

In more detail, this change:
1. Ensures that for every `npm install` invocation made by the app, all relevant socket events are broadcasted to all connected clients on the given channel. Previously, some calls sent everything, some sent a few events, and some sent none. At least in my anecdotal observations, a lot of complex and hard to reason about situation were coming up due to the server and client's state not being synced.
2. Adds a new message that gets sent when a npm install starts running. This means that all connected app instances will show a "loading" state, even if the npm install in question was initiated on the server or in another app instance.
3. When a user joins a channel initially, send a message to them giving them an initial npm install status, so that if an install is in flight, the newly connected app can display this.