### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/packages/api/ai/config.mts
+++ b/packages/api/ai/config.mts
@@ -57,6 +57,13 @@ export async function getModel(): Promise<LanguageModel> {
       });
       return openrouter.chat(model);
 
+    case 'litellm':
+      const litellm = createOpenAI({
+        apiKey: config.customApiKey || 'sk-1234',
+        baseURL: aiBaseUrl || 'http://localhost:4000/v1',
+      });
+      return litellm.chat(model);
+
     case 'custom':
       if (typeof aiBaseUrl !== 'string') {
         throw new Error('Local AI base URL is not set');

--- a/packages/api/test/litellm-provider.test.mts
+++ b/packages/api/test/litellm-provider.test.mts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { AiProvider, defaultModels, isValidProvider, getDefaultModel } from '../../shared/src/ai.mjs';
+
+describe('LiteLLM provider registration', () => {
+  it('should include litellm in AiProvider enum', () => {
+    expect(AiProvider.LiteLLM).toBe('litellm');
+  });
+
+  it('should have a default model for litellm', () => {
+    expect(defaultModels[AiProvider.LiteLLM]).toBeDefined();
+    expect(defaultModels[AiProvider.LiteLLM]).toBe('gpt-4o-mini');
+  });
+
+  it('should validate litellm as a valid provider', () => {
+    expect(isValidProvider('litellm')).toBe(true);
+  });
+
+  it('should return default model for litellm', () => {
+    expect(getDefaultModel('litellm')).toBe('gpt-4o-mini');
+  });
+
+  it('should not break existing providers', () => {
+    expect(isValidProvider('openai')).toBe(true);
+    expect(isValidProvider('anthropic')).toBe(true);
+    expect(isValidProvider('custom')).toBe(true);
+    expect(isValidProvider('openrouter')).toBe(true);
+  });
+
+  it('should reject invalid providers', () => {
+    expect(isValidProvider('nonexistent')).toBe(false);
+  });
+});

--- a/packages/shared/src/ai.mts
+++ b/packages/shared/src/ai.mts
@@ -4,6 +4,7 @@ export const AiProvider = {
   XAI: 'Xai',
   Gemini: 'Gemini',
   OpenRouter: 'openrouter',
+  LiteLLM: 'litellm',
   Custom: 'custom',
 } as const;
 
@@ -16,6 +17,7 @@ export const defaultModels: Record<AiProviderType, string> = {
   [AiProvider.XAI]: 'grok-beta',
   [AiProvider.Gemini]: 'gemini-1.5-pro-latest',
   [AiProvider.OpenRouter]: 'anthropic/claude-3-opus-20240229',
+  [AiProvider.LiteLLM]: 'gpt-4o-mini',
 } as const;
 
 export function isValidProvider(provider: string): provider is AiProviderType {

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -176,6 +176,16 @@ function AiInfoBanner() {
           </div>
         );
 
+      case 'litellm':
+        return (
+          <div className="flex items-center gap-10 bg-sb-yellow-20 text-sb-yellow-80 rounded-sm text-sm font-medium px-3 py-2">
+            <p>LiteLLM proxy URL required</p>
+            <a href="https://docs.litellm.ai/docs/simple_proxy" target="_blank" className="underline">
+              LiteLLM docs
+            </a>
+          </div>
+        );
+
       case 'custom':
         return (
           <div className="flex items-center gap-10 bg-sb-yellow-20 text-sb-yellow-80 rounded-sm text-sm font-medium px-3 py-2">
@@ -332,6 +342,7 @@ export function AiSettings({ saveButtonLabel }: AiSettingsProps) {
               <SelectItem value="Xai">Xai</SelectItem>
               <SelectItem value="Gemini">Gemini</SelectItem>
               <SelectItem value="openrouter">openrouter</SelectItem>
+              <SelectItem value="litellm">litellm</SelectItem>
               <SelectItem value="custom">custom</SelectItem>
             </SelectContent>
           </Select>
@@ -445,6 +456,44 @@ export function AiSettings({ saveButtonLabel }: AiSettingsProps) {
             </Button>
           </div>
           <OpenRouterModelSelector onSelectModel={setModel} currentModel={model} />
+        </div>
+      )}
+
+      {aiProvider === 'litellm' && (
+        <div>
+          <p className="opacity-70 text-sm mb-4">
+            LiteLLM is an AI gateway that routes to 100+ LLM providers through a single proxy.
+            Enter your proxy URL and API key below. Use LiteLLM model IDs like
+            &quot;anthropic/claude-3-5-sonnet&quot; or &quot;openai/gpt-4o&quot;.
+          </p>
+          <div className="flex flex-col gap-2">
+            <div className="flex gap-2">
+              <Input
+                name="baseUrl"
+                placeholder="http://localhost:4000/v1"
+                value={baseUrl}
+                onChange={(e) => setBaseUrl(e.target.value)}
+              />
+              <Input
+                name="customApiKey"
+                placeholder="LiteLLM API key"
+                type="password"
+                value={customApiKey}
+                onChange={(e) => setCustomApiKey(e.target.value)}
+              />
+            </div>
+            <div className="flex justify-end">
+              <Button
+                className="px-5"
+                onClick={() =>
+                  updateConfigContext({ aiBaseUrl: baseUrl, customApiKey, aiModel: model })
+                }
+                disabled={!customModelSaveEnabled}
+              >
+                {saveButtonLabel ?? 'Save'}
+              </Button>
+            </div>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION


## Summary
- Adds [LiteLLM](https://github.com/BerriAI/litellm) as a new AI provider, enabling users to route AI requests through 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex AI, Groq, Ollama, etc.) via a single LiteLLM proxy.
- Reuses the existing `customApiKey` and `aiBaseUrl` config fields, so no DB migration needed.

## Motivation
LiteLLM acts as a unified AI gateway. Instead of configuring individual provider API keys, users can point srcbook at a single LiteLLM proxy that handles provider routing, load balancing, cost tracking, and fallbacks across 100+ providers. Useful for teams that already run a centralized LiteLLM proxy, or users who need providers not directly supported (e.g., AWS Bedrock, Vertex AI).

## Changes

- `packages/shared/src/ai.mts` - added `LiteLLM: 'litellm'` to `AiProvider` enum and `gpt-4o-mini` as default model
- `packages/api/ai/config.mts` - added `case 'litellm':` that uses `createOpenAI` with proxy URL (default `http://localhost:4000/v1`), reuses `customApiKey` and `aiBaseUrl` fields
- `packages/web/src/routes/settings.tsx` - added LiteLLM option to provider dropdown, added LiteLLM config panel with proxy URL + API key inputs and link to LiteLLM docs

## Tests

**Live E2E - AI SDK with LiteLLM proxy routing to Claude Sonnet 4.6:**

    $ node --input-type=module -e '...'

    Model: claude-sonnet-4-6
    Content: OK
    Usage: {"promptTokens":13,"completionTokens":4,"totalTokens":17}
    Finish reason: stop

This proves the full chain: `createOpenAI` (same SDK srcbook uses) -> LiteLLM proxy -> Claude Sonnet 4.6 -> response parsed.

**Unit tests (6/6 pass):**

    $ bunx vitest run test/litellm-provider.test.mts

    ✓ test/litellm-provider.test.mts  (6 tests) 2ms
    Test Files  1 passed (1)
    Tests  6 passed (6)

Tests cover: provider enum registration, default model, provider validation, existing providers not broken, invalid provider rejection.

**Regression (11/11 pass, 1 pre-existing failure in srcmd.test.mts unrelated to this PR):**

    $ bunx vitest run

    ✓ test/tsserver.test.mts  (3 tests)
    ✓ test/streaming-xml-parser.test.mts  (2 tests)
    ✓ test/litellm-provider.test.mts  (6 tests)
    Tests  11 passed (11)

## Risk / Compatibility
- Additive only. Existing providers completely untouched.
- No new dependencies added - uses the existing `@ai-sdk/openai` package.
- No DB migration needed - reuses `customApiKey` and `aiBaseUrl` config fields.
- Default proxy URL is `http://localhost:4000/v1` (standard LiteLLM proxy port).

## Example usage

In Settings, select "litellm" from the provider dropdown, then:
1. Enter your LiteLLM proxy URL (e.g., `http://localhost:4000/v1`)
2. Enter your LiteLLM API key
3. Set model to any LiteLLM model ID (e.g., `anthropic/claude-3-5-sonnet`, `openai/gpt-4o`, `bedrock/anthropic.claude-3-sonnet`)
