### PR TITLE
feat: add model extra headers

### DIFF
--- a/packages/api/ai/config.mts
+++ b/packages/api/ai/config.mts
@@ -5,6 +5,13 @@ import type { LanguageModel } from 'ai';
 import { getDefaultModel, type AiProviderType } from '@srcbook/shared';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 
+function convertConfigHeaders(headers: Array<{key: string, value: string}>) {
+  return headers.reduce((acc: Record<string, string>, header: {key: string, value: string}) => ({
+    ...acc,
+    [header.key]: header.value,
+  }), {});
+}
+
 /**
  * Get the correct client and model configuration.
  * Throws an error if the given API key is not set in the settings.
@@ -21,6 +28,7 @@ export async function getModel(): Promise<LanguageModel> {
       const openai = createOpenAI({
         compatibility: 'strict', // strict mode, enabled when using the OpenAI API
         apiKey: config.openaiKey,
+        headers: convertConfigHeaders(JSON.parse(config.openaiHeaders || '[]')),
       });
       return openai(model);
 
@@ -28,14 +36,20 @@ export async function getModel(): Promise<LanguageModel> {
       if (!config.anthropicKey) {
         throw new Error('Anthropic API key is not set');
       }
-      const anthropic = createAnthropic({ apiKey: config.anthropicKey });
+      const anthropic = createAnthropic({
+        apiKey: config.anthropicKey,
+        headers: convertConfigHeaders(JSON.parse(config.anthropicHeaders || '[]')),
+      });
       return anthropic(model);
 
     case 'Gemini':
       if (!config.geminiKey) {
         throw new Error('Gemini API key is not set');
       }
-      const google = createGoogleGenerativeAI({ apiKey: config.geminiKey });
+      const google = createGoogleGenerativeAI({
+        apiKey: config.geminiKey,
+        headers: convertConfigHeaders(JSON.parse(config.geminiHeaders || '[]')),
+      });
       return google(model) as LanguageModel;
 
     case 'Xai':
@@ -46,6 +60,7 @@ export async function getModel(): Promise<LanguageModel> {
         compatibility: 'compatible',
         baseURL: 'https://api.x.ai/v1',
         apiKey: config.xaiKey,
+        headers: convertConfigHeaders(JSON.parse(config.xaiHeaders || '[]')),
       });
       return xai(model);
 
@@ -57,6 +72,7 @@ export async function getModel(): Promise<LanguageModel> {
         compatibility: 'compatible',
         apiKey: config.customApiKey || 'bogus', // use custom API key if set, otherwise use a bogus key
         baseURL: aiBaseUrl,
+        headers: convertConfigHeaders(JSON.parse(config.customHeaders || '[]')),
       });
       return openaiCompatible(model);
   }

--- a/packages/api/db/schema.mts
+++ b/packages/api/db/schema.mts
@@ -11,6 +11,12 @@ export const configs = sqliteTable('config', {
   xaiKey: text('xai_api_key'),
   geminiKey: text('gemini_api_key'),
   customApiKey: text('custom_api_key'),
+  // model api headers
+  openaiHeaders: text('openai_headers').default('[]'),
+  anthropicHeaders: text('anthropic_headers').default('[]'),
+  xaiHeaders: text('xai_headers').default('[]'),
+  geminiHeaders: text('gemini_headers').default('[]'),
+  customHeaders: text('custom_headers').default('[]'),
   // TODO: This is deprecated in favor of SRCBOOK_DISABLE_ANALYTICS env variable. Remove this.
   enabledAnalytics: integer('enabled_analytics', { mode: 'boolean' }).notNull().default(true),
   // Stable ID for posthog

--- a/packages/api/drizzle/0016_add_model_headers.sql
+++ b/packages/api/drizzle/0016_add_model_headers.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `config` ADD `openai_headers` text DEFAULT '[]' NOT NULL;--> statement-breakpoint
+ALTER TABLE `config` ADD `anthropic_headers` text DEFAULT '[]' NOT NULL;--> statement-breakpoint
+ALTER TABLE `config` ADD `xai_headers` text DEFAULT '[]' NOT NULL;--> statement-breakpoint
+ALTER TABLE `config` ADD `gemini_headers` text DEFAULT '[]' NOT NULL;--> statement-breakpoint
+ALTER TABLE `config` ADD `custom_headers` text DEFAULT '[]' NOT NULL;

--- a/packages/api/drizzle/meta/0016_snapshot.json
+++ b/packages/api/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,318 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "90d81a80-978a-4eb9-b250-eb8ea17c448d",
+  "prevId": "e4b05cbe-90d2-41a7-96fc-2130bd54bc16",
+  "tables": {
+    "apps": {
+      "name": "apps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "history": {
+          "name": "history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "history_version": {
+          "name": "history_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "apps_external_id_unique": {
+          "name": "apps_external_id_unique",
+          "columns": [
+            "external_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "config": {
+      "name": "config",
+      "columns": {
+        "base_dir": {
+          "name": "base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_language": {
+          "name": "default_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'typescript'"
+        },
+        "openai_api_key": {
+          "name": "openai_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anthropic_api_key": {
+          "name": "anthropic_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "xai_api_key": {
+          "name": "xai_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gemini_api_key": {
+          "name": "gemini_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_api_key": {
+          "name": "custom_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "openai_headers": {
+          "name": "openai_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anthropic_headers": {
+          "name": "anthropic_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "xai_headers": {
+          "name": "xai_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gemini_headers": {
+          "name": "gemini_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled_analytics": {
+          "name": "enabled_analytics",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "srcbook_installation_id": {
+          "name": "srcbook_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'r66nb586aqqvg8kjcu9uuukdb0'"
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openai'"
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'gpt-4o'"
+        },
+        "ai_base_url": {
+          "name": "ai_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subscription_email": {
+          "name": "subscription_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "secrets": {
+      "name": "secrets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "secrets_name_unique": {
+          "name": "secrets_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "secrets_to_sessions": {
+      "name": "secrets_to_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "secrets_to_sessions_session_id_secret_id_unique": {
+          "name": "secrets_to_sessions_session_id_secret_id_unique",
+          "columns": [
+            "session_id",
+            "secret_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "secrets_to_sessions_secret_id_secrets_id_fk": {
+          "name": "secrets_to_sessions_secret_id_secrets_id_fk",
+          "tableFrom": "secrets_to_sessions",
+          "tableTo": "secrets",
+          "columnsFrom": [
+            "secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1737324288698,
       "tag": "0015_add_custom_api_key",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1742862590885,
+      "tag": "0016_add_model_headers",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/web/src/components/settings/ai-model-headers.tsx
+++ b/packages/web/src/components/settings/ai-model-headers.tsx
@@ -1,0 +1,92 @@
+import { cn } from '@srcbook/components';
+import { Button } from '@srcbook/components/src/components/ui/button';
+import { Input } from '@srcbook/components/src/components/ui/input';
+import { Trash2 } from 'lucide-react';
+
+export type AiModelHeader = {
+  key: string;
+  value: string;
+};
+
+type AiModelHeadersProps = {
+  value: Array<AiModelHeader>;
+  onChange: (value: Array<AiModelHeader>) => void;
+};
+
+function AiModelHeaderRemoveButton({ onRemove }: { onRemove: () => void }) {
+  return (
+    <Button variant="ghost" size="icon" onClick={onRemove}>
+      <Trash2 size={16} />
+    </Button>
+  );
+}
+
+function AiModelHeaderRemoveEmptyButton() {
+  return (
+    <div>
+      <div className="w-[18px]" />
+    </div>
+  );
+}
+
+export default function AiModelHeaders({ value, onChange }: AiModelHeadersProps) {
+  function handleChange(index: number, param: 'key' | 'value', paramValue: string) {
+    const newHeaders = [...value];
+
+    let newHeader = newHeaders[index];
+    if (!newHeader) {
+      newHeader = { key: '', value: '' };
+      newHeaders.push(newHeader);
+    }
+
+    newHeader[param] = paramValue;
+    onChange(newHeaders);
+  }
+
+  function handleRemove(index: number) {
+    const newHeaders = value.filter((_, i) => i !== index);
+    onChange(newHeaders);
+  }
+
+  const headersWithNew = [...value, { key: '', value: '' }];
+  const lastHeaderIndex = headersWithNew.length - 1;
+
+  const isValid = (index: number, param: 'key' | 'value') => index >= lastHeaderIndex || headersWithNew[index]?.[param] !== '';
+
+  return (
+    <div className="flex flex-col gap-2">
+      {headersWithNew?.map((header, index) => (
+        <div className="flex gap-2" key={index}>
+          {index < lastHeaderIndex
+            ? <AiModelHeaderRemoveButton onRemove={() => handleRemove(index)} />
+            : <AiModelHeaderRemoveEmptyButton />
+          }
+          <div className="w-full">
+            <Input
+              placeholder='key'
+              value={header.key}
+              onChange={(e) => handleChange(index, 'key', e.target.value)}
+              required={index < lastHeaderIndex}
+              className={cn(
+                '[&.invalid:not(:focus)]:border-red-500',
+                isValid(index, 'key') ? 'valid' : 'invalid',
+              )}
+            />
+          </div>
+          <div className="w-full">
+            <Input
+              placeholder='value'
+              value={header.value}
+              onChange={(e) => handleChange(index, 'value', e.target.value)}
+              required={index < lastHeaderIndex}
+              className={cn(
+                '[&.invalid:not(:focus)]:border-red-500',
+                isValid(index, 'value') ? 'valid' : 'invalid',
+              )}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/ai-model-headers.tsx
+++ b/packages/web/src/components/settings/ai-model-headers.tsx
@@ -55,38 +55,41 @@ export default function AiModelHeaders({ value, onChange }: AiModelHeadersProps)
 
   return (
     <div className="flex flex-col gap-2">
-      {headersWithNew?.map((header, index) => (
-        <div className="flex gap-2" key={index}>
-          {index < lastHeaderIndex
-            ? <AiModelHeaderRemoveButton onRemove={() => handleRemove(index)} />
-            : <AiModelHeaderRemoveEmptyButton />
-          }
-          <div className="w-full">
-            <Input
-              placeholder='key'
-              value={header.key}
-              onChange={(e) => handleChange(index, 'key', e.target.value)}
-              required={index < lastHeaderIndex}
-              className={cn(
-                '[&.invalid:not(:focus)]:border-red-500',
-                isValid(index, 'key') ? 'valid' : 'invalid',
-              )}
-            />
+      {headersWithNew?.map((header, index) => {
+        let deleteButton = null;
+        if (lastHeaderIndex > index) deleteButton = <AiModelHeaderRemoveButton onRemove={() => handleRemove(index)} />;
+        else if (lastHeaderIndex > 0 && index === lastHeaderIndex) deleteButton = <AiModelHeaderRemoveEmptyButton />;
+
+        return (
+          <div className="flex gap-2" key={index}>
+            {deleteButton}
+            <div className="w-full">
+              <Input
+                placeholder='key'
+                value={header.key}
+                onChange={(e) => handleChange(index, 'key', e.target.value)}
+                required={index < lastHeaderIndex}
+                className={cn(
+                  '[&.invalid:not(:focus)]:border-red-500',
+                  isValid(index, 'key') ? 'valid' : 'invalid',
+                )}
+              />
+            </div>
+            <div className="w-full">
+              <Input
+                placeholder='value'
+                value={header.value}
+                onChange={(e) => handleChange(index, 'value', e.target.value)}
+                required={index < lastHeaderIndex}
+                className={cn(
+                  '[&.invalid:not(:focus)]:border-red-500',
+                  isValid(index, 'value') ? 'valid' : 'invalid',
+                )}
+              />
+            </div>
           </div>
-          <div className="w-full">
-            <Input
-              placeholder='value'
-              value={header.value}
-              onChange={(e) => handleChange(index, 'value', e.target.value)}
-              required={index < lastHeaderIndex}
-              className={cn(
-                '[&.invalid:not(:focus)]:border-red-500',
-                isValid(index, 'value') ? 'valid' : 'invalid',
-              )}
-            />
-          </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
Implements customization for model headers, as discussed in #489.

With this change, it will be possible to configure additional headers for the provider's API.
![image](https://github.com/user-attachments/assets/9dbd74b7-e444-496d-8308-d046e4276fa8)

Additionally, to improve code readability, I refactored the `AiSettings` component to use a static list of model providers ([see here](https://github.com/rafaelfbs/srcbook/blob/09a7daeaa34b908ce41d3b9eec210787e3cdbf87/packages/web/src/routes/settings.tsx#L20-L79))
