### PR TITLE
Fix issue #451: Add support for exposure outside Docker container to other devices on network

### DIFF
--- a/.changeset/dirty-hotels-press.md
+++ b/.changeset/dirty-hotels-press.md
@@ -1,0 +1,5 @@
+---
+'srcbook': patch
+---
+
+Added Docker support to enable running Srcbook in a containerized environment. This includes:

--- a/.changeset/dirty-hotels-press.md
+++ b/.changeset/dirty-hotels-press.md
@@ -2,10 +2,10 @@
 'srcbook': patch
 ---
 
-Added Docker support to enable exposing a Srcbook application running in a Docker container to other devices on the network. This includes:
+Added network exposure configuration to enable accessing Srcbook from other devices when running in Docker. This includes:
 
-- A new Dockerfile for building the application
-- A docker-compose.yml configuration for easy deployment
-- Support for exposing the application to external network devices via 0.0.0.0 binding
+- Added docker-compose.yml with 0.0.0.0 binding configuration
+- Configured port mapping to expose port 2150 to the network
+- Set HOST environment variable for external network access
 
-This addition allows users to run Srcbook in isolated containers and access it from other devices on their network, making it more flexible for various deployment scenarios.
+This change allows users to access their Srcbook instance from other devices on their network when running in Docker.

--- a/.changeset/dirty-hotels-press.md
+++ b/.changeset/dirty-hotels-press.md
@@ -2,4 +2,10 @@
 'srcbook': patch
 ---
 
-Added Docker support to enable running Srcbook in a containerized environment. This includes:
+Added Docker support to enable exposing a Srcbook application running in a Docker container to other devices on the network. This includes:
+
+- A new Dockerfile for building the application
+- A docker-compose.yml configuration for easy deployment
+- Support for exposing the application to external network devices via 0.0.0.0 binding
+
+This addition allows users to run Srcbook in isolated containers and access it from other devices on their network, making it more flexible for various deployment scenarios.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  srcbook:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "0.0.0.0:2150:2150"
+    volumes:
+      - type: bind
+        source: ~/.srcbook
+        target: /root/.srcbook
+        bind:
+          create_host_path: true
+    environment:
+      - NODE_ENV=production
+      - HOST=0.0.0.0
+      - SRCBOOK_INSTALL_DEPS=true
+    command: ["pnpm", "start"]


### PR DESCRIPTION
Added network exposure configuration to enable accessing Srcbook from other devices when running in Docker. This includes:

- Added docker-compose.yml with 0.0.0.0 binding configuration
- Configured port mapping to expose port 2150 to the network
- Set HOST environment variable for external network access

This change allows users to access their Srcbook instance from other devices on their network when running in Docker.