### PR TITLE
Update files from backend

### DIFF
--- a/.changeset/dirty-taxis-repair.md
+++ b/.changeset/dirty-taxis-repair.md
@@ -1,0 +1,7 @@
+---
+'@srcbook/shared': patch
+'@srcbook/api': patch
+'@srcbook/web': patch
+---
+
+The backend now notifies the frontend of file changes -> files update visually in realtime

--- a/packages/api/ai/plan-parser.mts
+++ b/packages/api/ai/plan-parser.mts
@@ -126,8 +126,7 @@ export async function parsePlan(
           const fileContent = await loadFile(app, filePath);
           originalContent = fileContent.source;
         } catch (error) {
-          console.error(`Error reading original file ${filePath}:`, error);
-          // If the file doesn't exist, we'll leave the original content as null
+          // If the file doesn't exist, it's likely that it's a new file.
         }
 
         plan.actions.push({
@@ -153,7 +152,6 @@ export async function parsePlan(
       }
     }
 
-    console.log('parsed plan', plan);
     return plan;
   } catch (error) {
     console.error('Error parsing XML:', error);

--- a/packages/shared/src/schemas/websockets.mts
+++ b/packages/shared/src/schemas/websockets.mts
@@ -150,8 +150,9 @@ export const FileCreatedPayloadSchema = z.object({
   file: FileSchema,
 });
 
+// Used both from client > server and server > client
 export const FileUpdatedPayloadSchema = z.object({
-  file: FileSchema.partial(),
+  file: FileSchema,
 });
 
 export const FileRenamedPayloadSchema = z.object({

--- a/packages/web/src/clients/websocket/index.ts
+++ b/packages/web/src/clients/websocket/index.ts
@@ -99,6 +99,7 @@ export class SessionChannel extends Channel<
 
 const IncomingAppEvents = {
   file: FilePayloadSchema,
+  'file:updated': FileUpdatedPayloadSchema,
   'preview:status': PreviewStatusPayloadSchema,
   'preview:log': PreviewLogPayloadSchema,
   'deps:install:log': DepsInstallLogPayloadSchema,

--- a/packages/web/src/components/apps/use-files.tsx
+++ b/packages/web/src/components/apps/use-files.tsx
@@ -36,7 +36,7 @@ export interface FilesContextValue {
   openedFile: FileType | null;
   openFile: (entry: FileEntryType) => void;
   createFile: (dirname: string, basename: string, source?: string) => Promise<FileEntryType>;
-  updateFile: (file: FileType, attrs: Partial<FileType>) => void;
+  updateFile: (modified: FileType) => void;
   renameFile: (entry: FileEntryType, name: string) => Promise<void>;
   deleteFile: (entry: FileEntryType) => Promise<void>;
   createFolder: (dirname: string, basename: string) => Promise<void>;
@@ -122,10 +122,9 @@ export function FilesProvider({
   );
 
   const updateFile = useCallback(
-    (file: FileType, attrs: Partial<FileType>) => {
-      const updatedFile: FileType = { ...file, ...attrs };
-      channel.push('file:updated', { file: updatedFile });
-      setOpenedFile(() => updatedFile);
+    (modified: FileType) => {
+      channel.push('file:updated', { file: modified });
+      setOpenedFile(() => modified);
       forceComponentRerender();
     },
     [channel, setOpenedFile],

--- a/packages/web/src/components/apps/use-files.tsx
+++ b/packages/web/src/components/apps/use-files.tsx
@@ -82,19 +82,6 @@ export function FilesProvider({
   const openedDirectoriesRef = useRef<Set<string>>(new Set());
   const [openedFile, _setOpenedFile] = useState<FileType | null>(initialOpenedFile);
 
-  // Handle file updates from the server
-  useEffect(() => {
-    function onFileUpdated(payload: FileUpdatedPayloadType) {
-      setOpenedFile(() => payload.file);
-      forceComponentRerender();
-    }
-    channel.on('file:updated', onFileUpdated);
-
-    return () => {
-      channel.off('file:updated', onFileUpdated);
-    };
-  }, [channel]);
-
   const setOpenedFile = useCallback(
     (fn: (file: FileType | null) => FileType | null) => {
       _setOpenedFile((prevOpenedFile) => {
@@ -107,6 +94,19 @@ export function FilesProvider({
     },
     [app.id],
   );
+
+  // Handle file updates from the server
+  useEffect(() => {
+    function onFileUpdated(payload: FileUpdatedPayloadType) {
+      setOpenedFile(() => payload.file);
+      forceComponentRerender();
+    }
+    channel.on('file:updated', onFileUpdated);
+
+    return () => {
+      channel.off('file:updated', onFileUpdated);
+    };
+  }, [channel, setOpenedFile]);
 
   const navigateToFile = useCallback(
     (file: { path: string }) => {

--- a/packages/web/src/routes/apps/files-show.tsx
+++ b/packages/web/src/routes/apps/files-show.tsx
@@ -13,7 +13,7 @@ export default function AppFilesShow() {
         <CodeEditor
           path={openedFile.path}
           source={openedFile.source}
-          onChange={(source) => updateFile(openedFile, { source })}
+          onChange={(source) => updateFile({ ...openedFile, source })}
         />
       )}
     </AppLayout>


### PR DESCRIPTION
The backend now has a `writeFile` function (which we should use most of the time) which also broadcasts the update to the frontend.

This fixes the bug with undo/redo not updating files live in the client.

This also lays the ground for version switching, coming later

![CleanShot 2024-10-24 at 12 41 24](https://github.com/user-attachments/assets/3914bc6f-ebb3-4cf5-b3a4-762727ba1af9)
