### PR TITLE
Fix issue #451: Configure host address for optional exposure outside container in Docker

### DIFF
--- a/.changeset/dirty-hotels-press.md
+++ b/.changeset/dirty-hotels-press.md
@@ -2,10 +2,11 @@
 'srcbook': patch
 ---
 
-Added network exposure configuration to enable accessing Srcbook from other devices when running in Docker. This includes:
+Added configurable network exposure for Docker deployments with secure defaults. This includes:
 
-- Added docker-compose.yml with 0.0.0.0 binding configuration
-- Configured port mapping to expose port 2150 to the network
-- Set HOST environment variable for external network access
+- Added docker-compose.yml with configurable network binding
+- Default configuration restricts access to localhost (127.0.0.1) for security
+- Optional network exposure via HOST_BIND environment variable
+- Configured port 2150 mapping for Docker container
 
-This change allows users to access their Srcbook instance from other devices on their network when running in Docker.
+Users can optionally expose their Srcbook instance to other network devices by setting HOST_BIND=0.0.0.0 when running Docker.

--- a/.changeset/dirty-hotels-press.md
+++ b/.changeset/dirty-hotels-press.md
@@ -1,0 +1,5 @@
+---
+'srcbook': patch
+---
+
+Added Docker support to enable running Srcbook in a containerized environment. This includes:

--- a/.changeset/dirty-hotels-press.md
+++ b/.changeset/dirty-hotels-press.md
@@ -2,10 +2,10 @@
 'srcbook': patch
 ---
 
-Added Docker support to enable exposing a Srcbook application running in a Docker container to other devices on the network. This includes:
+Added network exposure configuration to enable accessing Srcbook from other devices when running in Docker. This includes:
 
-- A new Dockerfile for building the application
-- A docker-compose.yml configuration for easy deployment
-- Support for exposing the application to external network devices via 0.0.0.0 binding
+- Added docker-compose.yml with 0.0.0.0 binding configuration
+- Configured port mapping to expose port 2150 to the network
+- Set HOST environment variable for external network access
 
-This addition allows users to run Srcbook in isolated containers and access it from other devices on their network, making it more flexible for various deployment scenarios.
+This change allows users to access their Srcbook instance from other devices on their network when running in Docker.

--- a/.changeset/dirty-hotels-press.md
+++ b/.changeset/dirty-hotels-press.md
@@ -2,4 +2,10 @@
 'srcbook': patch
 ---
 
-Added Docker support to enable running Srcbook in a containerized environment. This includes:
+Added Docker support to enable exposing a Srcbook application running in a Docker container to other devices on the network. This includes:
+
+- A new Dockerfile for building the application
+- A docker-compose.yml configuration for easy deployment
+- Support for exposing the application to external network devices via 0.0.0.0 binding
+
+This addition allows users to run Srcbook in isolated containers and access it from other devices on their network, making it more flexible for various deployment scenarios.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "0.0.0.0:2150:2150"
+      - "${HOST_BIND:-127.0.0.1}:2150:2150"
     volumes:
       - type: bind
         source: ~/.srcbook
@@ -14,6 +14,6 @@ services:
           create_host_path: true
     environment:
       - NODE_ENV=production
-      - HOST=0.0.0.0
+      - HOST=${HOST_BIND:-127.0.0.1}
       - SRCBOOK_INSTALL_DEPS=true
     command: ["pnpm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  srcbook:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "0.0.0.0:2150:2150"
+    volumes:
+      - type: bind
+        source: ~/.srcbook
+        target: /root/.srcbook
+        bind:
+          create_host_path: true
+    environment:
+      - NODE_ENV=production
+      - HOST=0.0.0.0
+      - SRCBOOK_INSTALL_DEPS=true
+    command: ["pnpm", "start"]


### PR DESCRIPTION
Added configurable network exposure for Docker deployments with secure defaults. This includes:

- Added docker-compose.yml with configurable network binding
- Default configuration restricts access to localhost (127.0.0.1) for security
- Optional network exposure via HOST_BIND environment variable
- Configured port 2150 mapping for Docker container

Users can optionally expose their Srcbook instance to other network devices by setting HOST_BIND=0.0.0.0 when running Docker.