### PR TITLE
Add a cli flag to configure base directory of srcbooks

### DIFF
--- a/.changeset/itchy-crabs-repeat.md
+++ b/.changeset/itchy-crabs-repeat.md
@@ -1,0 +1,6 @@
+---
+'@srcbook/api': patch
+'srcbook': patch
+---
+
+Add flag to change base dir of srcbooks

--- a/packages/api/constants.mts
+++ b/packages/api/constants.mts
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'url';
 const _filename = fileURLToPath(import.meta.url);
 const _dirname = path.dirname(_filename);
 
-export const HOME_DIR = os.homedir();
+export const HOME_DIR = process.env.BASE_DIR || os.homedir();
 export const SRCBOOK_DIR = path.join(HOME_DIR, '.srcbook');
 export const SRCBOOKS_DIR = path.join(SRCBOOK_DIR, 'srcbooks');
 export const APPS_DIR = path.join(SRCBOOK_DIR, 'apps');


### PR DESCRIPTION
Fixes https://github.com/srcbookdev/srcbook/issues/187

## Changes

Building on the work in https://github.com/srcbookdev/srcbook/pull/180 I've added another flag to be able to configure the base directory.

## Usecase

I want to create a github repo of srcbook files. Each file is a different prompt engineering experiment.
I  need different members of the team to pull the latest experiments and share their work.

## Possible enhancements

* Currently each scrbook is stored as a random hash `30v2av4eee17m59dg2c29758to` if this could be improved. For example with a date prefix, `2024-10-29-30v2av4eee17m59dg2c29758to` that would help a bit.
* The UI could have an option to group srcbooks into folders.