### PR TITLE
Handle non existing git repo

### DIFF
--- a/.changeset/smart-elephants-fly.md
+++ b/.changeset/smart-elephants-fly.md
@@ -1,0 +1,6 @@
+---
+'@srcbook/api': patch
+'srcbook': patch
+---
+
+Bugfix: dont crash if the git repo didnt previously exist

--- a/packages/api/apps/git.mts
+++ b/packages/api/apps/git.mts
@@ -81,7 +81,14 @@ export async function ensureRepoExists(app: DBAppType): Promise<void> {
 // Get the current commit SHA
 export async function getCurrentCommitSha(app: DBAppType): Promise<string> {
   const git = getGit(app);
+  // There might not be a .git initialized yet, so we need to handle that
+  const isRepo = await git.checkIsRepo();
+  if (!isRepo) {
+    await initRepo(app);
+  }
+
   const revparse = await git.revparse(['HEAD']);
+
   return revparse;
 }
 


### PR DESCRIPTION
If a user has an app pre-versions, the getCurrentCommit call will fail.
This makes a check and creates a repo if it doesn't exist. 

Tested locally